### PR TITLE
Release: staging → production (policy lifecycle)

### DIFF
--- a/.cursor/rules/specify-rules.mdc
+++ b/.cursor/rules/specify-rules.mdc
@@ -11,6 +11,8 @@ Auto-generated from all feature plans. Last updated: 2025-11-27
 - PostgreSQL (policies, policy_payments, mpesa_stk_push_requests, scheme.isPostpaid) (001-request-payment-ondemand)
 - TypeScript 5.3.x, Node.js 18+ + NestJS 11, Prisma 6, Next.js (agent-registration), `@react-pdf/renderer`, Sentry (001-premium-statement-pdf)
 - PostgreSQL; new column `packages.product_duration_days` (001-premium-statement-pdf)
+- TypeScript 5.3.x, Node.js >= 18 + NestJS 11.x, Prisma 6.x, `@nestjs/schedule`, existing messaging outbox, Next.js agent-registration (admin UI) (003-policy-lifecycle)
+- PostgreSQL via Prisma migrations (no `db push`) (003-policy-lifecycle)
 
 - TypeScript 5.3.x + NestJS 11.x, Prisma 6.x, Express (001-mpesa-ipn-integration)
 
@@ -30,6 +32,7 @@ npm test && npm run lint
 TypeScript 5.3.x: Follow standard conventions
 
 ## Recent Changes
+- 003-policy-lifecycle: Added TypeScript 5.3.x, Node.js >= 18 + NestJS 11.x, Prisma 6.x, `@nestjs/schedule`, existing messaging outbox, Next.js agent-registration (admin UI)
 - 001-premium-statement-pdf: Added TypeScript 5.3.x, Node.js 18+ + NestJS 11, Prisma 6, Next.js (agent-registration), `@react-pdf/renderer`, Sentry
 - 001-request-payment-ondemand: Added TypeScript 5.3.x, Node.js 18+ + NestJS 11, Prisma 6, Next.js (agent-registration), Socket.IO, Sentry
 

--- a/apps/agent-registration/src/app/(main)/admin/mpesa-payments/[uploadId]/page.tsx
+++ b/apps/agent-registration/src/app/(main)/admin/mpesa-payments/[uploadId]/page.tsx
@@ -8,6 +8,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { ArrowLeft, RefreshCw } from 'lucide-react';
 import { formatDate } from '@/lib/utils';
+import { formatTransactionReferenceForDisplay } from '@/lib/transaction-reference-display';
 import { supabase } from '@/lib/supabase';
 
 interface MpesaPaymentUpload {
@@ -314,7 +315,7 @@ export default function MpesaPaymentDetailsPage() {
                   <TableBody>
                     {items.map((item) => (
                       <TableRow key={item.id}>
-                        <TableCell className="font-medium">{item.transactionReference}</TableCell>
+                        <TableCell className="font-medium">{formatTransactionReferenceForDisplay(item.transactionReference)}</TableCell>
                         <TableCell>{formatDate(item.completionTime)}</TableCell>
                         <TableCell>{formatDate(item.initiationTime)}</TableCell>
                         <TableCell className="max-w-xs truncate">{item.paymentDetails ?? '-'}</TableCell>

--- a/apps/agent-registration/src/app/(main)/admin/recovery/page.tsx
+++ b/apps/agent-registration/src/app/(main)/admin/recovery/page.tsx
@@ -30,6 +30,7 @@ import {
   type RecoveryCustomer,
   type Plan,
 } from '@/lib/api';
+import { formatTransactionReferenceForDisplay } from '@/lib/transaction-reference-display';
 import { Loader2, RefreshCw, Plus } from 'lucide-react';
 
 interface InsurancePricing {
@@ -281,7 +282,7 @@ export default function RecoveryPage() {
                     <ul className="text-sm text-muted-foreground space-y-1">
                       {c.payments.map((p) => (
                         <li key={p.id}>
-                          {p.transactionReference} - KES {p.paidIn.toLocaleString()} - {new Date(p.completionTime).toLocaleString()}
+                          {formatTransactionReferenceForDisplay(p.transactionReference)} - KES {p.paidIn.toLocaleString()} - {new Date(p.completionTime).toLocaleString()}
                         </li>
                       ))}
                     </ul>

--- a/apps/agent-registration/src/app/(main)/admin/underwriters/packages/[packageId]/schemes/[schemeId]/page.tsx
+++ b/apps/agent-registration/src/app/(main)/admin/underwriters/packages/[packageId]/schemes/[schemeId]/page.tsx
@@ -13,6 +13,7 @@ import { RefreshCw, Edit, Save, X, CheckCircle, XCircle, Plus, Trash2 } from 'lu
 import { supabase } from '@/lib/supabase';
 import * as Sentry from '@sentry/nextjs';
 import { formatDate } from '@/lib/utils';
+import { formatTransactionReferenceForDisplay } from '@/lib/transaction-reference-display';
 import { TruncatedDescription } from '../../../../[underwriterId]/_components/truncated-description';
 import { validatePhoneNumber } from '@/lib/phone-validation';
 
@@ -1034,7 +1035,7 @@ export default function SchemeDetailPage() {
                   <TableBody>
                     {postpaidPayments.map((p) => (
                       <TableRow key={p.id}>
-                        <TableCell className="font-medium">{p.transactionReference}</TableCell>
+                        <TableCell className="font-medium">{formatTransactionReferenceForDisplay(p.transactionReference)}</TableCell>
                         <TableCell>{p.amount}</TableCell>
                         <TableCell>{p.paymentType}</TableCell>
                         <TableCell>{formatDate(p.createdAt)}</TableCell>

--- a/apps/agent-registration/src/app/(main)/customer/[customerId]/_components/customer-info-section.tsx
+++ b/apps/agent-registration/src/app/(main)/customer/[customerId]/_components/customer-info-section.tsx
@@ -12,6 +12,7 @@ type CustomerStatusKey =
   | 'PENDING_ACTIVATION'
   | 'PENDING_KYC'
   | 'SUSPENDED'
+  | 'DEACTIVATED'
   | 'DELETED'
   | 'TERMINATED'
   | 'KYC_VERIFIED';
@@ -33,6 +34,10 @@ function getCustomerStatusDisplay(status: string): { label: string; className: s
     SUSPENDED: {
       label: 'Suspended',
       className: 'bg-amber-100 text-amber-800 border-amber-300',
+    },
+    DEACTIVATED: {
+      label: 'Deactivated',
+      className: 'bg-gray-100 text-gray-700 border-gray-300',
     },
     DELETED: {
       label: 'Deleted',

--- a/apps/agent-registration/src/app/(main)/customer/[customerId]/_components/modify-product-dialog.tsx
+++ b/apps/agent-registration/src/app/(main)/customer/[customerId]/_components/modify-product-dialog.tsx
@@ -1,0 +1,333 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Input } from '@/components/ui/input';
+import { Loader2 } from 'lucide-react';
+import {
+  getModifyPolicyOptions,
+  getPackagePlans,
+  modifyCustomerPolicy,
+  type ModifyPolicyOptions,
+  type ModifyPolicyRequest,
+  type PolicyNumberChoice,
+  type Plan,
+} from '@/lib/api';
+
+interface InsurancePricing {
+  plans: Record<
+    string,
+    {
+      name: string;
+      categories: Record<string, { display: string; daily: number; weekly: number }>;
+      additional_spouse: { daily: number; weekly: number };
+    }
+  >;
+}
+
+const FREQUENCY_OPTIONS = [
+  { value: 'DAILY', label: 'Daily (1 day)' },
+  { value: 'WEEKLY', label: 'Weekly (7 days)' },
+  { value: 'MONTHLY', label: 'Monthly (31 days)' },
+  { value: 'QUARTERLY', label: 'Quarterly (90 days)' },
+  { value: 'ANNUALLY', label: 'Annually (365 days)' },
+  { value: 'CUSTOM', label: 'Custom' },
+] as const;
+
+interface ModifyProductDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  customerId: string;
+  policyId: string;
+  onSuccess: (newPolicyId: string) => void;
+}
+
+export default function ModifyProductDialog({
+  open,
+  onOpenChange,
+  customerId,
+  policyId,
+  onSuccess,
+}: ModifyProductDialogProps) {
+  const [loading, setLoading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [options, setOptions] = useState<ModifyPolicyOptions | null>(null);
+  const [plans, setPlans] = useState<Plan[]>([]);
+  const [pricing, setPricing] = useState<InsurancePricing | null>(null);
+
+  const [reason, setReason] = useState('');
+  const [selectedPlan, setSelectedPlan] = useState('');
+  const [frequency, setFrequency] = useState<string>('DAILY');
+  const [customDays, setCustomDays] = useState('');
+  const [packageSchemeId, setPackageSchemeId] = useState<string>('');
+  const [policyNumberChoice, setPolicyNumberChoice] = useState<PolicyNumberChoice | ''>('');
+  const [firstPaymentId, setFirstPaymentId] = useState<string>('');
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [opts, pricingRes] = await Promise.all([
+        getModifyPolicyOptions(customerId, policyId),
+        fetch('/insurance-pricing.json').then((r) => r.json() as Promise<InsurancePricing>),
+      ]);
+      setOptions(opts);
+      setPricing(pricingRes);
+      const plansData = await getPackagePlans(opts.packageId);
+      setPlans(plansData);
+      setFrequency(opts.currentFrequency);
+      setCustomDays(
+        opts.currentFrequency === 'CUSTOM' ? String(opts.currentPaymentCadence) : ''
+      );
+      if (opts.currentPlanName) {
+        setSelectedPlan(opts.currentPlanName.toLowerCase());
+      }
+      if (opts.schemes.length > 0) {
+        setPackageSchemeId(
+          String(opts.currentPackageSchemeId ?? opts.schemes[0]?.packageSchemeId ?? '')
+        );
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load modify options');
+    } finally {
+      setLoading(false);
+    }
+  }, [customerId, policyId]);
+
+  useEffect(() => {
+    if (open) {
+      void load();
+      setReason('');
+      setPolicyNumberChoice('');
+      setFirstPaymentId('');
+    }
+  }, [open, load]);
+
+  const premium = useMemo(() => {
+    if (!pricing || !options || !selectedPlan) return 0;
+    const plan = pricing.plans[selectedPlan];
+    if (!plan) return 0;
+    const cat = plan.categories[options.familyCategory as keyof typeof plan.categories];
+    if (!cat) return 0;
+    let daily = cat.daily;
+    let weekly = cat.weekly;
+    if (options.additionalSpouse) {
+      daily += plan.additional_spouse.daily;
+      weekly += plan.additional_spouse.weekly;
+    }
+    return frequency === 'WEEKLY' ? weekly : daily;
+  }, [pricing, options, selectedPlan, frequency, options?.additionalSpouse, options?.familyCategory]);
+
+  const packagePlanId = useMemo(() => {
+    if (!selectedPlan || plans.length === 0) return 0;
+    const match = plans.find((p) => p.name.toLowerCase() === selectedPlan.toLowerCase());
+    return match?.id ?? 0;
+  }, [selectedPlan, plans]);
+
+  const handleSubmit = async () => {
+    if (!options) return;
+    if (!reason.trim()) {
+      setError('Reason is required');
+      return;
+    }
+    if (!selectedPlan || !packagePlanId) {
+      setError('Select a plan');
+      return;
+    }
+    if (!policyNumberChoice) {
+      setError('Select policy number option (Keep Existing or Generate New)');
+      return;
+    }
+    if (options.paymentMigrationAllowed && !firstPaymentId) {
+      setError('Select the first payment to migrate');
+      return;
+    }
+    if (frequency === 'CUSTOM' && (!customDays || parseInt(customDays, 10) < 1)) {
+      setError('Enter valid custom cadence days');
+      return;
+    }
+
+    const body: ModifyPolicyRequest = {
+      reason: reason.trim(),
+      packagePlanId,
+      frequency: frequency as ModifyPolicyRequest['frequency'],
+      premium,
+      policyNumberChoice,
+      ...(frequency === 'CUSTOM' ? { customDays: parseInt(customDays, 10) } : {}),
+      ...(packageSchemeId ? { packageSchemeId: parseInt(packageSchemeId, 10) } : {}),
+      ...(firstPaymentId ? { firstPaymentId: parseInt(firstPaymentId, 10) } : {}),
+    };
+
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await modifyCustomerPolicy(customerId, policyId, body);
+      const newId = res.newPolicyId ?? res.policy.id;
+      onSuccess(newId);
+      onOpenChange(false);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Modify failed');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Modify product</DialogTitle>
+          <DialogDescription>
+            Deactivates the current policy and creates a new one on the same package. Family
+            category is derived from dependants ({options?.familyCategory ?? '…'}).
+          </DialogDescription>
+        </DialogHeader>
+
+        {loading ? (
+          <div className="flex justify-center py-8">
+            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+          </div>
+        ) : options ? (
+          <div className="space-y-4 py-2">
+            <div>
+              <Label>Package</Label>
+              <Input value={options.packageName} disabled />
+            </div>
+            <div>
+              <Label>Insurance plan</Label>
+              <Select value={selectedPlan} onValueChange={setSelectedPlan}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select plan" />
+                </SelectTrigger>
+                <SelectContent>
+                  {pricing &&
+                    Object.entries(pricing.plans).map(([key, plan]) => (
+                      <SelectItem key={key} value={key}>
+                        {plan.name}
+                      </SelectItem>
+                    ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label>Family category (read-only)</Label>
+              <Input value={options.familyCategory} disabled />
+            </div>
+            <div>
+              <Label>Payment frequency</Label>
+              <Select value={frequency} onValueChange={setFrequency}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {FREQUENCY_OPTIONS.map((f) => (
+                    <SelectItem key={f.value} value={f.value}>
+                      {f.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            {frequency === 'CUSTOM' && (
+              <div>
+                <Label>Cadence (days)</Label>
+                <Input
+                  value={customDays}
+                  onChange={(e) => setCustomDays(e.target.value.replace(/\D/g, '').slice(0, 3))}
+                />
+              </div>
+            )}
+            <div>
+              <Label>Scheme</Label>
+              <Select value={packageSchemeId} onValueChange={setPackageSchemeId}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select scheme" />
+                </SelectTrigger>
+                <SelectContent>
+                  {options.schemes.map((s) => (
+                    <SelectItem key={s.packageSchemeId} value={String(s.packageSchemeId)}>
+                      {s.schemeName}
+                      {s.isPostpaid ? ' (postpaid)' : ''}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label>Installment (KES)</Label>
+              <Input value={premium > 0 ? String(premium) : ''} disabled />
+            </div>
+            <div>
+              <Label>Policy number</Label>
+              <Select
+                value={policyNumberChoice}
+                onValueChange={(v) => setPolicyNumberChoice(v as PolicyNumberChoice)}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select option (required)" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="KEEP_EXISTING">Keep existing</SelectItem>
+                  <SelectItem value="GENERATE_NEW">Generate new</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            {options.paymentMigrationAllowed && (
+              <div>
+                <Label>First payment to migrate</Label>
+                <Select value={firstPaymentId} onValueChange={setFirstPaymentId}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select first payment" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {options.eligiblePayments.map((p) => (
+                      <SelectItem key={p.id} value={String(p.id)}>
+                        {p.transactionReference} — KES {p.amount} —{' '}
+                        {new Date(p.expectedPaymentDate).toLocaleDateString()}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+            <div>
+              <Label>Reason (required)</Label>
+              <Textarea value={reason} onChange={(e) => setReason(e.target.value)} rows={3} />
+            </div>
+            {error && <p className="text-sm text-destructive">{error}</p>}
+          </div>
+        ) : (
+          error && <p className="text-sm text-destructive">{error}</p>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button onClick={() => void handleSubmit()} disabled={submitting || loading || !options}>
+            {submitting && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+            Modify product
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/agent-registration/src/app/(main)/customer/[customerId]/_components/modify-product-dialog.tsx
+++ b/apps/agent-registration/src/app/(main)/customer/[customerId]/_components/modify-product-dialog.tsx
@@ -22,6 +22,10 @@ import {
 import { Input } from '@/components/ui/input';
 import { Loader2 } from 'lucide-react';
 import {
+  formatMigrationPaymentStatusLabel,
+  formatTransactionReferenceForDisplay,
+} from '@/lib/transaction-reference-display';
+import {
   getModifyPolicyOptions,
   getPackagePlans,
   modifyCustomerPolicy,
@@ -293,15 +297,23 @@ export default function ModifyProductDialog({
             {options.paymentMigrationAllowed && (
               <div>
                 <Label>First payment to migrate</Label>
-                <Select value={firstPaymentId} onValueChange={setFirstPaymentId}>
+                <Select
+                  value={firstPaymentId}
+                  onValueChange={(v) => {
+                    setFirstPaymentId(v);
+                    setError(null);
+                  }}
+                >
                   <SelectTrigger>
                     <SelectValue placeholder="Select first payment" />
                   </SelectTrigger>
                   <SelectContent>
                     {options.eligiblePayments.map((p) => (
                       <SelectItem key={p.id} value={String(p.id)}>
-                        {p.transactionReference} — KES {p.amount} —{' '}
-                        {new Date(p.expectedPaymentDate).toLocaleDateString()}
+                        {formatTransactionReferenceForDisplay(p.transactionReference)} — KES{' '}
+                        {p.amount} —{' '}
+                        {new Date(p.expectedPaymentDate).toLocaleDateString()}{' '}
+                        {formatMigrationPaymentStatusLabel(p.paymentStatus)}
                       </SelectItem>
                     ))}
                   </SelectContent>

--- a/apps/agent-registration/src/app/(main)/customer/[customerId]/_components/payments-tab.tsx
+++ b/apps/agent-registration/src/app/(main)/customer/[customerId]/_components/payments-tab.tsx
@@ -21,6 +21,7 @@ import {
   type MissedPaymentsAmountSide,
 } from '@/lib/api';
 import * as Sentry from '@sentry/nextjs';
+import { formatTransactionReferenceForDisplay } from '@/lib/transaction-reference-display';
 import RequestPaymentDialog from './request-payment-dialog';
 import { PAYMENTS_POLICY_STORAGE_KEY } from './products-tab';
 
@@ -568,7 +569,7 @@ export default function PaymentsTab({ customerId, customerPhone = '' }: Payments
                       </TableCell>
                     )}
                     <TableCell>{payment.paymentType}</TableCell>
-                    <TableCell>{payment.transactionReference}</TableCell>
+                    <TableCell>{formatTransactionReferenceForDisplay(payment.transactionReference)}</TableCell>
                     <TableCell>{payment.accountNumber ?? 'N/A'}</TableCell>
                     <TableCell>{payment.paymentStatus ?? '—'}</TableCell>
                     <TableCell>{formatDate(payment.expectedPaymentDate)}</TableCell>

--- a/apps/agent-registration/src/app/(main)/customer/[customerId]/_components/payments-tab.tsx
+++ b/apps/agent-registration/src/app/(main)/customer/[customerId]/_components/payments-tab.tsx
@@ -22,6 +22,9 @@ import {
 } from '@/lib/api';
 import * as Sentry from '@sentry/nextjs';
 import RequestPaymentDialog from './request-payment-dialog';
+import { PAYMENTS_POLICY_STORAGE_KEY } from './products-tab';
+
+const ALL_POLICIES_VALUE = '__all__';
 
 function numberOfInstallments(paymentCadenceDays: number, productDurationDays: number | null): number {
   if (paymentCadenceDays <= 0) return 0;
@@ -122,8 +125,11 @@ export default function PaymentsTab({ customerId, customerPhone = '' }: Payments
       setPoliciesLoading(true);
       const response = await getCustomerPolicies(customerId);
       setPolicies(response.data);
-      // T038: auto-select when exactly one selectable plan
-      if (response.data.length === 1) {
+      const stored = sessionStorage.getItem(PAYMENTS_POLICY_STORAGE_KEY(customerId));
+      if (stored && response.data.some((p) => p.id === stored)) {
+        setSelectedPolicyId(stored);
+        sessionStorage.removeItem(PAYMENTS_POLICY_STORAGE_KEY(customerId));
+      } else if (response.data.length === 1) {
         setSelectedPolicyId(response.data[0].id);
       }
     } catch (err) {
@@ -152,31 +158,36 @@ export default function PaymentsTab({ customerId, customerPhone = '' }: Payments
       return;
     }
 
+    const isAllPolicies = selectedPolicyId === ALL_POLICIES_VALUE;
+
     try {
       setLoading(true);
       setError(null);
       setGenerateError(null);
 
       const filters: PaymentFilter = {
-        policyId: selectedPolicyId,
+        policyId: isAllPolicies ? undefined : selectedPolicyId,
         fromDate: fromDate || undefined,
         toDate: toDate || undefined,
       };
 
-      const [paymentsRes, policyDetailRes] = await Promise.all([
-        getCustomerPayments(customerId, filters),
-        getCustomerPolicyDetail(customerId, selectedPolicyId, {
+      const paymentsRes = await getCustomerPayments(customerId, filters);
+      setPayments(paymentsRes.data);
+
+      if (isAllPolicies) {
+        setPolicyDetail(null);
+        setFilterRanForPolicyId(ALL_POLICIES_VALUE);
+      } else {
+        const policyDetailRes = await getCustomerPolicyDetail(customerId, selectedPolicyId, {
           fromDate: fromDate || undefined,
           toDate: toDate || undefined,
         }).catch((e) => {
           console.error('Error loading policy detail:', e);
           return null;
-        }),
-      ]);
-
-      setPayments(paymentsRes.data);
-      setPolicyDetail(policyDetailRes?.data ?? null);
-      setFilterRanForPolicyId(selectedPolicyId);
+        });
+        setPolicyDetail(policyDetailRes?.data ?? null);
+        setFilterRanForPolicyId(selectedPolicyId);
+      }
     } catch (err) {
       console.error('Error loading payments:', err);
       // Report error to Sentry
@@ -289,7 +300,10 @@ export default function PaymentsTab({ customerId, customerPhone = '' }: Payments
   };
 
   const confirmedCount = payments.filter(isConfirmedPayment).length;
+  const isAllPoliciesView = filterRanForPolicyId === ALL_POLICIES_VALUE;
+
   const canGenerateReport =
+    !isAllPoliciesView &&
     filterRanForPolicyId === selectedPolicyId &&
     !!selectedPolicyId &&
     policyDetail?.schemeBillingMode === 'prepaid' &&
@@ -316,12 +330,13 @@ export default function PaymentsTab({ customerId, customerPhone = '' }: Payments
             <Select
               value={selectedPolicyId}
               onValueChange={setSelectedPolicyId}
-              disabled={policiesLoading || policies.length === 1}
+              disabled={policiesLoading || policies.length === 0}
             >
               <SelectTrigger id="policy">
                 <SelectValue placeholder="Select policy" />
               </SelectTrigger>
               <SelectContent>
+                <SelectItem value={ALL_POLICIES_VALUE}>All policies</SelectItem>
                 {policies.map((policy) => (
                   <SelectItem key={policy.id} value={policy.id}>
                     {policy.displayText}
@@ -525,6 +540,7 @@ export default function PaymentsTab({ customerId, customerPhone = '' }: Payments
             <Table>
               <TableHeader>
                 <TableRow>
+                  {isAllPoliciesView && <TableHead>Policy</TableHead>}
                   <TableHead>Payment Type</TableHead>
                   <TableHead>Transaction Reference</TableHead>
                   <TableHead>Account Number</TableHead>
@@ -537,6 +553,20 @@ export default function PaymentsTab({ customerId, customerPhone = '' }: Payments
               <TableBody>
                 {payments.map((payment) => (
                   <TableRow key={payment.id}>
+                    {isAllPoliciesView && (
+                      <TableCell className="text-sm">
+                        {payment.policy ? (
+                          <span>
+                            {payment.policy.policyNumber ?? '—'}{' '}
+                            <Badge variant="outline" className="ml-1 text-xs">
+                              {payment.policy.status}
+                            </Badge>
+                          </span>
+                        ) : (
+                          '—'
+                        )}
+                      </TableCell>
+                    )}
                     <TableCell>{payment.paymentType}</TableCell>
                     <TableCell>{payment.transactionReference}</TableCell>
                     <TableCell>{payment.accountNumber ?? 'N/A'}</TableCell>

--- a/apps/agent-registration/src/app/(main)/customer/[customerId]/_components/policy-reason-dialog.tsx
+++ b/apps/agent-registration/src/app/(main)/customer/[customerId]/_components/policy-reason-dialog.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Loader2 } from 'lucide-react';
+
+interface PolicyReasonDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description: string;
+  confirmLabel: string;
+  onSubmit: (reason: string) => Promise<void>;
+}
+
+export default function PolicyReasonDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel,
+  onSubmit,
+}: PolicyReasonDialogProps) {
+  const [reason, setReason] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleClose = (next: boolean) => {
+    if (!submitting) {
+      if (!next) {
+        setReason('');
+        setError(null);
+      }
+      onOpenChange(next);
+    }
+  };
+
+  const handleSubmit = async () => {
+    if (!reason.trim()) {
+      setError('Reason is required');
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      await onSubmit(reason.trim());
+      setReason('');
+      onOpenChange(false);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Request failed');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <div className="space-y-2 py-2">
+          <Label htmlFor="policy-reason">Reason (required)</Label>
+          <Textarea
+            id="policy-reason"
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            rows={4}
+            maxLength={1000}
+            placeholder="Enter reason for this change"
+          />
+          {error && <p className="text-sm text-destructive">{error}</p>}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => handleClose(false)} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button onClick={() => void handleSubmit()} disabled={submitting}>
+            {submitting && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+            {confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/agent-registration/src/app/(main)/customer/[customerId]/_components/products-tab.tsx
+++ b/apps/agent-registration/src/app/(main)/customer/[customerId]/_components/products-tab.tsx
@@ -5,25 +5,52 @@ import { useRouter } from 'next/navigation';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Badge } from '@/components/ui/badge';
-import { Loader2 } from 'lucide-react';
-import { getCustomerPoliciesList, CustomerPolicyListItem } from '@/lib/api';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Loader2, MoreHorizontal } from 'lucide-react';
+import {
+  activateCustomerPolicy,
+  deactivateCustomerPolicy,
+  getCustomerPoliciesList,
+  resetCustomerPolicyStartDate,
+  type CustomerPolicyListItem,
+} from '@/lib/api';
+import { useAuth } from '@/hooks/useAuth';
 import * as Sentry from '@sentry/nextjs';
+import PolicyReasonDialog from './policy-reason-dialog';
+import ModifyProductDialog from './modify-product-dialog';
+import ResetStartDateDialog from './reset-start-date-dialog';
+
+const PAYMENTS_POLICY_STORAGE_KEY = (customerId: string) =>
+  `customer-${customerId}-payments-policy`;
 
 interface ProductsTabProps {
   customerId: string;
-  /** 'admin' or 'dashboard' - used for policy detail link */
-  basePath: 'admin' | 'dashboard';
+  /** 'admin' | 'dashboard' | 'agent' — used for policy detail link */
+  basePath: 'admin' | 'dashboard' | 'agent';
 }
+
+type RowAction = 'deactivate' | 'activate' | 'reset' | 'modify' | null;
 
 export default function ProductsTab({ customerId, basePath }: ProductsTabProps) {
   const router = useRouter();
+  const { isAdmin } = useAuth();
+  const showAdminActions = basePath === 'admin' && isAdmin;
+
   const [policies, setPolicies] = useState<CustomerPolicyListItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [actionPolicy, setActionPolicy] = useState<CustomerPolicyListItem | null>(null);
+  const [rowAction, setRowAction] = useState<RowAction>(null);
 
   useEffect(() => {
     if (customerId) {
-      loadProducts();
+      void loadProducts();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [customerId]);
@@ -49,8 +76,33 @@ export default function ProductsTab({ customerId, basePath }: ProductsTabProps) 
   };
 
   const handleRowClick = (policyId: string) => {
-    router.push(`/${basePath}/customer/${customerId}/policy/${policyId}`);
+    const prefix =
+      basePath === 'agent' ? 'dashboard' : basePath;
+    router.push(`/${prefix}/customer/${customerId}/policy/${policyId}`);
   };
+
+  const openAction = (policy: CustomerPolicyListItem, action: RowAction) => {
+    setActionPolicy(policy);
+    setRowAction(action);
+  };
+
+  const closeAction = () => {
+    setActionPolicy(null);
+    setRowAction(null);
+  };
+
+  const onModifySuccess = (newPolicyId: string) => {
+    sessionStorage.setItem(PAYMENTS_POLICY_STORAGE_KEY(customerId), newPolicyId);
+    void loadProducts();
+  };
+
+  const canModify = (p: CustomerPolicyListItem) =>
+    p.status === 'ACTIVE' || p.status === 'PENDING_ACTIVATION';
+  const canDeactivate = (p: CustomerPolicyListItem) =>
+    p.status === 'ACTIVE' || p.status === 'SUSPENDED' || p.status === 'PENDING_ACTIVATION';
+  const canActivate = (p: CustomerPolicyListItem) => p.status === 'SUSPENDED';
+  const canReset = (p: CustomerPolicyListItem) =>
+    p.status === 'ACTIVE' || p.status === 'SUSPENDED';
 
   if (loading) {
     return (
@@ -73,62 +125,185 @@ export default function ProductsTab({ customerId, basePath }: ProductsTabProps) 
   }
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Products</CardTitle>
-        <CardDescription>
-          Policies this customer is enrolled in. Click a row to view product and enrollment details.
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        {policies.length === 0 ? (
-          <p className="text-muted-foreground py-8 text-center">No products enrolled</p>
-        ) : (
-          <div className="rounded-md border">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Product / Package</TableHead>
-                  <TableHead>Plan</TableHead>
-                  <TableHead>Scheme</TableHead>
-                  <TableHead>Underwriter</TableHead>
-                  <TableHead>Status</TableHead>
-                  <TableHead className="text-right">Total premium</TableHead>
-                  <TableHead className="text-right">Installment</TableHead>
-                  <TableHead className="text-right">Paid</TableHead>
-                  <TableHead className="text-right">Missed</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {policies.map((p) => (
-                  <TableRow
-                    key={p.id}
-                    className="cursor-pointer hover:bg-muted/50"
-                    onClick={() => handleRowClick(p.id)}
-                  >
-                    <TableCell className="font-medium">
-                      {p.productName}
-                      <span className="block text-xs text-muted-foreground">{p.packageName}</span>
-                    </TableCell>
-                    <TableCell>{p.planName ?? '—'}</TableCell>
-                    <TableCell>{p.schemeName}</TableCell>
-                    <TableCell>{p.underwriterName ?? '—'}</TableCell>
-                    <TableCell>
-                      <Badge variant={p.status === 'ACTIVE' ? 'default' : 'secondary'}>
-                        {p.status}
-                      </Badge>
-                    </TableCell>
-                    <TableCell className="text-right">{p.totalPremium}</TableCell>
-                    <TableCell className="text-right">{p.installment}</TableCell>
-                    <TableCell className="text-right">{p.installmentsPaid}</TableCell>
-                    <TableCell className="text-right">{p.missedPayments}</TableCell>
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle>Products</CardTitle>
+          <CardDescription>
+            Policies this customer is enrolled in. Click a row to view product and enrollment
+            details.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {policies.length === 0 ? (
+            <p className="text-muted-foreground py-8 text-center">No products enrolled</p>
+          ) : (
+            <div className="rounded-md border">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Product / Package</TableHead>
+                    <TableHead>Plan</TableHead>
+                    <TableHead>Scheme</TableHead>
+                    <TableHead>Underwriter</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead className="text-right">Total premium</TableHead>
+                    <TableHead className="text-right">Installment</TableHead>
+                    <TableHead className="text-right">Paid</TableHead>
+                    <TableHead className="text-right">Missed</TableHead>
+                    {showAdminActions && <TableHead className="w-10" />}
                   </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </div>
-        )}
-      </CardContent>
-    </Card>
+                </TableHeader>
+                <TableBody>
+                  {policies.map((p) => (
+                    <TableRow key={p.id} className="hover:bg-muted/50">
+                      <TableCell
+                        className="font-medium cursor-pointer"
+                        onClick={() => handleRowClick(p.id)}
+                      >
+                        {p.productName}
+                        <span className="block text-xs text-muted-foreground">{p.packageName}</span>
+                      </TableCell>
+                      <TableCell className="cursor-pointer" onClick={() => handleRowClick(p.id)}>
+                        {p.planName ?? '—'}
+                      </TableCell>
+                      <TableCell className="cursor-pointer" onClick={() => handleRowClick(p.id)}>
+                        {p.schemeName}
+                      </TableCell>
+                      <TableCell className="cursor-pointer" onClick={() => handleRowClick(p.id)}>
+                        {p.underwriterName ?? '—'}
+                      </TableCell>
+                      <TableCell className="cursor-pointer" onClick={() => handleRowClick(p.id)}>
+                        <Badge variant={p.status === 'ACTIVE' ? 'default' : 'secondary'}>
+                          {p.status}
+                        </Badge>
+                      </TableCell>
+                      <TableCell
+                        className="text-right cursor-pointer"
+                        onClick={() => handleRowClick(p.id)}
+                      >
+                        {p.totalPremium}
+                      </TableCell>
+                      <TableCell
+                        className="text-right cursor-pointer"
+                        onClick={() => handleRowClick(p.id)}
+                      >
+                        {p.installment}
+                      </TableCell>
+                      <TableCell
+                        className="text-right cursor-pointer"
+                        onClick={() => handleRowClick(p.id)}
+                      >
+                        {p.installmentsPaid}
+                      </TableCell>
+                      <TableCell
+                        className="text-right cursor-pointer"
+                        onClick={() => handleRowClick(p.id)}
+                      >
+                        {p.missedPayments}
+                      </TableCell>
+                      {showAdminActions && (
+                        <TableCell>
+                          <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                className="h-8 w-8"
+                                onClick={(e) => e.stopPropagation()}
+                              >
+                                <MoreHorizontal className="h-4 w-4" />
+                              </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="end">
+                              {canModify(p) && (
+                                <DropdownMenuItem onClick={() => openAction(p, 'modify')}>
+                                  Modify product
+                                </DropdownMenuItem>
+                              )}
+                              {canDeactivate(p) && (
+                                <DropdownMenuItem onClick={() => openAction(p, 'deactivate')}>
+                                  Deactivate
+                                </DropdownMenuItem>
+                              )}
+                              {canActivate(p) && (
+                                <DropdownMenuItem onClick={() => openAction(p, 'activate')}>
+                                  Activate
+                                </DropdownMenuItem>
+                              )}
+                              {canReset(p) && (
+                                <DropdownMenuItem onClick={() => openAction(p, 'reset')}>
+                                  Reset start date
+                                </DropdownMenuItem>
+                              )}
+                            </DropdownMenuContent>
+                          </DropdownMenu>
+                        </TableCell>
+                      )}
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {actionPolicy && rowAction === 'modify' && (
+        <ModifyProductDialog
+          open
+          onOpenChange={(o) => !o && closeAction()}
+          customerId={customerId}
+          policyId={actionPolicy.id}
+          onSuccess={onModifySuccess}
+        />
+      )}
+
+      {actionPolicy && rowAction === 'deactivate' && (
+        <PolicyReasonDialog
+          open
+          onOpenChange={(o) => !o && closeAction()}
+          title="Deactivate policy"
+          description={`Deactivate ${actionPolicy.productName}. Customer status may change if this is their only active policy.`}
+          confirmLabel="Deactivate"
+          onSubmit={async (reason) => {
+            await deactivateCustomerPolicy(customerId, actionPolicy.id, reason);
+            await loadProducts();
+          }}
+        />
+      )}
+
+      {actionPolicy && rowAction === 'activate' && (
+        <PolicyReasonDialog
+          open
+          onOpenChange={(o) => !o && closeAction()}
+          title="Activate policy"
+          description="Reactivate a suspended policy."
+          confirmLabel="Activate"
+          onSubmit={async (reason) => {
+            await activateCustomerPolicy(customerId, actionPolicy.id, reason);
+            await loadProducts();
+          }}
+        />
+      )}
+
+      {actionPolicy && rowAction === 'reset' && (
+        <ResetStartDateDialog
+          open
+          onOpenChange={(o) => !o && closeAction()}
+          onSubmit={async (reason, startDateIso) => {
+            await resetCustomerPolicyStartDate(
+              customerId,
+              actionPolicy.id,
+              reason,
+              startDateIso
+            );
+            await loadProducts();
+          }}
+        />
+      )}
+    </>
   );
 }
+
+export { PAYMENTS_POLICY_STORAGE_KEY };

--- a/apps/agent-registration/src/app/(main)/customer/[customerId]/_components/products-tab.tsx
+++ b/apps/agent-registration/src/app/(main)/customer/[customerId]/_components/products-tab.tsx
@@ -103,6 +103,8 @@ export default function ProductsTab({ customerId, basePath }: ProductsTabProps) 
   const canActivate = (p: CustomerPolicyListItem) => p.status === 'SUSPENDED';
   const canReset = (p: CustomerPolicyListItem) =>
     p.status === 'ACTIVE' || p.status === 'SUSPENDED';
+  const hasRowActions = (p: CustomerPolicyListItem) =>
+    canModify(p) || canDeactivate(p) || canActivate(p) || canReset(p);
 
   if (loading) {
     return (
@@ -204,40 +206,44 @@ export default function ProductsTab({ customerId, basePath }: ProductsTabProps) 
                       </TableCell>
                       {showAdminActions && (
                         <TableCell>
-                          <DropdownMenu>
-                            <DropdownMenuTrigger asChild>
-                              <Button
-                                variant="ghost"
-                                size="icon"
-                                className="h-8 w-8"
-                                onClick={(e) => e.stopPropagation()}
-                              >
-                                <MoreHorizontal className="h-4 w-4" />
-                              </Button>
-                            </DropdownMenuTrigger>
-                            <DropdownMenuContent align="end">
-                              {canModify(p) && (
-                                <DropdownMenuItem onClick={() => openAction(p, 'modify')}>
-                                  Modify product
-                                </DropdownMenuItem>
-                              )}
-                              {canDeactivate(p) && (
-                                <DropdownMenuItem onClick={() => openAction(p, 'deactivate')}>
-                                  Deactivate
-                                </DropdownMenuItem>
-                              )}
-                              {canActivate(p) && (
-                                <DropdownMenuItem onClick={() => openAction(p, 'activate')}>
-                                  Activate
-                                </DropdownMenuItem>
-                              )}
-                              {canReset(p) && (
-                                <DropdownMenuItem onClick={() => openAction(p, 'reset')}>
-                                  Reset start date
-                                </DropdownMenuItem>
-                              )}
-                            </DropdownMenuContent>
-                          </DropdownMenu>
+                          {hasRowActions(p) ? (
+                            <DropdownMenu>
+                              <DropdownMenuTrigger asChild>
+                                <Button
+                                  variant="ghost"
+                                  size="icon"
+                                  className="h-8 w-8"
+                                  onClick={(e) => e.stopPropagation()}
+                                >
+                                  <MoreHorizontal className="h-4 w-4" />
+                                </Button>
+                              </DropdownMenuTrigger>
+                              <DropdownMenuContent align="end">
+                                {canModify(p) && (
+                                  <DropdownMenuItem onClick={() => openAction(p, 'modify')}>
+                                    Modify product
+                                  </DropdownMenuItem>
+                                )}
+                                {canDeactivate(p) && (
+                                  <DropdownMenuItem onClick={() => openAction(p, 'deactivate')}>
+                                    Deactivate
+                                  </DropdownMenuItem>
+                                )}
+                                {canActivate(p) && (
+                                  <DropdownMenuItem onClick={() => openAction(p, 'activate')}>
+                                    Activate
+                                  </DropdownMenuItem>
+                                )}
+                                {canReset(p) && (
+                                  <DropdownMenuItem onClick={() => openAction(p, 'reset')}>
+                                    Reset start date
+                                  </DropdownMenuItem>
+                                )}
+                              </DropdownMenuContent>
+                            </DropdownMenu>
+                          ) : (
+                            <span className="text-muted-foreground">—</span>
+                          )}
                         </TableCell>
                       )}
                     </TableRow>

--- a/apps/agent-registration/src/app/(main)/customer/[customerId]/_components/products-tab.tsx
+++ b/apps/agent-registration/src/app/(main)/customer/[customerId]/_components/products-tab.tsx
@@ -18,6 +18,7 @@ import {
   deactivateCustomerPolicy,
   getCustomerPoliciesList,
   resetCustomerPolicyStartDate,
+  terminateCustomerPolicy,
   type CustomerPolicyListItem,
 } from '@/lib/api';
 import { useAuth } from '@/hooks/useAuth';
@@ -35,7 +36,7 @@ interface ProductsTabProps {
   basePath: 'admin' | 'dashboard' | 'agent';
 }
 
-type RowAction = 'deactivate' | 'activate' | 'reset' | 'modify' | null;
+type RowAction = 'deactivate' | 'activate' | 'reset' | 'modify' | 'terminate' | null;
 
 export default function ProductsTab({ customerId, basePath }: ProductsTabProps) {
   const router = useRouter();
@@ -103,8 +104,10 @@ export default function ProductsTab({ customerId, basePath }: ProductsTabProps) 
   const canActivate = (p: CustomerPolicyListItem) => p.status === 'SUSPENDED';
   const canReset = (p: CustomerPolicyListItem) =>
     p.status === 'ACTIVE' || p.status === 'SUSPENDED';
+  const canTerminate = (p: CustomerPolicyListItem) =>
+    p.status !== 'TERMINATED' && p.status !== 'DEACTIVATED';
   const hasRowActions = (p: CustomerPolicyListItem) =>
-    canModify(p) || canDeactivate(p) || canActivate(p) || canReset(p);
+    canModify(p) || canDeactivate(p) || canActivate(p) || canReset(p) || canTerminate(p);
 
   if (loading) {
     return (
@@ -239,6 +242,14 @@ export default function ProductsTab({ customerId, basePath }: ProductsTabProps) 
                                     Reset start date
                                   </DropdownMenuItem>
                                 )}
+                                {canTerminate(p) && (
+                                  <DropdownMenuItem
+                                    className="text-destructive focus:text-destructive"
+                                    onClick={() => openAction(p, 'terminate')}
+                                  >
+                                    Terminate
+                                  </DropdownMenuItem>
+                                )}
                               </DropdownMenuContent>
                             </DropdownMenu>
                           ) : (
@@ -297,13 +308,27 @@ export default function ProductsTab({ customerId, basePath }: ProductsTabProps) 
         <ResetStartDateDialog
           open
           onOpenChange={(o) => !o && closeAction()}
-          onSubmit={async (reason, startDateIso) => {
+          onSubmit={async (reason, startDate) => {
             await resetCustomerPolicyStartDate(
               customerId,
               actionPolicy.id,
               reason,
-              startDateIso
+              startDate
             );
+            await loadProducts();
+          }}
+        />
+      )}
+
+      {actionPolicy && rowAction === 'terminate' && (
+        <PolicyReasonDialog
+          open
+          onOpenChange={(o) => !o && closeAction()}
+          title="Terminate policy"
+          description={`Permanently terminate ${actionPolicy.productName}. The customer becomes Terminated only if they have no remaining Active, Pending, or Suspended policies.`}
+          confirmLabel="Terminate"
+          onSubmit={async (reason) => {
+            await terminateCustomerPolicy(customerId, actionPolicy.id, reason);
             await loadProducts();
           }}
         />

--- a/apps/agent-registration/src/app/(main)/customer/[customerId]/_components/reset-start-date-dialog.tsx
+++ b/apps/agent-registration/src/app/(main)/customer/[customerId]/_components/reset-start-date-dialog.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Input } from '@/components/ui/input';
+import { Loader2 } from 'lucide-react';
+
+interface ResetStartDateDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (reason: string, startDateIso: string) => Promise<void>;
+}
+
+export default function ResetStartDateDialog({
+  open,
+  onOpenChange,
+  onSubmit,
+}: ResetStartDateDialogProps) {
+  const [reason, setReason] = useState('');
+  const [startDate, setStartDate] = useState(() => new Date().toISOString().slice(0, 10));
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async () => {
+    if (!reason.trim()) {
+      setError('Reason is required');
+      return;
+    }
+    if (!startDate) {
+      setError('Start date is required');
+      return;
+    }
+    const [y, m, d] = startDate.split('-').map(Number);
+    const iso = new Date(Date.UTC(y, m - 1, d, 0, 0, 0, 0)).toISOString();
+    setSubmitting(true);
+    setError(null);
+    try {
+      await onSubmit(reason.trim(), iso);
+      onOpenChange(false);
+      setReason('');
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Request failed');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Reset start date</DialogTitle>
+          <DialogDescription>
+            Updates policy start and end dates only. Earlier payments stay on the policy but are
+            treated as lost for coverage accounting.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4 py-2">
+          <div>
+            <Label htmlFor="reset-start">New start date</Label>
+            <Input
+              id="reset-start"
+              type="date"
+              value={startDate}
+              onChange={(e) => setStartDate(e.target.value)}
+            />
+          </div>
+          <div>
+            <Label htmlFor="reset-reason">Reason (required)</Label>
+            <Textarea
+              id="reset-reason"
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              rows={3}
+            />
+          </div>
+          {error && <p className="text-sm text-destructive">{error}</p>}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button onClick={() => void handleSubmit()} disabled={submitting}>
+            {submitting && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+            Reset start date
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/agent-registration/src/app/(main)/customer/[customerId]/page.tsx
+++ b/apps/agent-registration/src/app/(main)/customer/[customerId]/page.tsx
@@ -14,6 +14,7 @@ import SpouseSection from './_components/spouse-section';
 import ChildrenSection from './_components/children-section';
 import PaymentsTab from './_components/payments-tab';
 import MemberCardsTab from './_components/member-cards-tab';
+import ProductsTab from './_components/products-tab';
 import { useEditPermissions } from './_hooks/use-edit-permissions';
 
 export default function CustomerDetailPage() {
@@ -113,6 +114,7 @@ export default function CustomerDetailPage() {
       <Tabs defaultValue="details" className="w-full">
         <TabsList>
           <TabsTrigger value="details">Customer Details</TabsTrigger>
+          <TabsTrigger value="products">Products</TabsTrigger>
           <TabsTrigger value="payments">Payments</TabsTrigger>
           <TabsTrigger value="member-cards">Member cards</TabsTrigger>
         </TabsList>
@@ -144,6 +146,10 @@ export default function CustomerDetailPage() {
             canAdd={canEdit}
             onUpdate={loadCustomerDetails}
           />
+        </TabsContent>
+
+        <TabsContent value="products">
+          <ProductsTab customerId={customerId} basePath="agent" />
         </TabsContent>
 
         <TabsContent value="payments">

--- a/apps/agent-registration/src/app/self/customer/[customerId]/(portal)/products/[productId]/page.tsx
+++ b/apps/agent-registration/src/app/self/customer/[customerId]/(portal)/products/[productId]/page.tsx
@@ -14,6 +14,7 @@ import {
   type PortalPayment,
   type PortalMemberCardsResponse,
 } from '@/lib/customer-portal-api';
+import { formatTransactionReferenceForDisplay } from '@/lib/transaction-reference-display';
 import { Loader2 } from 'lucide-react';
 import MemberCardWithDownload from '@/components/member-cards/MemberCardWithDownload';
 
@@ -325,7 +326,7 @@ function PaymentsTab({
                       {p.paymentStatus ?? '—'}
                     </td>
                     <td className="px-4 py-3 text-xs text-[#4f434e]">
-                      {p.transactionReference || '—'}
+                      {formatTransactionReferenceForDisplay(p.transactionReference)}
                     </td>
                   </tr>
                 ))}

--- a/apps/agent-registration/src/lib/api.ts
+++ b/apps/agent-registration/src/lib/api.ts
@@ -2466,6 +2466,18 @@ export async function deactivateCustomerPolicy(
   )
 }
 
+export async function terminateCustomerPolicy(
+  customerId: string,
+  policyId: string,
+  reason: string
+): Promise<PolicyLifecycleResponse> {
+  return policyLifecycleFetch(
+    `/internal/customers/${customerId}/policies/${policyId}/terminate`,
+    'POST',
+    { reason }
+  )
+}
+
 export async function activateCustomerPolicy(
   customerId: string,
   policyId: string,

--- a/apps/agent-registration/src/lib/api.ts
+++ b/apps/agent-registration/src/lib/api.ts
@@ -929,6 +929,11 @@ export interface PolicyOption {
   displayText: string
   packageName: string
   planName?: string
+  status?: string
+  policyNumber?: string | null
+  startDate?: string | null
+  endDate?: string | null
+  deactivatedAt?: string | null
 }
 
 export interface CustomerPoliciesResponse {
@@ -1024,6 +1029,12 @@ export interface Payment {
   actualPaymentDate?: string
   amount: number
   paymentStatus?: string
+  policy?: {
+    id: string
+    policyNumber: string | null
+    status: string
+    displayText: string
+  }
 }
 
 export interface CustomerPaymentsResponse {
@@ -2353,6 +2364,152 @@ export async function resendMessagingDelivery(deliveryId: string): Promise<{ new
   }
   const body = await response.json()
   return { newDeliveryId: body.data?.newDeliveryId ?? body.newDeliveryId ?? deliveryId }
+}
+
+// ── Policy lifecycle (admin) ─────────────────────────────────────────────────
+
+export interface PolicyLifecyclePolicy {
+  id: string
+  policyNumber?: string | null
+  status: string
+}
+
+export interface PolicyLifecycleResponse {
+  status: number
+  correlationId: string
+  message: string
+  policy: PolicyLifecyclePolicy
+  newPolicyId?: string
+}
+
+export interface ModifyPolicyOptionsPayment {
+  id: number
+  transactionReference: string
+  amount: number
+  expectedPaymentDate: string
+  actualPaymentDate?: string
+}
+
+export interface ModifyPolicyOptionsScheme {
+  packageSchemeId: number
+  schemeName: string
+  isPostpaid: boolean
+}
+
+export interface ModifyPolicyOptions {
+  status: number
+  correlationId: string
+  message: string
+  packageId: number
+  packageName: string
+  familyCategory: string
+  additionalSpouse: boolean
+  currentPackagePlanId: number
+  currentPlanName?: string
+  currentPremium: number
+  currentFrequency: string
+  currentPaymentCadence: number
+  currentPackageSchemeId: number | null
+  paymentMigrationAllowed: boolean
+  eligiblePayments: ModifyPolicyOptionsPayment[]
+  schemes: ModifyPolicyOptionsScheme[]
+}
+
+export type PolicyNumberChoice = 'KEEP_EXISTING' | 'GENERATE_NEW'
+
+export interface ModifyPolicyRequest {
+  reason: string
+  packagePlanId: number
+  frequency: 'DAILY' | 'WEEKLY' | 'MONTHLY' | 'QUARTERLY' | 'ANNUALLY' | 'CUSTOM'
+  premium: number
+  customDays?: number
+  packageSchemeId?: number
+  policyNumberChoice: PolicyNumberChoice
+  firstPaymentId?: number
+}
+
+async function policyLifecycleFetch<T>(
+  path: string,
+  method: 'GET' | 'POST',
+  body?: unknown
+): Promise<T> {
+  const token = await getSupabaseToken()
+  const response = await fetch(
+    `${process.env.NEXT_PUBLIC_INTERNAL_API_BASE_URL}${path}`,
+    {
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+        'x-correlation-id': `policy-lifecycle-${Date.now()}`,
+      },
+      ...(body != null ? { body: JSON.stringify(body) } : {}),
+    }
+  )
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}))
+    throw new Error(err?.error?.message ?? `Request failed: ${response.statusText}`)
+  }
+  return response.json() as Promise<T>
+}
+
+export async function deactivateCustomerPolicy(
+  customerId: string,
+  policyId: string,
+  reason: string
+): Promise<PolicyLifecycleResponse> {
+  return policyLifecycleFetch(
+    `/internal/customers/${customerId}/policies/${policyId}/deactivate`,
+    'POST',
+    { reason }
+  )
+}
+
+export async function activateCustomerPolicy(
+  customerId: string,
+  policyId: string,
+  reason: string
+): Promise<PolicyLifecycleResponse> {
+  return policyLifecycleFetch(
+    `/internal/customers/${customerId}/policies/${policyId}/activate`,
+    'POST',
+    { reason }
+  )
+}
+
+export async function resetCustomerPolicyStartDate(
+  customerId: string,
+  policyId: string,
+  reason: string,
+  startDate: string
+): Promise<PolicyLifecycleResponse> {
+  return policyLifecycleFetch(
+    `/internal/customers/${customerId}/policies/${policyId}/reset-start-date`,
+    'POST',
+    { reason, startDate }
+  )
+}
+
+export async function getModifyPolicyOptions(
+  customerId: string,
+  policyId: string
+): Promise<ModifyPolicyOptions> {
+  return policyLifecycleFetch(
+    `/internal/customers/${customerId}/policies/${policyId}/modify-options`,
+    'GET'
+  )
+}
+
+export async function modifyCustomerPolicy(
+  customerId: string,
+  policyId: string,
+  body: ModifyPolicyRequest
+): Promise<PolicyLifecycleResponse> {
+  return policyLifecycleFetch(
+    `/internal/customers/${customerId}/policies/${policyId}/modify`,
+    'POST',
+    body
+  )
 }
 
 async function getSupabaseToken(): Promise<string> {

--- a/apps/agent-registration/src/lib/api.ts
+++ b/apps/agent-registration/src/lib/api.ts
@@ -2388,6 +2388,7 @@ export interface ModifyPolicyOptionsPayment {
   amount: number
   expectedPaymentDate: string
   actualPaymentDate?: string
+  paymentStatus: string
 }
 
 export interface ModifyPolicyOptionsScheme {

--- a/apps/agent-registration/src/lib/transaction-reference-display.ts
+++ b/apps/agent-registration/src/lib/transaction-reference-display.ts
@@ -1,0 +1,36 @@
+const QUERY_PENDING_PREFIX = 'QUERY-PENDING-';
+const PENDING_STK_PREFIX = 'PENDING-STK-';
+
+/** Display-only: first segment of suffix, capped at 8 characters. */
+function shortenSuffix(suffix: string): string {
+  const first = suffix.split('-')[0] ?? suffix;
+  return first.slice(0, 8);
+}
+
+/**
+ * Shorten QUERY-PENDING / PENDING-STK placeholder references for read-only UI.
+ * Backend values are unchanged.
+ */
+export function formatTransactionReferenceForDisplay(
+  ref: string | null | undefined
+): string {
+  if (!ref) return '—';
+  if (ref.startsWith(QUERY_PENDING_PREFIX)) {
+    const id = ref.slice(QUERY_PENDING_PREFIX.length);
+    return `${QUERY_PENDING_PREFIX}${shortenSuffix(id)}`;
+  }
+  if (ref.startsWith(PENDING_STK_PREFIX)) {
+    const id = ref.slice(PENDING_STK_PREFIX.length);
+    return `${PENDING_STK_PREFIX}${shortenSuffix(id)}`;
+  }
+  return ref;
+}
+
+/** Human-readable suffix for modify-product payment picker only. */
+export function formatMigrationPaymentStatusLabel(
+  status: string | null | undefined
+): string {
+  if (status === 'COMPLETED') return '(Completed)';
+  if (status === 'COMPLETED_PENDING_RECEIPT') return '(Pending receipt)';
+  return '';
+}

--- a/apps/api/prisma/migrations/20260709120000_policy_lifecycle_foundation/migration.sql
+++ b/apps/api/prisma/migrations/20260709120000_policy_lifecycle_foundation/migration.sql
@@ -1,0 +1,56 @@
+-- Policy lifecycle: DEACTIVATED status, EntityStatusChange audit, supersession, partial unique index, OUTSTANDING payments
+
+-- Enums
+ALTER TYPE "PolicyStatus" ADD VALUE IF NOT EXISTS 'DEACTIVATED';
+ALTER TYPE "CustomerStatus" ADD VALUE IF NOT EXISTS 'DEACTIVATED';
+ALTER TYPE "PaymentStatus" ADD VALUE IF NOT EXISTS 'OUTSTANDING';
+
+CREATE TYPE "StatusChangeEntityType" AS ENUM ('POLICY', 'CUSTOMER');
+CREATE TYPE "StatusChangeTrigger" AS ENUM ('MANUAL_ADMIN', 'MODIFY_PRODUCT', 'PAYMENT_LIFECYCLE', 'SYSTEM');
+
+-- Policy lineage + deactivatedAt
+ALTER TABLE "policies" ADD COLUMN IF NOT EXISTS "deactivatedAt" TIMESTAMP(3);
+ALTER TABLE "policies" ADD COLUMN IF NOT EXISTS "supersedesPolicyId" UUID;
+ALTER TABLE "policies" ADD COLUMN IF NOT EXISTS "supersededByPolicyId" UUID;
+
+ALTER TABLE "policies" ADD CONSTRAINT "policies_supersedesPolicyId_fkey"
+  FOREIGN KEY ("supersedesPolicyId") REFERENCES "policies"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "policies" ADD CONSTRAINT "policies_supersededByPolicyId_fkey"
+  FOREIGN KEY ("supersededByPolicyId") REFERENCES "policies"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- Customer deactivatedAt
+ALTER TABLE "customers" ADD COLUMN IF NOT EXISTS "deactivatedAt" TIMESTAMP(3);
+
+-- Entity status change audit
+CREATE TABLE "entity_status_changes" (
+    "id" UUID NOT NULL,
+    "entityType" "StatusChangeEntityType" NOT NULL,
+    "customerId" UUID NOT NULL,
+    "policyId" UUID,
+    "fromStatus" VARCHAR(50) NOT NULL,
+    "toStatus" VARCHAR(50) NOT NULL,
+    "reason" VARCHAR(1000) NOT NULL,
+    "trigger" "StatusChangeTrigger" NOT NULL,
+    "changedBy" UUID NOT NULL,
+    "correlationId" VARCHAR(100),
+    "metadata" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "entity_status_changes_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "entity_status_changes_customerId_createdAt_idx" ON "entity_status_changes"("customerId", "createdAt");
+CREATE INDEX "entity_status_changes_policyId_createdAt_idx" ON "entity_status_changes"("policyId", "createdAt");
+
+ALTER TABLE "entity_status_changes" ADD CONSTRAINT "entity_status_changes_customerId_fkey"
+  FOREIGN KEY ("customerId") REFERENCES "customers"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "entity_status_changes" ADD CONSTRAINT "entity_status_changes_policyId_fkey"
+  FOREIGN KEY ("policyId") REFERENCES "policies"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- Replace full unique (customerId, packageId) with partial unique for non-terminal policies
+DROP INDEX IF EXISTS "policies_customer_id_package_id_key";
+CREATE INDEX IF NOT EXISTS "policies_customerId_packageId_idx" ON "policies"("customerId", "packageId");
+
+CREATE UNIQUE INDEX "policies_customer_package_active_unique"
+  ON "policies"("customerId", "packageId")
+  WHERE status IN ('ACTIVE', 'PENDING_ACTIVATION', 'SUSPENDED');

--- a/apps/api/prisma/migrations/20260711120000_policy_payment_lifecycle/migration.sql
+++ b/apps/api/prisma/migrations/20260711120000_policy_payment_lifecycle/migration.sql
@@ -1,0 +1,40 @@
+-- Policy payment lifecycle: INACTIVE status, grace/suspension clocks, notification ledger
+
+ALTER TYPE "PolicyStatus" ADD VALUE IF NOT EXISTS 'INACTIVE';
+
+ALTER TABLE "policies" ADD COLUMN IF NOT EXISTS "inGracePeriod" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "policies" ADD COLUMN IF NOT EXISTS "graceEnteredAt" TIMESTAMP(3);
+ALTER TABLE "policies" ADD COLUMN IF NOT EXISTS "overdueAnchorDueDate" TIMESTAMP(3);
+ALTER TABLE "policies" ADD COLUMN IF NOT EXISTS "suspendedAt" TIMESTAMP(3);
+ALTER TABLE "policies" ADD COLUMN IF NOT EXISTS "inactivatedAt" TIMESTAMP(3);
+ALTER TABLE "policies" ADD COLUMN IF NOT EXISTS "expiredAt" TIMESTAMP(3);
+
+CREATE TABLE IF NOT EXISTS "policy_lifecycle_notifications" (
+    "id" UUID NOT NULL,
+    "policyId" UUID NOT NULL,
+    "scheduleKey" VARCHAR(80) NOT NULL,
+    "templateKey" VARCHAR(120) NOT NULL,
+    "sentAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "metadata" JSONB,
+
+    CONSTRAINT "policy_lifecycle_notifications_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "policy_lifecycle_notifications_policyId_scheduleKey_key"
+  ON "policy_lifecycle_notifications"("policyId", "scheduleKey");
+
+CREATE INDEX IF NOT EXISTS "policy_lifecycle_notifications_policyId_idx"
+  ON "policy_lifecycle_notifications"("policyId");
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'policy_lifecycle_notifications_policyId_fkey'
+  ) THEN
+    ALTER TABLE "policy_lifecycle_notifications"
+      ADD CONSTRAINT "policy_lifecycle_notifications_policyId_fkey"
+      FOREIGN KEY ("policyId") REFERENCES "policies"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+  END IF;
+END $$;
+
+-- Partial unique index remains ACTIVE|PENDING_ACTIVATION|SUSPENDED only (INACTIVE not included)

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -305,6 +305,18 @@ model Policy {
   /// Denormalized; source of truth is EntityStatusChange
   deactivatedAt DateTime?
 
+  /// Grace overlay (member-facing status remains ACTIVE when true)
+  inGracePeriod        Boolean   @default(false)
+  graceEnteredAt       DateTime?
+  /// Anchor: next unpaid expected due date that opened this overdue episode
+  overdueAnchorDueDate DateTime?
+  /// When status became SUSPENDED (for >30 day → INACTIVE clock before end)
+  suspendedAt          DateTime?
+  /// When status became INACTIVE
+  inactivatedAt        DateTime?
+  /// When status became EXPIRED
+  expiredAt            DateTime?
+
   /// Modify-product lineage: this policy replaced an older policy (same package)
   supersedesPolicyId   String? @db.Uuid
   /// Modify-product lineage: this policy was replaced by a newer policy
@@ -317,6 +329,7 @@ model Policy {
   policyPayments PolicyPayment[]
   policyTags     PolicyTag[]
   messagingDeliveries MessagingDelivery[]
+  lifecycleNotifications PolicyLifecycleNotification[]
 
   supersedesPolicy       Policy?  @relation("PolicySupersedes", fields: [supersedesPolicyId], references: [id], onDelete: SetNull)
   policiesSupersedingThis Policy[] @relation("PolicySupersedes")
@@ -330,6 +343,22 @@ model Policy {
 
   @@index([customerId, packageId])
   @@map("policies")
+}
+
+/// Idempotent scheduled/event notification ledger for policy lifecycle SMS
+model PolicyLifecycleNotification {
+  id          String   @id @default(uuid()) @db.Uuid
+  policyId    String   @db.Uuid
+  scheduleKey String   @db.VarChar(80)
+  templateKey String   @db.VarChar(120)
+  sentAt      DateTime @default(now())
+  metadata    Json?
+
+  policy Policy @relation(fields: [policyId], references: [id], onDelete: Cascade)
+
+  @@unique([policyId, scheduleKey])
+  @@index([policyId])
+  @@map("policy_lifecycle_notifications")
 }
 
 enum CustomerStatus {
@@ -393,6 +422,7 @@ enum PolicyStatus {
   PENDING_ACTIVATION
   ACTIVE
   SUSPENDED
+  INACTIVE
   DEACTIVATED
   TERMINATED
   EXPIRED

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -142,6 +142,11 @@ model Customer {
   // Messaging relations
   messagingDeliveries MessagingDelivery[]
 
+  /// Denormalized; source of truth is EntityStatusChange
+  deactivatedAt DateTime?
+
+  statusChanges EntityStatusChange[]
+
   /// Set when the member completes first-time 4-digit PIN setup (Supabase password updated). Null = must complete PIN flow.
   portalPinSetupCompletedAt DateTime?
 
@@ -297,6 +302,14 @@ model Policy {
   frequency      PaymentFrequency
   paymentCadence Int // Number of days between premium payments
 
+  /// Denormalized; source of truth is EntityStatusChange
+  deactivatedAt DateTime?
+
+  /// Modify-product lineage: this policy replaced an older policy (same package)
+  supersedesPolicyId   String? @db.Uuid
+  /// Modify-product lineage: this policy was replaced by a newer policy
+  supersededByPolicyId String? @db.Uuid
+
   // Relations
   customer       Customer        @relation(fields: [customerId], references: [id], onDelete: Cascade)
   package        Package         @relation(fields: [packageId], references: [id], onDelete: Restrict)
@@ -305,10 +318,17 @@ model Policy {
   policyTags     PolicyTag[]
   messagingDeliveries MessagingDelivery[]
 
+  supersedesPolicy       Policy?  @relation("PolicySupersedes", fields: [supersedesPolicyId], references: [id], onDelete: SetNull)
+  policiesSupersedingThis Policy[] @relation("PolicySupersedes")
+  supersededByPolicy     Policy?  @relation("PolicySupersededBy", fields: [supersededByPolicyId], references: [id], onDelete: SetNull)
+  policiesSupersededByThis Policy[] @relation("PolicySupersededBy")
+
+  statusChanges EntityStatusChange[]
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  @@unique([customerId, packageId])
+  @@index([customerId, packageId])
   @@map("policies")
 }
 
@@ -318,6 +338,7 @@ enum CustomerStatus {
   KYC_VERIFIED
   ACTIVE
   SUSPENDED
+  DEACTIVATED
   TERMINATED
   DELETED
 }
@@ -372,6 +393,7 @@ enum PolicyStatus {
   PENDING_ACTIVATION
   ACTIVE
   SUSPENDED
+  DEACTIVATED
   TERMINATED
   EXPIRED
 }
@@ -396,6 +418,41 @@ enum PaymentStatus {
   PENDING_STK_CALLBACK        // Waiting for STK callback (has PENDING-STK-* reference)
   COMPLETED_PENDING_RECEIPT   // Query confirmed success, awaiting callback for receipt
   COMPLETED                   // Has real M-Pesa receipt number
+  OUTSTANDING                 // Backfilled expected installment slot not yet paid
+}
+
+enum StatusChangeEntityType {
+  POLICY
+  CUSTOMER
+}
+
+enum StatusChangeTrigger {
+  MANUAL_ADMIN
+  MODIFY_PRODUCT
+  PAYMENT_LIFECYCLE
+  SYSTEM
+}
+
+model EntityStatusChange {
+  id            String                  @id @default(uuid()) @db.Uuid
+  entityType    StatusChangeEntityType
+  customerId    String                  @db.Uuid
+  policyId      String?                 @db.Uuid
+  fromStatus    String                  @db.VarChar(50)
+  toStatus      String                  @db.VarChar(50)
+  reason        String                  @db.VarChar(1000)
+  trigger       StatusChangeTrigger
+  changedBy     String                  @db.Uuid
+  correlationId String?                 @db.VarChar(100)
+  metadata      Json?
+  createdAt     DateTime                @default(now())
+
+  customer Customer @relation(fields: [customerId], references: [id], onDelete: Cascade)
+  policy   Policy?  @relation(fields: [policyId], references: [id], onDelete: SetNull)
+
+  @@index([customerId, createdAt])
+  @@index([policyId, createdAt])
+  @@map("entity_status_changes")
 }
 
 // New enums for Agent Registration module

--- a/apps/api/prisma/seed-messaging.sql
+++ b/apps/api/prisma/seed-messaging.sql
@@ -229,3 +229,255 @@ VALUES (
 )
 ON CONFLICT ("templateKey", "channel", "language") DO UPDATE
 SET "body" = EXCLUDED."body", "placeholders" = EXCLUDED."placeholders", "isActive" = EXCLUDED."isActive", "updatedAt" = NOW();
+
+-- ---------- Pending activation reminders (D3 / D7 only; day-0 = customer_created) ----------
+
+INSERT INTO messaging_routes ("templateKey", "smsEnabled", "emailEnabled", "isActive", "createdAt", "updatedAt")
+VALUES ('pending_activation_d3', true, false, true, NOW(), NOW())
+ON CONFLICT ("templateKey") DO UPDATE
+SET "smsEnabled" = EXCLUDED."smsEnabled", "emailEnabled" = EXCLUDED."emailEnabled", "isActive" = EXCLUDED."isActive", "updatedAt" = NOW();
+
+INSERT INTO messaging_templates (id, "templateKey", "channel", "language", "subject", "body", "textBody", "placeholders", "isActive", "createdAt", "updatedAt")
+VALUES (
+  gen_random_uuid(), 'pending_activation_d3', 'SMS', 'en', NULL,
+  'Dear {first_name}, your {product_name} cover is still pending activation. Please complete your first premium payment to activate your policy. For help call {general_support_number}.',
+  NULL,
+  ARRAY['first_name', 'product_name', 'general_support_number'],
+  true, NOW(), NOW()
+)
+ON CONFLICT ("templateKey", "channel", "language") DO UPDATE
+SET "body" = EXCLUDED."body", "placeholders" = EXCLUDED."placeholders", "isActive" = EXCLUDED."isActive", "updatedAt" = NOW();
+
+INSERT INTO messaging_routes ("templateKey", "smsEnabled", "emailEnabled", "isActive", "createdAt", "updatedAt")
+VALUES ('pending_activation_d7', true, false, true, NOW(), NOW())
+ON CONFLICT ("templateKey") DO UPDATE
+SET "smsEnabled" = EXCLUDED."smsEnabled", "emailEnabled" = EXCLUDED."emailEnabled", "isActive" = EXCLUDED."isActive", "updatedAt" = NOW();
+
+INSERT INTO messaging_templates (id, "templateKey", "channel", "language", "subject", "body", "textBody", "placeholders", "isActive", "createdAt", "updatedAt")
+VALUES (
+  gen_random_uuid(), 'pending_activation_d7', 'SMS', 'en', NULL,
+  'Dear {first_name}, this is a final reminder that your {product_name} cover is still pending activation. Pay your first premium to activate. For help call {general_support_number}.',
+  NULL,
+  ARRAY['first_name', 'product_name', 'general_support_number'],
+  true, NOW(), NOW()
+)
+ON CONFLICT ("templateKey", "channel", "language") DO UPDATE
+SET "body" = EXCLUDED."body", "placeholders" = EXCLUDED."placeholders", "isActive" = EXCLUDED."isActive", "updatedAt" = NOW();
+
+-- ---------- Grace period reminders ----------
+
+INSERT INTO messaging_routes ("templateKey", "smsEnabled", "emailEnabled", "isActive", "createdAt", "updatedAt")
+VALUES ('grace_due', true, false, true, NOW(), NOW())
+ON CONFLICT ("templateKey") DO UPDATE
+SET "smsEnabled" = EXCLUDED."smsEnabled", "emailEnabled" = EXCLUDED."emailEnabled", "isActive" = EXCLUDED."isActive", "updatedAt" = NOW();
+
+INSERT INTO messaging_templates (id, "templateKey", "channel", "language", "subject", "body", "textBody", "placeholders", "isActive", "createdAt", "updatedAt")
+VALUES (
+  gen_random_uuid(), 'grace_due', 'SMS', 'en', NULL,
+  'Dear {first_name}, your {product_name} premium of {amount_due} was due on {due_date}. Please pay to stay covered. Call {general_support_number} for help.',
+  NULL,
+  ARRAY['first_name', 'product_name', 'amount_due', 'due_date', 'general_support_number'],
+  true, NOW(), NOW()
+)
+ON CONFLICT ("templateKey", "channel", "language") DO UPDATE
+SET "body" = EXCLUDED."body", "placeholders" = EXCLUDED."placeholders", "isActive" = EXCLUDED."isActive", "updatedAt" = NOW();
+
+INSERT INTO messaging_routes ("templateKey", "smsEnabled", "emailEnabled", "isActive", "createdAt", "updatedAt")
+VALUES ('grace_d7', true, false, true, NOW(), NOW())
+ON CONFLICT ("templateKey") DO UPDATE
+SET "smsEnabled" = EXCLUDED."smsEnabled", "emailEnabled" = EXCLUDED."emailEnabled", "isActive" = EXCLUDED."isActive", "updatedAt" = NOW();
+
+INSERT INTO messaging_templates (id, "templateKey", "channel", "language", "subject", "body", "textBody", "placeholders", "isActive", "createdAt", "updatedAt")
+VALUES (
+  gen_random_uuid(), 'grace_d7', 'SMS', 'en', NULL,
+  'Dear {first_name}, your {product_name} premium of {amount_due} is overdue (due {due_date}). Please pay soon to avoid suspension. Call {general_support_number}.',
+  NULL,
+  ARRAY['first_name', 'product_name', 'amount_due', 'due_date', 'general_support_number'],
+  true, NOW(), NOW()
+)
+ON CONFLICT ("templateKey", "channel", "language") DO UPDATE
+SET "body" = EXCLUDED."body", "placeholders" = EXCLUDED."placeholders", "isActive" = EXCLUDED."isActive", "updatedAt" = NOW();
+
+INSERT INTO messaging_routes ("templateKey", "smsEnabled", "emailEnabled", "isActive", "createdAt", "updatedAt")
+VALUES ('grace_d10', true, false, true, NOW(), NOW())
+ON CONFLICT ("templateKey") DO UPDATE
+SET "smsEnabled" = EXCLUDED."smsEnabled", "emailEnabled" = EXCLUDED."emailEnabled", "isActive" = EXCLUDED."isActive", "updatedAt" = NOW();
+
+INSERT INTO messaging_templates (id, "templateKey", "channel", "language", "subject", "body", "textBody", "placeholders", "isActive", "createdAt", "updatedAt")
+VALUES (
+  gen_random_uuid(), 'grace_d10', 'SMS', 'en', NULL,
+  'Dear {first_name}, urgent: your {product_name} premium of {amount_due} (due {due_date}) is still unpaid. Pay now to keep cover. Call {general_support_number}.',
+  NULL,
+  ARRAY['first_name', 'product_name', 'amount_due', 'due_date', 'general_support_number'],
+  true, NOW(), NOW()
+)
+ON CONFLICT ("templateKey", "channel", "language") DO UPDATE
+SET "body" = EXCLUDED."body", "placeholders" = EXCLUDED."placeholders", "isActive" = EXCLUDED."isActive", "updatedAt" = NOW();
+
+INSERT INTO messaging_routes ("templateKey", "smsEnabled", "emailEnabled", "isActive", "createdAt", "updatedAt")
+VALUES ('grace_d13', true, false, true, NOW(), NOW())
+ON CONFLICT ("templateKey") DO UPDATE
+SET "smsEnabled" = EXCLUDED."smsEnabled", "emailEnabled" = EXCLUDED."emailEnabled", "isActive" = EXCLUDED."isActive", "updatedAt" = NOW();
+
+INSERT INTO messaging_templates (id, "templateKey", "channel", "language", "subject", "body", "textBody", "placeholders", "isActive", "createdAt", "updatedAt")
+VALUES (
+  gen_random_uuid(), 'grace_d13', 'SMS', 'en', NULL,
+  'Dear {first_name}, final notice before suspension: pay {amount_due} for {product_name} (due {due_date}) today. Call {general_support_number}.',
+  NULL,
+  ARRAY['first_name', 'product_name', 'amount_due', 'due_date', 'general_support_number'],
+  true, NOW(), NOW()
+)
+ON CONFLICT ("templateKey", "channel", "language") DO UPDATE
+SET "body" = EXCLUDED."body", "placeholders" = EXCLUDED."placeholders", "isActive" = EXCLUDED."isActive", "updatedAt" = NOW();
+
+-- ---------- Suspension / reactivation SMS ----------
+
+INSERT INTO messaging_routes ("templateKey", "smsEnabled", "emailEnabled", "isActive", "createdAt", "updatedAt")
+VALUES ('policy_suspended', true, false, true, NOW(), NOW())
+ON CONFLICT ("templateKey") DO UPDATE
+SET "smsEnabled" = EXCLUDED."smsEnabled", "emailEnabled" = EXCLUDED."emailEnabled", "isActive" = EXCLUDED."isActive", "updatedAt" = NOW();
+
+INSERT INTO messaging_templates (id, "templateKey", "channel", "language", "subject", "body", "textBody", "placeholders", "isActive", "createdAt", "updatedAt")
+VALUES (
+  gen_random_uuid(), 'policy_suspended', 'SMS', 'en', NULL,
+  'Dear {first_name}, your {product_name} policy has been suspended due to unpaid premium of {amount_due}. Pay arrears plus 2 weeks to restore cover. Call {general_support_number}.',
+  NULL,
+  ARRAY['first_name', 'product_name', 'amount_due', 'general_support_number'],
+  true, NOW(), NOW()
+)
+ON CONFLICT ("templateKey", "channel", "language") DO UPDATE
+SET "body" = EXCLUDED."body", "placeholders" = EXCLUDED."placeholders", "isActive" = EXCLUDED."isActive", "updatedAt" = NOW();
+
+INSERT INTO messaging_routes ("templateKey", "smsEnabled", "emailEnabled", "isActive", "createdAt", "updatedAt")
+VALUES ('policy_reactivated', true, false, true, NOW(), NOW())
+ON CONFLICT ("templateKey") DO UPDATE
+SET "smsEnabled" = EXCLUDED."smsEnabled", "emailEnabled" = EXCLUDED."emailEnabled", "isActive" = EXCLUDED."isActive", "updatedAt" = NOW();
+
+INSERT INTO messaging_templates (id, "templateKey", "channel", "language", "subject", "body", "textBody", "placeholders", "isActive", "createdAt", "updatedAt")
+VALUES (
+  gen_random_uuid(), 'policy_reactivated', 'SMS', 'en', NULL,
+  'Dear {first_name}, your {product_name} policy is active again. Thank you for your payment. Call {general_support_number} for help.',
+  NULL,
+  ARRAY['first_name', 'product_name', 'general_support_number'],
+  true, NOW(), NOW()
+)
+ON CONFLICT ("templateKey", "channel", "language") DO UPDATE
+SET "body" = EXCLUDED."body", "placeholders" = EXCLUDED."placeholders", "isActive" = EXCLUDED."isActive", "updatedAt" = NOW();
+
+INSERT INTO messaging_routes ("templateKey", "smsEnabled", "emailEnabled", "isActive", "createdAt", "updatedAt")
+VALUES ('suspend_d1', true, false, true, NOW(), NOW())
+ON CONFLICT ("templateKey") DO UPDATE
+SET "smsEnabled" = EXCLUDED."smsEnabled", "emailEnabled" = EXCLUDED."emailEnabled", "isActive" = EXCLUDED."isActive", "updatedAt" = NOW();
+
+INSERT INTO messaging_templates (id, "templateKey", "channel", "language", "subject", "body", "textBody", "placeholders", "isActive", "createdAt", "updatedAt")
+VALUES (
+  gen_random_uuid(), 'suspend_d1', 'SMS', 'en', NULL,
+  'Dear {first_name}, your {product_name} policy remains suspended. Outstanding amount is {amount_due}. Call {general_support_number}.',
+  NULL,
+  ARRAY['first_name', 'product_name', 'amount_due', 'general_support_number'],
+  true, NOW(), NOW()
+)
+ON CONFLICT ("templateKey", "channel", "language") DO UPDATE
+SET "body" = EXCLUDED."body", "placeholders" = EXCLUDED."placeholders", "isActive" = EXCLUDED."isActive", "updatedAt" = NOW();
+
+INSERT INTO messaging_routes ("templateKey", "smsEnabled", "emailEnabled", "isActive", "createdAt", "updatedAt")
+VALUES ('suspend_d7', true, false, true, NOW(), NOW())
+ON CONFLICT ("templateKey") DO UPDATE
+SET "smsEnabled" = EXCLUDED."smsEnabled", "emailEnabled" = EXCLUDED."emailEnabled", "isActive" = EXCLUDED."isActive", "updatedAt" = NOW();
+
+INSERT INTO messaging_templates (id, "templateKey", "channel", "language", "subject", "body", "textBody", "placeholders", "isActive", "createdAt", "updatedAt")
+VALUES (
+  gen_random_uuid(), 'suspend_d7', 'SMS', 'en', NULL,
+  'Dear {first_name}, reminder: {product_name} is suspended. Pay {amount_due} (arrears + 2 weeks) to restore. Call {general_support_number}.',
+  NULL,
+  ARRAY['first_name', 'product_name', 'amount_due', 'general_support_number'],
+  true, NOW(), NOW()
+)
+ON CONFLICT ("templateKey", "channel", "language") DO UPDATE
+SET "body" = EXCLUDED."body", "placeholders" = EXCLUDED."placeholders", "isActive" = EXCLUDED."isActive", "updatedAt" = NOW();
+
+INSERT INTO messaging_routes ("templateKey", "smsEnabled", "emailEnabled", "isActive", "createdAt", "updatedAt")
+VALUES ('suspend_d13', true, false, true, NOW(), NOW())
+ON CONFLICT ("templateKey") DO UPDATE
+SET "smsEnabled" = EXCLUDED."smsEnabled", "emailEnabled" = EXCLUDED."emailEnabled", "isActive" = EXCLUDED."isActive", "updatedAt" = NOW();
+
+INSERT INTO messaging_templates (id, "templateKey", "channel", "language", "subject", "body", "textBody", "placeholders", "isActive", "createdAt", "updatedAt")
+VALUES (
+  gen_random_uuid(), 'suspend_d13', 'SMS', 'en', NULL,
+  'Dear {first_name}, final notice: {product_name} may become inactive soon. Pay {amount_due} to restore. Call {general_support_number}.',
+  NULL,
+  ARRAY['first_name', 'product_name', 'amount_due', 'general_support_number'],
+  true, NOW(), NOW()
+)
+ON CONFLICT ("templateKey", "channel", "language") DO UPDATE
+SET "body" = EXCLUDED."body", "placeholders" = EXCLUDED."placeholders", "isActive" = EXCLUDED."isActive", "updatedAt" = NOW();
+
+-- ---------- Inactive / renewal SMS ----------
+
+INSERT INTO messaging_routes ("templateKey", "smsEnabled", "emailEnabled", "isActive", "createdAt", "updatedAt")
+VALUES ('policy_inactive', true, false, true, NOW(), NOW())
+ON CONFLICT ("templateKey") DO UPDATE
+SET "smsEnabled" = EXCLUDED."smsEnabled", "emailEnabled" = EXCLUDED."emailEnabled", "isActive" = EXCLUDED."isActive", "updatedAt" = NOW();
+
+INSERT INTO messaging_templates (id, "templateKey", "channel", "language", "subject", "body", "textBody", "placeholders", "isActive", "createdAt", "updatedAt")
+VALUES (
+  gen_random_uuid(), 'policy_inactive', 'SMS', 'en', NULL,
+  'Dear {first_name}, your {product_name} policy is now inactive due to prolonged non-payment. Pay to restore cover. Call {general_support_number}.',
+  NULL,
+  ARRAY['first_name', 'product_name', 'general_support_number'],
+  true, NOW(), NOW()
+)
+ON CONFLICT ("templateKey", "channel", "language") DO UPDATE
+SET "body" = EXCLUDED."body", "placeholders" = EXCLUDED."placeholders", "isActive" = EXCLUDED."isActive", "updatedAt" = NOW();
+
+INSERT INTO messaging_routes ("templateKey", "smsEnabled", "emailEnabled", "isActive", "createdAt", "updatedAt")
+VALUES ('policy_renewed', true, false, true, NOW(), NOW())
+ON CONFLICT ("templateKey") DO UPDATE
+SET "smsEnabled" = EXCLUDED."smsEnabled", "emailEnabled" = EXCLUDED."emailEnabled", "isActive" = EXCLUDED."isActive", "updatedAt" = NOW();
+
+INSERT INTO messaging_templates (id, "templateKey", "channel", "language", "subject", "body", "textBody", "placeholders", "isActive", "createdAt", "updatedAt")
+VALUES (
+  gen_random_uuid(), 'policy_renewed', 'SMS', 'en', NULL,
+  'Dear {first_name}, your {product_name} cover has been renewed. Thank you. Call {general_support_number} for help.',
+  NULL,
+  ARRAY['first_name', 'product_name', 'general_support_number'],
+  true, NOW(), NOW()
+)
+ON CONFLICT ("templateKey", "channel", "language") DO UPDATE
+SET "body" = EXCLUDED."body", "placeholders" = EXCLUDED."placeholders", "isActive" = EXCLUDED."isActive", "updatedAt" = NOW();
+
+-- ---------- Terminate SMS ----------
+
+INSERT INTO messaging_routes ("templateKey", "smsEnabled", "emailEnabled", "isActive", "createdAt", "updatedAt")
+VALUES ('policy_terminated', true, false, true, NOW(), NOW())
+ON CONFLICT ("templateKey") DO UPDATE
+SET "smsEnabled" = EXCLUDED."smsEnabled", "emailEnabled" = EXCLUDED."emailEnabled", "isActive" = EXCLUDED."isActive", "updatedAt" = NOW();
+
+INSERT INTO messaging_templates (id, "templateKey", "channel", "language", "subject", "body", "textBody", "placeholders", "isActive", "createdAt", "updatedAt")
+VALUES (
+  gen_random_uuid(), 'policy_terminated', 'SMS', 'en', NULL,
+  'Dear {first_name}, your {product_name} policy has been terminated. Call {general_support_number} if you have questions.',
+  NULL,
+  ARRAY['first_name', 'product_name', 'general_support_number'],
+  true, NOW(), NOW()
+)
+ON CONFLICT ("templateKey", "channel", "language") DO UPDATE
+SET "body" = EXCLUDED."body", "placeholders" = EXCLUDED."placeholders", "isActive" = EXCLUDED."isActive", "updatedAt" = NOW();
+
+-- ---------- Renewal reminder schedule templates ----------
+
+INSERT INTO messaging_routes ("templateKey", "smsEnabled", "emailEnabled", "isActive", "createdAt", "updatedAt")
+VALUES ('renewal_reminder', true, false, true, NOW(), NOW())
+ON CONFLICT ("templateKey") DO UPDATE
+SET "smsEnabled" = EXCLUDED."smsEnabled", "emailEnabled" = EXCLUDED."emailEnabled", "isActive" = EXCLUDED."isActive", "updatedAt" = NOW();
+
+INSERT INTO messaging_templates (id, "templateKey", "channel", "language", "subject", "body", "textBody", "placeholders", "isActive", "createdAt", "updatedAt")
+VALUES (
+  gen_random_uuid(), 'renewal_reminder', 'SMS', 'en', NULL,
+  'Dear {first_name}, your {product_name} cover {renewal_message}. Call {general_support_number} to renew.',
+  NULL,
+  ARRAY['first_name', 'product_name', 'renewal_message', 'general_support_number'],
+  true, NOW(), NOW()
+)
+ON CONFLICT ("templateKey", "channel", "language") DO UPDATE
+SET "body" = EXCLUDED."body", "placeholders" = EXCLUDED."placeholders", "isActive" = EXCLUDED."isActive", "updatedAt" = NOW();

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -22,6 +22,7 @@ import { MissingRequirementService } from './services/missing-requirement.servic
 import { ProductManagementService } from './services/product-management.service';
 import { PolicyService } from './services/policy.service';
 import { PolicyLifecycleService } from './services/policy-lifecycle.service';
+import { PolicyLifecycleJobService } from './services/policy-lifecycle-job.service';
 import { EntityStatusChangeService } from './services/entity-status-change.service';
 import { UnderwriterService } from './services/underwriter.service';
 import { MpesaPaymentsService } from './services/mpesa-payments.service';
@@ -46,7 +47,7 @@ import { MpesaIpnController } from './controllers/public/mpesa-ipn.controller';
 import { MpesaStkPushController } from './controllers/internal/mpesa-stk-push.controller';
 import { MpesaStkPushPublicController } from './controllers/public/mpesa-stk-push.controller';
 import { RecoveryController } from './controllers/internal/recovery.controller';
-import { PolicyLifecycleController } from './controllers/internal/policy-lifecycle.controller';
+import { PolicyLifecycleController, PolicyLifecycleOpsController } from './controllers/internal/policy-lifecycle.controller';
 import { TestCustomersController } from './controllers/internal/test-customers.controller';
 import { MpesaIpnService } from './services/mpesa-ipn.service';
 import { MpesaStkPushService } from './services/mpesa-stk-push.service';
@@ -79,8 +80,8 @@ import { PaymentStatusGateway } from './gateways/payment-status.gateway';
     MessagingModule,
     CustomerPortalModule,
   ],
-  controllers: [AppController, CustomerController, InternalCustomerController, InternalPartnerManagementController, PublicPartnerManagementController, SupabaseTestController, ConnectionMonitorController, SosController, AgentRegistrationController, BootstrapController, ProductManagementController, PolicyController, PolicyLifecycleController, UnderwriterController, UserController, MpesaPaymentsController, MpesaIpnController, MpesaStkPushController, MpesaStkPushPublicController, RecoveryController, TestCustomersController],
-  providers: [AppService, ExternalIntegrationsService, CustomerService, PartnerManagementService, SupabaseService, SosService, AgentRegistrationService, MissingRequirementService, ProductManagementService, PolicyService, PolicyLifecycleService, EntityStatusChangeService, UnderwriterService, MpesaPaymentsService, PaymentAccountNumberService, SchemeContactService, PostpaidSchemePaymentService, MpesaIpnService, MpesaStkPushService, MpesaDarajaApiService, MpesaErrorMapperService, TestCustomersService, BootstrapUserService, IpWhitelistGuard, RootOnlyGuard, PaymentStatusGateway, PremiumStatementService],
+  controllers: [AppController, CustomerController, InternalCustomerController, InternalPartnerManagementController, PublicPartnerManagementController, SupabaseTestController, ConnectionMonitorController, SosController, AgentRegistrationController, BootstrapController, ProductManagementController, PolicyController, PolicyLifecycleController, PolicyLifecycleOpsController, UnderwriterController, UserController, MpesaPaymentsController, MpesaIpnController, MpesaStkPushController, MpesaStkPushPublicController, RecoveryController, TestCustomersController],
+  providers: [AppService, ExternalIntegrationsService, CustomerService, PartnerManagementService, SupabaseService, SosService, AgentRegistrationService, MissingRequirementService, ProductManagementService, PolicyService, PolicyLifecycleService, PolicyLifecycleJobService, EntityStatusChangeService, UnderwriterService, MpesaPaymentsService, PaymentAccountNumberService, SchemeContactService, PostpaidSchemePaymentService, MpesaIpnService, MpesaStkPushService, MpesaDarajaApiService, MpesaErrorMapperService, TestCustomersService, BootstrapUserService, IpWhitelistGuard, RootOnlyGuard, PaymentStatusGateway, PremiumStatementService],
   exports: [PrismaModule], // Export PrismaModule so middleware can access PrismaService
 })
 export class AppModule implements NestModule {

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -21,6 +21,8 @@ import { AgentRegistrationService } from './services/agent-registration.service'
 import { MissingRequirementService } from './services/missing-requirement.service';
 import { ProductManagementService } from './services/product-management.service';
 import { PolicyService } from './services/policy.service';
+import { PolicyLifecycleService } from './services/policy-lifecycle.service';
+import { EntityStatusChangeService } from './services/entity-status-change.service';
 import { UnderwriterService } from './services/underwriter.service';
 import { MpesaPaymentsService } from './services/mpesa-payments.service';
 import { PaymentAccountNumberService } from './services/payment-account-number.service';
@@ -44,6 +46,7 @@ import { MpesaIpnController } from './controllers/public/mpesa-ipn.controller';
 import { MpesaStkPushController } from './controllers/internal/mpesa-stk-push.controller';
 import { MpesaStkPushPublicController } from './controllers/public/mpesa-stk-push.controller';
 import { RecoveryController } from './controllers/internal/recovery.controller';
+import { PolicyLifecycleController } from './controllers/internal/policy-lifecycle.controller';
 import { TestCustomersController } from './controllers/internal/test-customers.controller';
 import { MpesaIpnService } from './services/mpesa-ipn.service';
 import { MpesaStkPushService } from './services/mpesa-stk-push.service';
@@ -76,8 +79,8 @@ import { PaymentStatusGateway } from './gateways/payment-status.gateway';
     MessagingModule,
     CustomerPortalModule,
   ],
-  controllers: [AppController, CustomerController, InternalCustomerController, InternalPartnerManagementController, PublicPartnerManagementController, SupabaseTestController, ConnectionMonitorController, SosController, AgentRegistrationController, BootstrapController, ProductManagementController, PolicyController, UnderwriterController, UserController, MpesaPaymentsController, MpesaIpnController, MpesaStkPushController, MpesaStkPushPublicController, RecoveryController, TestCustomersController],
-  providers: [AppService, ExternalIntegrationsService, CustomerService, PartnerManagementService, SupabaseService, SosService, AgentRegistrationService, MissingRequirementService, ProductManagementService, PolicyService, UnderwriterService, MpesaPaymentsService, PaymentAccountNumberService, SchemeContactService, PostpaidSchemePaymentService, MpesaIpnService, MpesaStkPushService, MpesaDarajaApiService, MpesaErrorMapperService, TestCustomersService, BootstrapUserService, IpWhitelistGuard, RootOnlyGuard, PaymentStatusGateway, PremiumStatementService],
+  controllers: [AppController, CustomerController, InternalCustomerController, InternalPartnerManagementController, PublicPartnerManagementController, SupabaseTestController, ConnectionMonitorController, SosController, AgentRegistrationController, BootstrapController, ProductManagementController, PolicyController, PolicyLifecycleController, UnderwriterController, UserController, MpesaPaymentsController, MpesaIpnController, MpesaStkPushController, MpesaStkPushPublicController, RecoveryController, TestCustomersController],
+  providers: [AppService, ExternalIntegrationsService, CustomerService, PartnerManagementService, SupabaseService, SosService, AgentRegistrationService, MissingRequirementService, ProductManagementService, PolicyService, PolicyLifecycleService, EntityStatusChangeService, UnderwriterService, MpesaPaymentsService, PaymentAccountNumberService, SchemeContactService, PostpaidSchemePaymentService, MpesaIpnService, MpesaStkPushService, MpesaDarajaApiService, MpesaErrorMapperService, TestCustomersService, BootstrapUserService, IpWhitelistGuard, RootOnlyGuard, PaymentStatusGateway, PremiumStatementService],
   exports: [PrismaModule], // Export PrismaModule so middleware can access PrismaService
 })
 export class AppModule implements NestModule {

--- a/apps/api/src/controllers/internal/policy-lifecycle.controller.ts
+++ b/apps/api/src/controllers/internal/policy-lifecycle.controller.ts
@@ -18,20 +18,26 @@ import {
 import { Request } from 'express';
 import { CorrelationId } from '../../decorators/correlation-id.decorator';
 import { PolicyLifecycleService } from '../../services/policy-lifecycle.service';
+import { PolicyLifecycleJobService } from '../../services/policy-lifecycle-job.service';
 import {
   ActivatePolicyRequestDto,
+  DailyLifecycleRunResponseDto,
   DeactivatePolicyRequestDto,
   ModifyPolicyOptionsResponseDto,
   ModifyPolicyRequestDto,
   PolicyLifecycleResponseDto,
   ResetPolicyStartDateRequestDto,
+  TerminatePolicyRequestDto,
 } from '../../dto/policy-lifecycle/policy-lifecycle.dto';
 
 @ApiTags('Internal - Policy Lifecycle')
 @ApiBearerAuth()
 @Controller('internal/customers')
 export class PolicyLifecycleController {
-  constructor(private readonly policyLifecycleService: PolicyLifecycleService) {}
+  constructor(
+    private readonly policyLifecycleService: PolicyLifecycleService,
+    private readonly policyLifecycleJobService: PolicyLifecycleJobService
+  ) {}
 
   @Post(':customerId/policies/:policyId/deactivate')
   @HttpCode(HttpStatus.OK)
@@ -49,6 +55,31 @@ export class PolicyLifecycleController {
     const userId = req.user?.id ?? 'system';
     const userRoles = req.user?.roles ?? [];
     return this.policyLifecycleService.deactivatePolicy(
+      customerId,
+      policyId,
+      body,
+      userId,
+      userRoles,
+      correlationId
+    );
+  }
+
+  @Post(':customerId/policies/:policyId/terminate')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Terminate policy (admin; starter blacklist)' })
+  @ApiParam({ name: 'customerId' })
+  @ApiParam({ name: 'policyId' })
+  @ApiResponse({ status: 200, type: PolicyLifecycleResponseDto })
+  async terminatePolicy(
+    @Param('customerId') customerId: string,
+    @Param('policyId') policyId: string,
+    @Body() body: TerminatePolicyRequestDto,
+    @CorrelationId() correlationId: string,
+    @Req() req: Request
+  ): Promise<PolicyLifecycleResponseDto> {
+    const userId = req.user?.id ?? 'system';
+    const userRoles = req.user?.roles ?? [];
+    return this.policyLifecycleService.terminatePolicy(
       customerId,
       policyId,
       body,
@@ -152,5 +183,28 @@ export class PolicyLifecycleController {
       userRoles,
       correlationId
     );
+  }
+}
+
+@ApiTags('Internal - Policy Lifecycle')
+@ApiBearerAuth()
+@Controller('internal/policies/lifecycle')
+export class PolicyLifecycleOpsController {
+  constructor(
+    private readonly policyLifecycleService: PolicyLifecycleService,
+    private readonly policyLifecycleJobService: PolicyLifecycleJobService
+  ) {}
+
+  @Post('run-daily')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Run daily policy lifecycle evaluation once (admin/ops)' })
+  @ApiResponse({ status: 200, type: DailyLifecycleRunResponseDto })
+  async runDaily(
+    @CorrelationId() correlationId: string,
+    @Req() req: Request
+  ): Promise<DailyLifecycleRunResponseDto> {
+    const userRoles = req.user?.roles ?? [];
+    this.policyLifecycleService.assertAdmin(userRoles);
+    return this.policyLifecycleJobService.runDaily(correlationId);
   }
 }

--- a/apps/api/src/controllers/internal/policy-lifecycle.controller.ts
+++ b/apps/api/src/controllers/internal/policy-lifecycle.controller.ts
@@ -1,0 +1,156 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Post,
+  Req,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { Request } from 'express';
+import { CorrelationId } from '../../decorators/correlation-id.decorator';
+import { PolicyLifecycleService } from '../../services/policy-lifecycle.service';
+import {
+  ActivatePolicyRequestDto,
+  DeactivatePolicyRequestDto,
+  ModifyPolicyOptionsResponseDto,
+  ModifyPolicyRequestDto,
+  PolicyLifecycleResponseDto,
+  ResetPolicyStartDateRequestDto,
+} from '../../dto/policy-lifecycle/policy-lifecycle.dto';
+
+@ApiTags('Internal - Policy Lifecycle')
+@ApiBearerAuth()
+@Controller('internal/customers')
+export class PolicyLifecycleController {
+  constructor(private readonly policyLifecycleService: PolicyLifecycleService) {}
+
+  @Post(':customerId/policies/:policyId/deactivate')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Deactivate policy (admin)' })
+  @ApiParam({ name: 'customerId' })
+  @ApiParam({ name: 'policyId' })
+  @ApiResponse({ status: 200, type: PolicyLifecycleResponseDto })
+  async deactivatePolicy(
+    @Param('customerId') customerId: string,
+    @Param('policyId') policyId: string,
+    @Body() body: DeactivatePolicyRequestDto,
+    @CorrelationId() correlationId: string,
+    @Req() req: Request
+  ): Promise<PolicyLifecycleResponseDto> {
+    const userId = req.user?.id ?? 'system';
+    const userRoles = req.user?.roles ?? [];
+    return this.policyLifecycleService.deactivatePolicy(
+      customerId,
+      policyId,
+      body,
+      userId,
+      userRoles,
+      correlationId
+    );
+  }
+
+  @Post(':customerId/policies/:policyId/activate')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Activate suspended policy (admin)' })
+  @ApiParam({ name: 'customerId' })
+  @ApiParam({ name: 'policyId' })
+  @ApiResponse({ status: 200, type: PolicyLifecycleResponseDto })
+  async activatePolicy(
+    @Param('customerId') customerId: string,
+    @Param('policyId') policyId: string,
+    @Body() body: ActivatePolicyRequestDto,
+    @CorrelationId() correlationId: string,
+    @Req() req: Request
+  ): Promise<PolicyLifecycleResponseDto> {
+    const userId = req.user?.id ?? 'system';
+    const userRoles = req.user?.roles ?? [];
+    return this.policyLifecycleService.activatePolicy(
+      customerId,
+      policyId,
+      body,
+      userId,
+      userRoles,
+      correlationId
+    );
+  }
+
+  @Post(':customerId/policies/:policyId/reset-start-date')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Reset policy start/end dates (admin)' })
+  @ApiParam({ name: 'customerId' })
+  @ApiParam({ name: 'policyId' })
+  @ApiResponse({ status: 200, type: PolicyLifecycleResponseDto })
+  async resetStartDate(
+    @Param('customerId') customerId: string,
+    @Param('policyId') policyId: string,
+    @Body() body: ResetPolicyStartDateRequestDto,
+    @CorrelationId() correlationId: string,
+    @Req() req: Request
+  ): Promise<PolicyLifecycleResponseDto> {
+    const userId = req.user?.id ?? 'system';
+    const userRoles = req.user?.roles ?? [];
+    return this.policyLifecycleService.resetPolicyStartDate(
+      customerId,
+      policyId,
+      body,
+      userId,
+      userRoles,
+      correlationId
+    );
+  }
+
+  @Get(':customerId/policies/:policyId/modify-options')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Get modify-product options (admin)' })
+  @ApiParam({ name: 'customerId' })
+  @ApiParam({ name: 'policyId' })
+  @ApiResponse({ status: 200, type: ModifyPolicyOptionsResponseDto })
+  async getModifyOptions(
+    @Param('customerId') customerId: string,
+    @Param('policyId') policyId: string,
+    @CorrelationId() correlationId: string,
+    @Req() req: Request
+  ): Promise<ModifyPolicyOptionsResponseDto> {
+    const userRoles = req.user?.roles ?? [];
+    return this.policyLifecycleService.getModifyOptions(
+      customerId,
+      policyId,
+      userRoles,
+      correlationId
+    );
+  }
+
+  @Post(':customerId/policies/:policyId/modify')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Modify product — deactivate and recreate policy (admin)' })
+  @ApiParam({ name: 'customerId' })
+  @ApiParam({ name: 'policyId' })
+  @ApiResponse({ status: 200, type: PolicyLifecycleResponseDto })
+  async modifyPolicy(
+    @Param('customerId') customerId: string,
+    @Param('policyId') policyId: string,
+    @Body() body: ModifyPolicyRequestDto,
+    @CorrelationId() correlationId: string,
+    @Req() req: Request
+  ): Promise<PolicyLifecycleResponseDto> {
+    const userId = req.user?.id ?? 'system';
+    const userRoles = req.user?.roles ?? [];
+    return this.policyLifecycleService.modifyPolicy(
+      customerId,
+      policyId,
+      body,
+      userId,
+      userRoles,
+      correlationId
+    );
+  }
+}

--- a/apps/api/src/dto/customers/customer-payments-filter.dto.ts
+++ b/apps/api/src/dto/customers/customer-payments-filter.dto.ts
@@ -106,6 +106,41 @@ export class PolicyOptionDto {
   @IsOptional()
   @IsString()
   planName?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  status?: string;
+
+  @ApiProperty({ required: false, nullable: true })
+  @IsOptional()
+  policyNumber?: string | null;
+
+  @ApiProperty({ required: false, nullable: true })
+  @IsOptional()
+  startDate?: string | null;
+
+  @ApiProperty({ required: false, nullable: true })
+  @IsOptional()
+  endDate?: string | null;
+
+  @ApiProperty({ required: false, nullable: true })
+  @IsOptional()
+  deactivatedAt?: string | null;
+}
+
+export class PaymentPolicySummaryDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty({ nullable: true })
+  policyNumber: string | null;
+
+  @ApiProperty()
+  status: string;
+
+  @ApiProperty()
+  displayText: string;
 }
 
 export class PaymentDto {
@@ -167,6 +202,14 @@ export class PaymentDto {
   @IsOptional()
   @IsEnum(PaymentStatus)
   paymentStatus?: PaymentStatus;
+
+  @ApiProperty({
+    description: 'Policy summary when listing all policies (no policyId filter)',
+    type: PaymentPolicySummaryDto,
+    required: false,
+  })
+  @IsOptional()
+  policy?: PaymentPolicySummaryDto;
 }
 
 export class CustomerPaymentsResponseDto {

--- a/apps/api/src/dto/customers/member-cards.dto.ts
+++ b/apps/api/src/dto/customers/member-cards.dto.ts
@@ -30,6 +30,9 @@ export class MemberCardsByPolicyItemDto {
   @ApiProperty({ description: 'Policy number', nullable: true })
   policyNumber: string | null;
 
+  @ApiProperty({ description: 'Policy status' })
+  policyStatus: string;
+
   @ApiProperty({ description: 'Package id' })
   packageId: number;
 

--- a/apps/api/src/dto/policy-lifecycle/policy-lifecycle.dto.ts
+++ b/apps/api/src/dto/policy-lifecycle/policy-lifecycle.dto.ts
@@ -24,6 +24,8 @@ export class DeactivatePolicyRequestDto extends PolicyLifecycleReasonDto {}
 
 export class ActivatePolicyRequestDto extends PolicyLifecycleReasonDto {}
 
+export class TerminatePolicyRequestDto extends PolicyLifecycleReasonDto {}
+
 export class ResetPolicyStartDateRequestDto extends PolicyLifecycleReasonDto {
   @ApiProperty({ description: 'New policy start date (ISO 8601)', example: '2026-02-15T00:00:00.000Z' })
   @IsString()
@@ -180,4 +182,33 @@ export class ModifyPolicyOptionsResponseDto {
 
   @ApiProperty({ type: [ModifyPolicyOptionsSchemeDto] })
   schemes: ModifyPolicyOptionsSchemeDto[];
+}
+
+export class DailyLifecycleRunResponseDto {
+  @ApiProperty()
+  evaluatedAt: string;
+
+  @ApiProperty()
+  graceEntered: number;
+
+  @ApiProperty()
+  graceCleared: number;
+
+  @ApiProperty()
+  suspended: number;
+
+  @ApiProperty()
+  inactivated: number;
+
+  @ApiProperty()
+  expired: number;
+
+  @ApiProperty()
+  notificationsQueued: number;
+
+  @ApiProperty()
+  correlationId: string;
+
+  @ApiPropertyOptional()
+  durationMs?: number;
 }

--- a/apps/api/src/dto/policy-lifecycle/policy-lifecycle.dto.ts
+++ b/apps/api/src/dto/policy-lifecycle/policy-lifecycle.dto.ts
@@ -116,6 +116,9 @@ export class ModifyPolicyOptionsPaymentDto {
 
   @ApiPropertyOptional()
   actualPaymentDate?: string;
+
+  @ApiProperty({ description: 'COMPLETED or COMPLETED_PENDING_RECEIPT' })
+  paymentStatus: string;
 }
 
 export class ModifyPolicyOptionsSchemeDto {

--- a/apps/api/src/dto/policy-lifecycle/policy-lifecycle.dto.ts
+++ b/apps/api/src/dto/policy-lifecycle/policy-lifecycle.dto.ts
@@ -1,0 +1,180 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsString,
+  IsNotEmpty,
+  MaxLength,
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsNumber,
+  Min,
+  ValidateIf,
+} from 'class-validator';
+import { PaymentFrequency, PolicyStatus } from '@prisma/client';
+
+export class PolicyLifecycleReasonDto {
+  @ApiProperty({ description: 'Mandatory reason for the status change', maxLength: 1000 })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(1000)
+  reason: string;
+}
+
+export class DeactivatePolicyRequestDto extends PolicyLifecycleReasonDto {}
+
+export class ActivatePolicyRequestDto extends PolicyLifecycleReasonDto {}
+
+export class ResetPolicyStartDateRequestDto extends PolicyLifecycleReasonDto {
+  @ApiProperty({ description: 'New policy start date (ISO 8601)', example: '2026-02-15T00:00:00.000Z' })
+  @IsString()
+  @IsNotEmpty()
+  startDate: string;
+}
+
+export enum PolicyNumberChoice {
+  KEEP_EXISTING = 'KEEP_EXISTING',
+  GENERATE_NEW = 'GENERATE_NEW',
+}
+
+export class ModifyPolicyRequestDto extends PolicyLifecycleReasonDto {
+  @ApiProperty({ example: 2 })
+  @IsInt()
+  packagePlanId: number;
+
+  @ApiProperty({ enum: PaymentFrequency })
+  @IsEnum(PaymentFrequency)
+  frequency: PaymentFrequency;
+
+  @ApiProperty({ description: 'Installment amount (KES) from insurance-pricing.json' })
+  @IsNumber()
+  @Min(0)
+  premium: number;
+
+  @ApiPropertyOptional({ description: 'Required when frequency is CUSTOM' })
+  @ValidateIf((o) => o.frequency === PaymentFrequency.CUSTOM)
+  @IsInt()
+  @Min(1)
+  customDays?: number;
+
+  @ApiPropertyOptional({ description: 'New package scheme id (same package)' })
+  @IsOptional()
+  @IsInt()
+  packageSchemeId?: number;
+
+  @ApiProperty({ enum: PolicyNumberChoice })
+  @IsEnum(PolicyNumberChoice)
+  policyNumberChoice: PolicyNumberChoice;
+
+  @ApiPropertyOptional({
+    description: 'First completed payment to migrate (required when source has completed prepaid payments)',
+  })
+  @IsOptional()
+  @IsInt()
+  firstPaymentId?: number;
+}
+
+export class PolicyLifecyclePolicyDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiPropertyOptional()
+  policyNumber?: string | null;
+
+  @ApiProperty({ enum: PolicyStatus })
+  status: PolicyStatus;
+}
+
+export class PolicyLifecycleResponseDto {
+  @ApiProperty({ example: 200 })
+  status: number;
+
+  @ApiProperty()
+  correlationId: string;
+
+  @ApiProperty()
+  message: string;
+
+  @ApiProperty({ type: PolicyLifecyclePolicyDto })
+  policy: PolicyLifecyclePolicyDto;
+
+  @ApiPropertyOptional({ description: 'Set after modify — select this policy in Payments tab' })
+  newPolicyId?: string;
+}
+
+export class ModifyPolicyOptionsPaymentDto {
+  @ApiProperty()
+  id: number;
+
+  @ApiProperty()
+  transactionReference: string;
+
+  @ApiProperty()
+  amount: number;
+
+  @ApiProperty()
+  expectedPaymentDate: string;
+
+  @ApiPropertyOptional()
+  actualPaymentDate?: string;
+}
+
+export class ModifyPolicyOptionsSchemeDto {
+  @ApiProperty()
+  packageSchemeId: number;
+
+  @ApiProperty()
+  schemeName: string;
+
+  @ApiProperty()
+  isPostpaid: boolean;
+}
+
+export class ModifyPolicyOptionsResponseDto {
+  @ApiProperty({ example: 200 })
+  status: number;
+
+  @ApiProperty()
+  correlationId: string;
+
+  @ApiProperty()
+  message: string;
+
+  @ApiProperty()
+  packageId: number;
+
+  @ApiProperty()
+  packageName: string;
+
+  @ApiProperty()
+  familyCategory: string;
+
+  @ApiProperty()
+  additionalSpouse: boolean;
+
+  @ApiProperty()
+  currentPackagePlanId: number;
+
+  @ApiPropertyOptional()
+  currentPlanName?: string;
+
+  @ApiProperty()
+  currentPremium: number;
+
+  @ApiProperty({ enum: PaymentFrequency })
+  currentFrequency: PaymentFrequency;
+
+  @ApiProperty()
+  currentPaymentCadence: number;
+
+  @ApiPropertyOptional({ nullable: true })
+  currentPackageSchemeId: number | null;
+
+  @ApiProperty()
+  paymentMigrationAllowed: boolean;
+
+  @ApiProperty({ type: [ModifyPolicyOptionsPaymentDto] })
+  eligiblePayments: ModifyPolicyOptionsPaymentDto[];
+
+  @ApiProperty({ type: [ModifyPolicyOptionsSchemeDto] })
+  schemes: ModifyPolicyOptionsSchemeDto[];
+}

--- a/apps/api/src/mappers/customer.mapper.ts
+++ b/apps/api/src/mappers/customer.mapper.ts
@@ -174,6 +174,8 @@ export class CustomerMapper {
         return 'active';
       case CustomerStatus.SUSPENDED:
         return 'suspended';
+      case CustomerStatus.DEACTIVATED:
+        return 'deactivated';
       case CustomerStatus.TERMINATED:
         return 'terminated';
       case CustomerStatus.DELETED:

--- a/apps/api/src/modules/messaging/messaging.module.ts
+++ b/apps/api/src/modules/messaging/messaging.module.ts
@@ -4,6 +4,7 @@ import { SupabaseService } from '../../services/supabase.service';
 import { MessagingService } from './messaging.service';
 import { MessagingWorker } from './messaging.worker';
 import { PaymentMessagingService } from './payment-messaging.service';
+import { PolicyLifecycleMessagingService } from './policy-lifecycle-messaging.service';
 import { MessagingOutboxRepository } from './messaging-outbox.repository';
 import { SystemSettingsService } from './settings/system-settings.service';
 import { TemplateResolverService } from './rendering/template-resolver.service';
@@ -28,6 +29,7 @@ import { AfricasTalkingWebhookController } from '../../controllers/webhooks/mess
     MessagingService,
     MessagingWorker,
     PaymentMessagingService,
+    PolicyLifecycleMessagingService,
     MessagingOutboxRepository,
     SystemSettingsService,
     MessagingTemplatesService,
@@ -42,7 +44,7 @@ import { AfricasTalkingWebhookController } from '../../controllers/webhooks/mess
     AttachmentGeneratorService,
     AttachmentRetentionCleanupService,
   ],
-  exports: [MessagingService, SystemSettingsService, PaymentMessagingService],
+  exports: [MessagingService, SystemSettingsService, PaymentMessagingService, PolicyLifecycleMessagingService],
 })
 export class MessagingModule {}
 

--- a/apps/api/src/modules/messaging/policy-lifecycle-messaging.service.ts
+++ b/apps/api/src/modules/messaging/policy-lifecycle-messaging.service.ts
@@ -1,0 +1,205 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import { MessagingService } from './messaging.service';
+import { SystemSettingsService } from './settings/system-settings.service';
+import { formatSmsAmount, formatSmsDate } from '../../utils/sms-format.util';
+
+export const PENDING_ACTIVATION_SCHEDULE = {
+  D3: 'PENDING_D3',
+  D7: 'PENDING_D7',
+} as const;
+
+export const PENDING_ACTIVATION_TEMPLATE = {
+  D3: 'pending_activation_d3',
+  D7: 'pending_activation_d7',
+} as const;
+
+export const GRACE_SCHEDULE = {
+  DUE: 'GRACE_DUE',
+  D7: 'GRACE_D7',
+  D10: 'GRACE_D10',
+  D13: 'GRACE_D13',
+} as const;
+
+export const GRACE_TEMPLATE = {
+  DUE: 'grace_due',
+  D7: 'grace_d7',
+  D10: 'grace_d10',
+  D13: 'grace_d13',
+} as const;
+
+export const SUSPEND_SCHEDULE = {
+  D1: 'SUSPEND_D1',
+  D7: 'SUSPEND_D7',
+  D13: 'SUSPEND_D13',
+} as const;
+
+export const SUSPEND_TEMPLATE = {
+  NOTICE: 'policy_suspended',
+  D1: 'suspend_d1',
+  D7: 'suspend_d7',
+  D13: 'suspend_d13',
+  REACTIVATE: 'policy_reactivated',
+} as const;
+
+export type PendingActivationScheduleKey =
+  (typeof PENDING_ACTIVATION_SCHEDULE)[keyof typeof PENDING_ACTIVATION_SCHEDULE];
+
+export interface EnqueueLifecycleNotificationParams {
+  policyId: string;
+  customerId: string;
+  scheduleKey: string;
+  templateKey: string;
+  placeholderValues: Record<string, string>;
+  correlationId: string;
+  metadata?: Prisma.InputJsonValue;
+}
+
+/**
+ * Lifecycle SMS with PolicyLifecycleNotification ledger dedupe.
+ * Insert ledger row before enqueue; unique (policyId, scheduleKey) = already sent/suppressed.
+ */
+@Injectable()
+export class PolicyLifecycleMessagingService {
+  private readonly logger = new Logger(PolicyLifecycleMessagingService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly messagingService: MessagingService,
+    private readonly systemSettings: SystemSettingsService
+  ) {}
+
+  /**
+   * Fire-and-forget wrapper for lifecycle notifications.
+   */
+  enqueueLifecycleNotificationAsync(params: EnqueueLifecycleNotificationParams): void {
+    this.enqueueLifecycleNotification(params).catch((error) => {
+      this.logger.warn(
+        `[${params.correlationId}] Failed lifecycle SMS scheduleKey=${params.scheduleKey} policy=${params.policyId}: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    });
+  }
+
+  /**
+   * Insert ledger then enqueue. Returns false if scheduleKey already recorded (idempotent).
+   */
+  async enqueueLifecycleNotification(
+    params: EnqueueLifecycleNotificationParams
+  ): Promise<boolean> {
+    try {
+      await this.prisma.policyLifecycleNotification.create({
+        data: {
+          policyId: params.policyId,
+          scheduleKey: params.scheduleKey,
+          templateKey: params.templateKey,
+          metadata: params.metadata ?? Prisma.JsonNull,
+        },
+      });
+    } catch (error) {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === 'P2002'
+      ) {
+        this.logger.debug(
+          `[${params.correlationId}] Lifecycle SMS already recorded policy=${params.policyId} key=${params.scheduleKey}`
+        );
+        return false;
+      }
+      throw error;
+    }
+
+    await this.messagingService.enqueue({
+      templateKey: params.templateKey,
+      customerId: params.customerId,
+      policyId: params.policyId,
+      placeholderValues: params.placeholderValues,
+      correlationId: params.correlationId,
+    });
+
+    this.logger.log(
+      `[${params.correlationId}] Enqueued lifecycle SMS ${params.templateKey} for policy ${params.policyId}`
+    );
+    return true;
+  }
+
+  /**
+   * Mark PENDING_D3 / PENDING_D7 as suppressed without sending SMS so daily eval skips them.
+   */
+  async suppressPendingActivationReminders(
+    policyId: string,
+    correlationId: string,
+    tx?: Prisma.TransactionClient
+  ): Promise<void> {
+    const client = tx ?? this.prisma;
+    const keys: Array<{ scheduleKey: string; templateKey: string }> = [
+      {
+        scheduleKey: PENDING_ACTIVATION_SCHEDULE.D3,
+        templateKey: PENDING_ACTIVATION_TEMPLATE.D3,
+      },
+      {
+        scheduleKey: PENDING_ACTIVATION_SCHEDULE.D7,
+        templateKey: PENDING_ACTIVATION_TEMPLATE.D7,
+      },
+    ];
+
+    for (const row of keys) {
+      try {
+        await client.policyLifecycleNotification.create({
+          data: {
+            policyId,
+            scheduleKey: row.scheduleKey,
+            templateKey: row.templateKey,
+            metadata: {
+              suppressed: true,
+              reason: 'activated',
+              correlationId,
+            },
+          },
+        });
+      } catch (error) {
+        if (
+          error instanceof Prisma.PrismaClientKnownRequestError &&
+          error.code === 'P2002'
+        ) {
+          continue;
+        }
+        throw error;
+      }
+    }
+
+    this.logger.log(
+      `[${correlationId}] Suppressed pending-activation reminders for policy ${policyId}`
+    );
+  }
+
+  async buildPendingReminderPlaceholders(params: {
+    firstName: string;
+    productName: string;
+  }): Promise<Record<string, string>> {
+    const settings = await this.systemSettings.getSnapshot();
+    return {
+      first_name: params.firstName,
+      product_name: params.productName,
+      general_support_number: settings.general_support_number ?? '',
+    };
+  }
+
+  async buildGraceReminderPlaceholders(params: {
+    firstName: string;
+    productName: string;
+    arrears: number;
+    dueDate: Date;
+  }): Promise<Record<string, string>> {
+    const settings = await this.systemSettings.getSnapshot();
+    return {
+      first_name: params.firstName,
+      product_name: params.productName,
+      amount_due: formatSmsAmount(params.arrears, settings.defaultSystemCurrency),
+      due_date: formatSmsDate(params.dueDate),
+      general_support_number: settings.general_support_number ?? '',
+    };
+  }
+}

--- a/apps/api/src/services/__tests__/mpesa-ipn.service.spec.ts
+++ b/apps/api/src/services/__tests__/mpesa-ipn.service.spec.ts
@@ -3,6 +3,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { MpesaIpnService } from '../mpesa-ipn.service';
 import { PrismaService } from '../../prisma/prisma.service';
 import { PolicyService } from '../policy.service';
+import { PolicyLifecycleService } from '../policy-lifecycle.service';
 import { PaymentMessagingService } from '../../modules/messaging/payment-messaging.service';
 import { MpesaIpnPayloadDto } from '../../dto/mpesa-ipn/mpesa-ipn.dto';
 import { MpesaPaymentSource, MpesaStkPushStatus, MpesaStatementReasonType } from '@prisma/client';
@@ -53,10 +54,15 @@ describe('MpesaIpnService', () => {
     tryEnqueueUnmatchedPaymentSms: jest.fn(),
   });
 
+  const createPolicyLifecycleServiceMock = () => ({
+    applyPaymentToPolicyLifecycle: jest.fn().mockResolvedValue({ action: 'noop' }),
+  });
+
   beforeEach(async () => {
     const prismaMock = createPrismaMock();
     const policyServiceMock = createPolicyServiceMock();
     const paymentMessagingServiceMock = createPaymentMessagingServiceMock();
+    const policyLifecycleServiceMock = createPolicyLifecycleServiceMock();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -72,6 +78,10 @@ describe('MpesaIpnService', () => {
         {
           provide: PaymentMessagingService,
           useValue: paymentMessagingServiceMock,
+        },
+        {
+          provide: PolicyLifecycleService,
+          useValue: policyLifecycleServiceMock,
         },
       ],
     })

--- a/apps/api/src/services/__tests__/mpesa-stk-push.service.spec.ts
+++ b/apps/api/src/services/__tests__/mpesa-stk-push.service.spec.ts
@@ -7,6 +7,7 @@ import { MpesaDarajaApiService } from '../mpesa-daraja-api.service';
 import { MpesaErrorMapperService } from '../mpesa-error-mapper.service';
 import { ConfigurationService } from '../../config/configuration.service';
 import { PolicyService } from '../policy.service';
+import { PolicyLifecycleService } from '../policy-lifecycle.service';
 import { SchedulerRegistry } from '@nestjs/schedule';
 import {
   InitiateStkPushDto,
@@ -118,6 +119,9 @@ describe('MpesaStkPushService', () => {
     const paymentStatusGatewayMock = createPaymentStatusGatewayMock();
     const jwtServiceMock = createJwtServiceMock();
     const paymentMessagingServiceMock = createPaymentMessagingServiceMock();
+    const policyLifecycleServiceMock = {
+      applyPaymentToPolicyLifecycle: jest.fn().mockResolvedValue({ action: 'noop' }),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -153,6 +157,10 @@ describe('MpesaStkPushService', () => {
         {
           provide: PaymentMessagingService,
           useValue: paymentMessagingServiceMock,
+        },
+        {
+          provide: PolicyLifecycleService,
+          useValue: policyLifecycleServiceMock,
         },
         {
           provide: SchedulerRegistry,

--- a/apps/api/src/services/__tests__/policy-lifecycle.service.spec.ts
+++ b/apps/api/src/services/__tests__/policy-lifecycle.service.spec.ts
@@ -1,0 +1,43 @@
+/// <reference types="jest" />
+import { PolicyStatus, CustomerStatus } from '@prisma/client';
+import { isPolicyEndDatePassed } from '../../utils/policy-due-date.util';
+import { assertPolicyMayBecomeActive } from '../../utils/policy-activation-gate.util';
+import { ValidationException } from '../../exceptions/validation.exception';
+
+describe('policy lifecycle gates (US3/US5 helpers)', () => {
+  it('blocks Active after end date', () => {
+    const end = new Date(Date.UTC(2026, 0, 1));
+    expect(isPolicyEndDatePassed(end, new Date(Date.UTC(2026, 0, 2)))).toBe(true);
+    expect(() =>
+      assertPolicyMayBecomeActive({ status: PolicyStatus.SUSPENDED, endDate: end })
+    ).toThrow(ValidationException);
+  });
+
+  it('blocks terminal statuses from becoming Active', () => {
+    expect(() =>
+      assertPolicyMayBecomeActive({
+        status: PolicyStatus.TERMINATED,
+        endDate: null,
+      })
+    ).toThrow(ValidationException);
+    expect(() =>
+      assertPolicyMayBecomeActive({
+        status: PolicyStatus.EXPIRED,
+        endDate: null,
+      })
+    ).toThrow(ValidationException);
+  });
+
+  it('documents Option C open statuses for customer Terminated coupling', () => {
+    const open: PolicyStatus[] = [
+      PolicyStatus.ACTIVE,
+      PolicyStatus.PENDING_ACTIVATION,
+      PolicyStatus.SUSPENDED,
+    ];
+    const remaining = [PolicyStatus.INACTIVE, PolicyStatus.EXPIRED];
+    const hasOpen = remaining.some((s) => open.includes(s));
+    expect(hasOpen).toBe(false);
+    // When no open remain after terminate → customer TERMINATED
+    expect(CustomerStatus.TERMINATED).toBe('TERMINATED');
+  });
+});

--- a/apps/api/src/services/__tests__/policy.service.spec.ts
+++ b/apps/api/src/services/__tests__/policy.service.spec.ts
@@ -3,6 +3,7 @@ import { PolicyService } from '../policy.service';
 import { PrismaService } from '../../prisma/prisma.service';
 import { PaymentAccountNumberService } from '../payment-account-number.service';
 import { PaymentMessagingService } from '../../modules/messaging/payment-messaging.service';
+import { PolicyLifecycleMessagingService } from '../../modules/messaging/policy-lifecycle-messaging.service';
 
 describe('PolicyService - generatePolicyNumber', () => {
   const prismaMock = {
@@ -25,10 +26,16 @@ describe('PolicyService - generatePolicyNumber', () => {
     tryEnqueueMatchedPaymentSms: jest.fn(),
   };
 
+  const lifecycleMessagingServiceMock = {
+    suppressPendingActivationReminders: jest.fn(),
+    enqueueLifecycleNotification: jest.fn(),
+  };
+
   const policyService = new PolicyService(
     prismaMock as unknown as PrismaService,
     paymentAccountNumberServiceMock as unknown as PaymentAccountNumberService,
-    paymentMessagingServiceMock as unknown as PaymentMessagingService
+    paymentMessagingServiceMock as unknown as PaymentMessagingService,
+    lifecycleMessagingServiceMock as unknown as PolicyLifecycleMessagingService
   );
 
   beforeEach(() => {

--- a/apps/api/src/services/customer.service.ts
+++ b/apps/api/src/services/customer.service.ts
@@ -53,6 +53,7 @@ import {
   isUtcCalendarDayBefore,
   parseYmdToUtcStart,
 } from '../utils/premium-statement-math';
+import { buildPolicyDisplayText } from '../utils/policy-display.util';
 import { OndemandStkMode, OndemandStkPaymentDto } from '../dto/customers/ondemand-stk-payment.dto';
 import { InitiateStkPushDto, StkPushRequestResponseDto } from '../dto/mpesa-stk-push/mpesa-stk-push.dto';
 import { MpesaStkPushService } from './mpesa-stk-push.service';
@@ -181,6 +182,29 @@ export class CustomerService {
             validationErrors['general'] = error;
           }
         });
+      }
+
+      // Block registration when identity matches a TERMINATED customer
+      const terminatedById = await this.prismaService.customer.findFirst({
+        where: {
+          idNumber: customerEntity.idNumber,
+          status: 'TERMINATED',
+        },
+      });
+      if (terminatedById) {
+        validationErrors['id_number'] =
+          'This ID number is associated with a terminated account and cannot be used';
+      }
+
+      const terminatedByPhone = await this.prismaService.customer.findFirst({
+        where: {
+          phoneNumber: customerEntity.phoneNumber,
+          status: 'TERMINATED',
+        },
+      });
+      if (terminatedByPhone) {
+        validationErrors['phoneNumber'] =
+          'This phone number is associated with a terminated account and cannot be used';
       }
 
       // Pre-save validation: Check for email uniqueness
@@ -2436,15 +2460,26 @@ export class CustomerService {
             },
           },
         },
+        orderBy: { createdAt: 'desc' },
       });
 
       const policyOptions: PolicyOptionDto[] = policies.map((p) => ({
         id: p.id,
-        displayText: p.packagePlan
-          ? `${p.package.name} - ${p.packagePlan.name}`
-          : p.package.name,
+        displayText: buildPolicyDisplayText({
+          packageName: p.package.name,
+          planName: p.packagePlan?.name,
+          status: p.status,
+          startDate: p.startDate,
+          endDate: p.endDate,
+          deactivatedAt: p.deactivatedAt,
+        }),
         packageName: p.package.name,
         planName: p.packagePlan?.name,
+        status: p.status,
+        policyNumber: p.policyNumber,
+        startDate: p.startDate?.toISOString() ?? null,
+        endDate: p.endDate?.toISOString() ?? null,
+        deactivatedAt: p.deactivatedAt?.toISOString() ?? null,
       }));
 
       return {
@@ -3000,19 +3035,56 @@ export class CustomerService {
         orderBy: {
           actualPaymentDate: 'desc',
         },
+        include: {
+          policy: {
+            select: {
+              id: true,
+              policyNumber: true,
+              status: true,
+              package: { select: { name: true } },
+              packagePlan: { select: { name: true } },
+              startDate: true,
+              endDate: true,
+              deactivatedAt: true,
+            },
+          },
+        },
         ...(paginate ? { skip: (page - 1) * pageSize, take: pageSize } : {}),
       });
 
-      const paymentDtos: PaymentDto[] = payments.map((p) => ({
-        id: p.id,
-        paymentType: p.paymentType,
-        transactionReference: p.transactionReference,
-        accountNumber: p.accountNumber ?? undefined,
-        expectedPaymentDate: p.expectedPaymentDate.toISOString(),
-        actualPaymentDate: p.actualPaymentDate?.toISOString(),
-        amount: Number(p.amount),
-        paymentStatus: p.paymentStatus,
-      }));
+      const paymentDtos: PaymentDto[] = payments.map((p) => {
+        const base = {
+          id: p.id,
+          paymentType: p.paymentType,
+          transactionReference: p.transactionReference,
+          accountNumber: p.accountNumber ?? undefined,
+          expectedPaymentDate: p.expectedPaymentDate.toISOString(),
+          actualPaymentDate: p.actualPaymentDate?.toISOString(),
+          amount: Number(p.amount),
+          paymentStatus: p.paymentStatus,
+        };
+        if (!filters.policyId) {
+          const pol = p.policy;
+          const label = buildPolicyDisplayText({
+            packageName: pol.package.name,
+            planName: pol.packagePlan?.name,
+            status: pol.status,
+            startDate: pol.startDate,
+            endDate: pol.endDate,
+            deactivatedAt: pol.deactivatedAt,
+          });
+          return {
+            ...base,
+            policy: {
+              id: pol.id,
+              policyNumber: pol.policyNumber,
+              status: pol.status,
+              displayText: label,
+            },
+          };
+        }
+        return base;
+      });
 
       const totalPages =
         paginate && totalItems != null ? Math.max(1, Math.ceil(totalItems / pageSize)) : undefined;
@@ -3601,6 +3673,7 @@ export class CustomerService {
       memberCardsByPolicy.push({
         policyId: policy.id,
         policyNumber: policy.policyNumber,
+        policyStatus: policy.status,
         packageId: pkg.id,
         packageName: pkg.name,
         cardTemplateName: pkg.cardTemplateName ?? null,

--- a/apps/api/src/services/entity-status-change.service.ts
+++ b/apps/api/src/services/entity-status-change.service.ts
@@ -20,6 +20,9 @@ export interface RecordStatusChangeParams {
   tx?: Prisma.TransactionClient;
 }
 
+/** Audit marker for grace overlay enter (member-facing status stays ACTIVE). */
+export const POLICY_STATUS_ACTIVE_GRACE = 'ACTIVE_GRACE';
+
 @Injectable()
 export class EntityStatusChangeService {
   private readonly logger = new Logger(EntityStatusChangeService.name);
@@ -45,5 +48,46 @@ export class EntityStatusChangeService {
     this.logger.log(
       `[${params.correlationId ?? 'n/a'}] Status change ${params.entityType} ${params.fromStatus} → ${params.toStatus} (customer=${params.customerId})`
     );
+  }
+
+  /**
+   * Required for every Policy status transition and grace enter/exit.
+   * Triggers: SYSTEM (daily), PAYMENT_LIFECYCLE (payments), MANUAL_ADMIN (admin).
+   */
+  async recordPolicyChange(
+    params: Omit<RecordStatusChangeParams, 'entityType'> & { policyId: string }
+  ): Promise<void> {
+    await this.record({
+      ...params,
+      entityType: StatusChangeEntityType.POLICY,
+    });
+  }
+
+  /** Grace enter: ACTIVE → ACTIVE_GRACE (overlay only; Policy.status remains ACTIVE). */
+  async recordGraceEnter(
+    params: Omit<RecordStatusChangeParams, 'entityType' | 'fromStatus' | 'toStatus'> & {
+      policyId: string;
+      fromStatus?: string;
+    }
+  ): Promise<void> {
+    await this.recordPolicyChange({
+      ...params,
+      fromStatus: params.fromStatus ?? 'ACTIVE',
+      toStatus: POLICY_STATUS_ACTIVE_GRACE,
+    });
+  }
+
+  /** Grace exit: ACTIVE_GRACE → ACTIVE (or next status such as SUSPENDED via recordPolicyChange). */
+  async recordGraceExit(
+    params: Omit<RecordStatusChangeParams, 'entityType' | 'fromStatus' | 'toStatus'> & {
+      policyId: string;
+      toStatus?: string;
+    }
+  ): Promise<void> {
+    await this.recordPolicyChange({
+      ...params,
+      fromStatus: POLICY_STATUS_ACTIVE_GRACE,
+      toStatus: params.toStatus ?? 'ACTIVE',
+    });
   }
 }

--- a/apps/api/src/services/entity-status-change.service.ts
+++ b/apps/api/src/services/entity-status-change.service.ts
@@ -1,0 +1,49 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  Prisma,
+  StatusChangeEntityType,
+  StatusChangeTrigger,
+} from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+
+export interface RecordStatusChangeParams {
+  entityType: StatusChangeEntityType;
+  customerId: string;
+  policyId?: string | null;
+  fromStatus: string;
+  toStatus: string;
+  reason: string;
+  trigger: StatusChangeTrigger;
+  changedBy: string;
+  correlationId?: string;
+  metadata?: Prisma.InputJsonValue;
+  tx?: Prisma.TransactionClient;
+}
+
+@Injectable()
+export class EntityStatusChangeService {
+  private readonly logger = new Logger(EntityStatusChangeService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async record(params: RecordStatusChangeParams): Promise<void> {
+    const client = params.tx ?? this.prisma;
+    await client.entityStatusChange.create({
+      data: {
+        entityType: params.entityType,
+        customerId: params.customerId,
+        policyId: params.policyId ?? null,
+        fromStatus: params.fromStatus,
+        toStatus: params.toStatus,
+        reason: params.reason,
+        trigger: params.trigger,
+        changedBy: params.changedBy,
+        correlationId: params.correlationId ?? null,
+        metadata: params.metadata ?? Prisma.JsonNull,
+      },
+    });
+    this.logger.log(
+      `[${params.correlationId ?? 'n/a'}] Status change ${params.entityType} ${params.fromStatus} → ${params.toStatus} (customer=${params.customerId})`
+    );
+  }
+}

--- a/apps/api/src/services/mpesa-ipn.service.ts
+++ b/apps/api/src/services/mpesa-ipn.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger, forwardRef, Inject } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { PolicyService } from './policy.service';
+import { PolicyLifecycleService } from './policy-lifecycle.service';
 import { PaymentMessagingService } from '../modules/messaging/payment-messaging.service';
 import { MpesaIpnPayloadDto, MpesaIpnResponseDto } from '../dto/mpesa-ipn/mpesa-ipn.dto';
 import { normalizeMsisdnOrReturnRaw } from '../utils/phone-number.util';
@@ -31,6 +32,7 @@ export class MpesaIpnService {
     @Inject(forwardRef(() => PolicyService))
     private readonly policyService: PolicyService,
     private readonly paymentMessagingService: PaymentMessagingService,
+    private readonly policyLifecycleService: PolicyLifecycleService,
   ) {}
 
   /**
@@ -669,6 +671,18 @@ export class MpesaIpnService {
         activationSucceeded,
         correlationId,
       });
+    }
+
+    if (policyPaymentId != null && (!wasPendingActivation || activationSucceeded)) {
+      this.policyLifecycleService
+        .applyPaymentToPolicyLifecycle(policy.id, correlationId)
+        .catch((error) => {
+          this.logger.warn(
+            `[${correlationId}] applyPaymentToPolicyLifecycle failed for policy ${policy.id}: ${
+              error instanceof Error ? error.message : String(error)
+            }`
+          );
+        });
     }
 
     return true;

--- a/apps/api/src/services/mpesa-payments.service.ts
+++ b/apps/api/src/services/mpesa-payments.service.ts
@@ -10,6 +10,7 @@ import { existsSync } from 'fs';
 import { ValidationException } from '../exceptions/validation.exception';
 import { ErrorCodes } from '../enums/error-codes.enum';
 import { PolicyService } from './policy.service';
+import { PolicyLifecycleService } from './policy-lifecycle.service';
 import { PaymentMessagingService } from '../modules/messaging/payment-messaging.service';
 
 /** Result of processing statement items into policy payments */
@@ -71,6 +72,7 @@ export class MpesaPaymentsService {
     private readonly supabaseService: SupabaseService,
     private readonly policyService: PolicyService,
     private readonly paymentMessagingService: PaymentMessagingService,
+    private readonly policyLifecycleService: PolicyLifecycleService,
   ) {}
 
   /**
@@ -899,7 +901,12 @@ export class MpesaPaymentsService {
               }
             }
 
-            return { policyPaymentId: payment.id, wasPendingActivation, activationSucceeded };
+            return {
+              policyPaymentId: payment.id,
+              policyId: policy.id,
+              wasPendingActivation,
+              activationSucceeded,
+            };
           }).then((smsContext) => {
             if (smsContext) {
               this.paymentMessagingService.notifyMatchedPaymentSmsAsync({
@@ -908,6 +915,17 @@ export class MpesaPaymentsService {
                 activationSucceeded: smsContext.activationSucceeded,
                 correlationId,
               });
+              if (!smsContext.wasPendingActivation || smsContext.activationSucceeded) {
+                this.policyLifecycleService
+                  .applyPaymentToPolicyLifecycle(smsContext.policyId, correlationId)
+                  .catch((error) => {
+                    this.logger.warn(
+                      `[${correlationId}] applyPaymentToPolicyLifecycle failed for policy ${smsContext.policyId}: ${
+                        error instanceof Error ? error.message : String(error)
+                      }`
+                    );
+                  });
+              }
             }
           });
         } catch (error) {

--- a/apps/api/src/services/mpesa-stk-push.service.ts
+++ b/apps/api/src/services/mpesa-stk-push.service.ts
@@ -7,6 +7,7 @@ import { MpesaDarajaApiService } from './mpesa-daraja-api.service';
 import { MpesaErrorMapperService } from './mpesa-error-mapper.service';
 import { ConfigurationService } from '../config/configuration.service';
 import { PolicyService } from './policy.service';
+import { PolicyLifecycleService } from './policy-lifecycle.service';
 import { PaymentMessagingService } from '../modules/messaging/payment-messaging.service';
 import {
   InitiateStkPushDto,
@@ -41,6 +42,7 @@ export class MpesaStkPushService implements OnModuleInit {
     @Inject(forwardRef(() => PolicyService))
     private readonly policyService: PolicyService,
     private readonly paymentMessagingService: PaymentMessagingService,
+    private readonly policyLifecycleService: PolicyLifecycleService,
     @Inject(forwardRef(() => PaymentStatusGateway))
     private readonly paymentStatusGateway: PaymentStatusGateway
   ) {}
@@ -1500,6 +1502,18 @@ export class MpesaStkPushService implements OnModuleInit {
       activationSucceeded,
       correlationId,
     });
+
+    if (!wasPendingActivation || activationSucceeded) {
+      this.policyLifecycleService
+        .applyPaymentToPolicyLifecycle(policy.id, correlationId)
+        .catch((error) => {
+          this.logger.warn(
+            `[${correlationId}] applyPaymentToPolicyLifecycle failed for policy ${policy.id}: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        });
+    }
   }
 }
 

--- a/apps/api/src/services/policy-lifecycle-job.service.ts
+++ b/apps/api/src/services/policy-lifecycle-job.service.ts
@@ -1,0 +1,125 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import * as Sentry from '@sentry/nestjs';
+import { PolicyLifecycleService } from './policy-lifecycle.service';
+
+/**
+ * Daily policy lifecycle evaluation job (@Cron 01:00 UTC).
+ */
+@Injectable()
+export class PolicyLifecycleJobService {
+  private readonly logger = new Logger(PolicyLifecycleJobService.name);
+  private isRunning = false;
+
+  constructor(private readonly lifecycleService: PolicyLifecycleService) {}
+
+  @Cron('0 1 * * *', { timeZone: 'UTC' })
+  async handleCron(): Promise<void> {
+    const correlationId = `lifecycle-cron-${Date.now()}`;
+    try {
+      await this.runDaily(correlationId);
+    } catch (error) {
+      this.logger.error(
+        `[${correlationId}] Daily lifecycle cron failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        error instanceof Error ? error.stack : undefined
+      );
+      Sentry.captureException(error, {
+        tags: { service: 'PolicyLifecycleJobService', operation: 'handleCron' },
+        extra: { correlationId },
+      });
+    }
+  }
+
+  async runDaily(correlationId?: string): Promise<{
+    evaluatedAt: string;
+    graceEntered: number;
+    graceCleared: number;
+    suspended: number;
+    inactivated: number;
+    expired: number;
+    notificationsQueued: number;
+    correlationId: string;
+    durationMs: number;
+  }> {
+    const cid = correlationId ?? `lifecycle-daily-${Date.now()}`;
+    if (this.isRunning) {
+      this.logger.warn(`[${cid}] Skipping daily run — previous run still in progress`);
+      return {
+        evaluatedAt: new Date().toISOString(),
+        graceEntered: 0,
+        graceCleared: 0,
+        suspended: 0,
+        inactivated: 0,
+        expired: 0,
+        notificationsQueued: 0,
+        correlationId: cid,
+        durationMs: 0,
+      };
+    }
+
+    this.isRunning = true;
+    const started = Date.now();
+    this.logger.log(`[${cid}] PolicyLifecycleJobService.runDaily starting`);
+
+    try {
+      const asOf = new Date();
+
+      // DEACTIVATED/TERMINATED are excluded inside each evaluator; Suspended past end
+      // is frozen (no Inactive/Expired) inside evaluateInactive / evaluateTermEnd.
+      const pendingQueued =
+        await this.lifecycleService.evaluatePendingActivationReminders(asOf, cid);
+      const grace = await this.lifecycleService.evaluateGraceForActivePolicies(asOf, cid);
+      const suspend = await this.lifecycleService.evaluateSuspendForActivePolicies(asOf, cid);
+      const inactive = await this.lifecycleService.evaluateInactiveForSuspendedPolicies(
+        asOf,
+        cid
+      );
+      const termEnd = await this.lifecycleService.evaluateTermEndTransitions(asOf, cid);
+      const renewalQueued = await this.lifecycleService.evaluateRenewalReminders(asOf, cid);
+
+      const durationMs = Date.now() - started;
+      const result = {
+        evaluatedAt: asOf.toISOString(),
+        graceEntered: grace.graceEntered,
+        graceCleared: grace.graceCleared,
+        suspended: suspend.suspended,
+        inactivated: inactive.inactivated,
+        expired: termEnd.expired,
+        notificationsQueued:
+          pendingQueued +
+          grace.notificationsQueued +
+          suspend.notificationsQueued +
+          inactive.notificationsQueued +
+          renewalQueued,
+        correlationId: cid,
+        durationMs,
+      };
+
+      this.logger.log(
+        `[${cid}] PolicyLifecycleJobService.runDaily finished in ${durationMs}ms ` +
+          `graceEntered=${result.graceEntered} suspended=${result.suspended} ` +
+          `inactivated=${result.inactivated} expired=${result.expired} ` +
+          `notificationsQueued=${result.notificationsQueued}`
+      );
+
+      return result;
+    } catch (error) {
+      const durationMs = Date.now() - started;
+      this.logger.error(
+        `[${cid}] PolicyLifecycleJobService.runDaily failed after ${durationMs}ms: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        error instanceof Error ? error.stack : undefined
+      );
+      Sentry.captureException(error, {
+        tags: { service: 'PolicyLifecycleJobService', operation: 'runDaily' },
+        extra: { correlationId: cid, durationMs },
+      });
+      throw error;
+    } finally {
+      this.isRunning = false;
+    }
+  }
+}

--- a/apps/api/src/services/policy-lifecycle.service.ts
+++ b/apps/api/src/services/policy-lifecycle.service.ts
@@ -1,0 +1,724 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import {
+  CustomerStatus,
+  PaymentFrequency,
+  PaymentStatus,
+  PaymentType,
+  PolicyStatus,
+  Prisma,
+  StatusChangeEntityType,
+  StatusChangeTrigger,
+} from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { EntityStatusChangeService } from './entity-status-change.service';
+import { PolicyService } from './policy.service';
+import { ValidationException } from '../exceptions/validation.exception';
+import { ErrorCodes } from '../enums/error-codes.enum';
+import { PAYMENT_CADENCE } from '../constants/payment-cadence.constants';
+import { policyDatesFromPayment, policyEndDateFromStart } from '../utils/policy-dates.util';
+import {
+  buildOutstandingTransactionReference,
+  computeInstallmentBackfillSlots,
+} from '../utils/installment-backfill.util';
+import {
+  deriveFamilyCategoryFromDependants,
+  hasAdditionalSpousePremium,
+} from '../utils/family-category.util';
+import {
+  ActivatePolicyRequestDto,
+  DeactivatePolicyRequestDto,
+  ModifyPolicyOptionsResponseDto,
+  ModifyPolicyRequestDto,
+  PolicyLifecycleResponseDto,
+  PolicyNumberChoice,
+  ResetPolicyStartDateRequestDto,
+} from '../dto/policy-lifecycle/policy-lifecycle.dto';
+
+const CONFIRMED_PAYMENT_STATUSES: PaymentStatus[] = [
+  PaymentStatus.COMPLETED,
+  PaymentStatus.COMPLETED_PENDING_RECEIPT,
+];
+
+const ADMIN_ROLE = 'registration_admin';
+
+@Injectable()
+export class PolicyLifecycleService {
+  private readonly logger = new Logger(PolicyLifecycleService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly statusChangeService: EntityStatusChangeService,
+    private readonly policyService: PolicyService
+  ) {}
+
+  assertAdmin(userRoles: string[]): void {
+    if (userRoles.includes(ADMIN_ROLE)) return;
+    throw new ForbiddenException({
+      error: {
+        code: ErrorCodes.INSUFFICIENT_PERMISSIONS,
+        status: 403,
+        message: 'Admin role required',
+      },
+    });
+  }
+
+  private calculatePaymentCadence(frequency: PaymentFrequency, customDays?: number): number {
+    switch (frequency) {
+      case PaymentFrequency.DAILY:
+        return PAYMENT_CADENCE.DAILY;
+      case PaymentFrequency.WEEKLY:
+        return PAYMENT_CADENCE.WEEKLY;
+      case PaymentFrequency.MONTHLY:
+        return PAYMENT_CADENCE.MONTHLY;
+      case PaymentFrequency.QUARTERLY:
+        return PAYMENT_CADENCE.QUARTERLY;
+      case PaymentFrequency.ANNUALLY:
+        return PAYMENT_CADENCE.ANNUALLY;
+      case PaymentFrequency.CUSTOM:
+        if (!customDays || customDays <= 0) {
+          throw new BadRequestException('Custom days must be provided for CUSTOM frequency');
+        }
+        return customDays;
+      default:
+        throw new BadRequestException(`Invalid payment frequency: ${frequency}`);
+    }
+  }
+
+  private async loadPolicyForCustomer(customerId: string, policyId: string) {
+    const policy = await this.prisma.policy.findFirst({
+      where: { id: policyId, customerId },
+      include: {
+        package: { select: { id: true, name: true } },
+        packagePlan: { select: { id: true, name: true } },
+        customer: { select: { id: true, status: true } },
+      },
+    });
+    if (!policy) {
+      throw new NotFoundException('Policy not found or does not belong to this customer');
+    }
+    return policy;
+  }
+
+  private assertCustomerNotTerminated(customerStatus: CustomerStatus): void {
+    if (customerStatus === CustomerStatus.TERMINATED) {
+      throw ValidationException.forField(
+        'customer',
+        'Terminated customers cannot have policy lifecycle changes'
+      );
+    }
+  }
+
+  private async syncCustomerStatusAfterPolicyChange(
+    customerId: string,
+    changedBy: string,
+    correlationId: string,
+    tx: Prisma.TransactionClient
+  ): Promise<void> {
+    const policies = await tx.policy.findMany({
+      where: {
+        customerId,
+        status: { notIn: [PolicyStatus.DEACTIVATED, PolicyStatus.TERMINATED, PolicyStatus.EXPIRED] },
+      },
+      select: { status: true },
+    });
+
+    const hasActive = policies.some((p) => p.status === PolicyStatus.ACTIVE);
+    const hasPending = policies.some((p) => p.status === PolicyStatus.PENDING_ACTIVATION);
+
+    const customer = await tx.customer.findUnique({ where: { id: customerId } });
+    if (!customer) return;
+
+    let nextStatus: CustomerStatus | null = null;
+    if (hasActive) {
+      if (
+        customer.status === CustomerStatus.DEACTIVATED ||
+        customer.status === CustomerStatus.SUSPENDED
+      ) {
+        nextStatus = CustomerStatus.ACTIVE;
+      }
+    } else if (hasPending) {
+      if (customer.status !== CustomerStatus.PENDING_ACTIVATION) {
+        nextStatus = CustomerStatus.PENDING_ACTIVATION;
+      }
+    } else {
+      nextStatus = CustomerStatus.DEACTIVATED;
+    }
+
+    if (nextStatus == null || nextStatus === customer.status) {
+      return;
+    }
+
+    await this.statusChangeService.record({
+      entityType: StatusChangeEntityType.CUSTOMER,
+      customerId,
+      fromStatus: customer.status,
+      toStatus: nextStatus,
+      reason: 'Automatic customer status update after policy change',
+      trigger: StatusChangeTrigger.SYSTEM,
+      changedBy,
+      correlationId,
+      tx,
+    });
+
+    await tx.customer.update({
+      where: { id: customerId },
+      data: {
+        status: nextStatus,
+        deactivatedAt: nextStatus === CustomerStatus.DEACTIVATED ? new Date() : null,
+      },
+    });
+  }
+
+  async deactivatePolicy(
+    customerId: string,
+    policyId: string,
+    dto: DeactivatePolicyRequestDto,
+    userId: string,
+    userRoles: string[],
+    correlationId: string
+  ): Promise<PolicyLifecycleResponseDto> {
+    this.assertAdmin(userRoles);
+    const source = await this.loadPolicyForCustomer(customerId, policyId);
+    this.assertCustomerNotTerminated(source.customer.status);
+
+    if (
+      source.status === PolicyStatus.DEACTIVATED ||
+      source.status === PolicyStatus.TERMINATED
+    ) {
+      throw ValidationException.forField('status', 'Policy cannot be deactivated from this status');
+    }
+
+    const now = new Date();
+    const updated = await this.prisma.$transaction(async (tx) => {
+      await this.statusChangeService.record({
+        entityType: StatusChangeEntityType.POLICY,
+        customerId,
+        policyId,
+        fromStatus: source.status,
+        toStatus: PolicyStatus.DEACTIVATED,
+        reason: dto.reason,
+        trigger: StatusChangeTrigger.MANUAL_ADMIN,
+        changedBy: userId,
+        correlationId,
+        tx,
+      });
+
+      const policy = await tx.policy.update({
+        where: { id: policyId },
+        data: { status: PolicyStatus.DEACTIVATED, deactivatedAt: now },
+      });
+
+      await this.syncCustomerStatusAfterPolicyChange(customerId, userId, correlationId, tx);
+      return policy;
+    });
+
+    return {
+      status: 200,
+      correlationId,
+      message: 'Policy deactivated successfully',
+      policy: {
+        id: updated.id,
+        policyNumber: updated.policyNumber,
+        status: updated.status,
+      },
+    };
+  }
+
+  async activatePolicy(
+    customerId: string,
+    policyId: string,
+    dto: ActivatePolicyRequestDto,
+    userId: string,
+    userRoles: string[],
+    correlationId: string
+  ): Promise<PolicyLifecycleResponseDto> {
+    this.assertAdmin(userRoles);
+    const source = await this.loadPolicyForCustomer(customerId, policyId);
+    this.assertCustomerNotTerminated(source.customer.status);
+
+    if (source.status !== PolicyStatus.SUSPENDED) {
+      throw ValidationException.forField(
+        'status',
+        'Only suspended policies can be manually activated'
+      );
+    }
+
+    const updated = await this.prisma.$transaction(async (tx) => {
+      await this.statusChangeService.record({
+        entityType: StatusChangeEntityType.POLICY,
+        customerId,
+        policyId,
+        fromStatus: source.status,
+        toStatus: PolicyStatus.ACTIVE,
+        reason: dto.reason,
+        trigger: StatusChangeTrigger.MANUAL_ADMIN,
+        changedBy: userId,
+        correlationId,
+        tx,
+      });
+
+      const policy = await tx.policy.update({
+        where: { id: policyId },
+        data: { status: PolicyStatus.ACTIVE, deactivatedAt: null },
+      });
+
+      await this.syncCustomerStatusAfterPolicyChange(customerId, userId, correlationId, tx);
+      return policy;
+    });
+
+    return {
+      status: 200,
+      correlationId,
+      message: 'Policy activated successfully',
+      policy: {
+        id: updated.id,
+        policyNumber: updated.policyNumber,
+        status: updated.status,
+      },
+    };
+  }
+
+  async resetPolicyStartDate(
+    customerId: string,
+    policyId: string,
+    dto: ResetPolicyStartDateRequestDto,
+    userId: string,
+    userRoles: string[],
+    correlationId: string
+  ): Promise<PolicyLifecycleResponseDto> {
+    this.assertAdmin(userRoles);
+    const source = await this.loadPolicyForCustomer(customerId, policyId);
+    this.assertCustomerNotTerminated(source.customer.status);
+
+    if (source.status !== PolicyStatus.ACTIVE && source.status !== PolicyStatus.SUSPENDED) {
+      throw ValidationException.forField(
+        'status',
+        'Reset start date is only allowed for active or suspended policies'
+      );
+    }
+
+    const newStart = new Date(dto.startDate);
+    if (Number.isNaN(newStart.getTime())) {
+      throw ValidationException.forField('startDate', 'Invalid start date');
+    }
+
+    const newEnd = policyEndDateFromStart(newStart);
+
+    const updated = await this.prisma.$transaction(async (tx) => {
+      await this.statusChangeService.record({
+        entityType: StatusChangeEntityType.POLICY,
+        customerId,
+        policyId,
+        fromStatus: source.status,
+        toStatus: source.status,
+        reason: dto.reason,
+        trigger: StatusChangeTrigger.MANUAL_ADMIN,
+        changedBy: userId,
+        correlationId,
+        metadata: {
+          operation: 'RESET_START_DATE',
+          previousStartDate: source.startDate?.toISOString() ?? null,
+          newStartDate: newStart.toISOString(),
+          previousEndDate: source.endDate?.toISOString() ?? null,
+          newEndDate: newEnd.toISOString(),
+        },
+        tx,
+      });
+
+      return tx.policy.update({
+        where: { id: policyId },
+        data: { startDate: newStart, endDate: newEnd },
+      });
+    });
+
+    return {
+      status: 200,
+      correlationId,
+      message: 'Policy start date reset successfully',
+      policy: {
+        id: updated.id,
+        policyNumber: updated.policyNumber,
+        status: updated.status,
+      },
+    };
+  }
+
+  async getModifyOptions(
+    customerId: string,
+    policyId: string,
+    userRoles: string[],
+    correlationId: string
+  ): Promise<ModifyPolicyOptionsResponseDto> {
+    this.assertAdmin(userRoles);
+    const policy = await this.loadPolicyForCustomer(customerId, policyId);
+
+    if (
+      policy.status !== PolicyStatus.ACTIVE &&
+      policy.status !== PolicyStatus.PENDING_ACTIVATION
+    ) {
+      throw ValidationException.forField('status', 'Policy is not eligible for modify');
+    }
+
+    const dependants = await this.prisma.dependant.findMany({
+      where: { customerId, deletedAt: null },
+    });
+    const familyCategory = deriveFamilyCategoryFromDependants(dependants);
+    const additionalSpouse = hasAdditionalSpousePremium(familyCategory, dependants);
+
+    const completedPayments = await this.prisma.policyPayment.findMany({
+      where: {
+        policyId,
+        paymentStatus: { in: CONFIRMED_PAYMENT_STATUSES },
+        actualPaymentDate: { not: null },
+      },
+      orderBy: { expectedPaymentDate: 'asc' },
+      include: { postpaidSchemePaymentItem: { select: { id: true } } },
+    });
+
+    const hasPostpaidLinks = completedPayments.some((p) => p.postpaidSchemePaymentItem != null);
+    const paymentMigrationAllowed = !hasPostpaidLinks && completedPayments.length > 0;
+
+    const schemeCustomer = await this.prisma.packageSchemeCustomer.findFirst({
+      where: {
+        customerId,
+        packageScheme: { packageId: policy.packageId },
+      },
+      select: { packageSchemeId: true },
+    });
+
+    const packageSchemes = await this.prisma.packageScheme.findMany({
+      where: { packageId: policy.packageId },
+      include: { scheme: { select: { schemeName: true, isPostpaid: true } } },
+    });
+
+    return {
+      status: 200,
+      correlationId,
+      message: 'Modify options retrieved successfully',
+      packageId: policy.packageId,
+      packageName: policy.package.name,
+      familyCategory,
+      additionalSpouse,
+      currentPackagePlanId: policy.packagePlanId ?? 0,
+      currentPlanName: policy.packagePlan?.name,
+      currentPremium: Number(policy.premium),
+      currentFrequency: policy.frequency,
+      currentPaymentCadence: policy.paymentCadence,
+      currentPackageSchemeId: schemeCustomer?.packageSchemeId ?? null,
+      paymentMigrationAllowed,
+      eligiblePayments: completedPayments.map((p) => ({
+        id: p.id,
+        transactionReference: p.transactionReference,
+        amount: Number(p.amount),
+        expectedPaymentDate: p.expectedPaymentDate.toISOString(),
+        actualPaymentDate: p.actualPaymentDate?.toISOString(),
+      })),
+      schemes: packageSchemes.map((ps) => ({
+        packageSchemeId: ps.id,
+        schemeName: ps.scheme.schemeName,
+        isPostpaid: ps.scheme.isPostpaid,
+      })),
+    };
+  }
+
+  async modifyPolicy(
+    customerId: string,
+    policyId: string,
+    dto: ModifyPolicyRequestDto,
+    userId: string,
+    userRoles: string[],
+    correlationId: string
+  ): Promise<PolicyLifecycleResponseDto> {
+    this.assertAdmin(userRoles);
+    const source = await this.loadPolicyForCustomer(customerId, policyId);
+    this.assertCustomerNotTerminated(source.customer.status);
+
+    if (
+      source.status !== PolicyStatus.ACTIVE &&
+      source.status !== PolicyStatus.PENDING_ACTIVATION
+    ) {
+      throw ValidationException.forField('status', 'Policy is not eligible for modify');
+    }
+
+    const validationErrors: Record<string, string> = {};
+    if (dto.frequency === PaymentFrequency.CUSTOM && (!dto.customDays || dto.customDays <= 0)) {
+      validationErrors['customDays'] = 'Custom days required for CUSTOM frequency';
+    }
+    if (Object.keys(validationErrors).length > 0) {
+      throw ValidationException.withMultipleErrors(validationErrors);
+    }
+
+    const plan = await this.prisma.packagePlan.findFirst({
+      where: { id: dto.packagePlanId, packageId: source.packageId },
+    });
+    if (!plan) {
+      throw ValidationException.forField('packagePlanId', 'Plan not found for this package');
+    }
+
+    const paymentCadence = this.calculatePaymentCadence(dto.frequency, dto.customDays);
+
+    const completedPayments = await this.prisma.policyPayment.findMany({
+      where: {
+        policyId,
+        paymentStatus: { in: CONFIRMED_PAYMENT_STATUSES },
+        actualPaymentDate: { not: null },
+      },
+      orderBy: { expectedPaymentDate: 'asc' },
+      include: { postpaidSchemePaymentItem: { select: { id: true } } },
+    });
+
+    const hasPostpaidLinks = completedPayments.some((p) => p.postpaidSchemePaymentItem != null);
+    const wantsMigration = completedPayments.length > 0;
+
+    if (wantsMigration && hasPostpaidLinks) {
+      throw ValidationException.forField(
+        'firstPaymentId',
+        'Cannot migrate postpaid bulk-linked payments'
+      );
+    }
+
+    let paymentsToMove: typeof completedPayments = [];
+    if (wantsMigration) {
+      if (dto.firstPaymentId == null) {
+        throw ValidationException.forField(
+          'firstPaymentId',
+          'First payment to migrate is required'
+        );
+      }
+      const firstIdx = completedPayments.findIndex((p) => p.id === dto.firstPaymentId);
+      if (firstIdx < 0) {
+        throw ValidationException.forField('firstPaymentId', 'Payment not found on this policy');
+      }
+      paymentsToMove = completedPayments.slice(firstIdx);
+    }
+
+    if (dto.packageSchemeId != null) {
+      const scheme = await this.prisma.packageScheme.findFirst({
+        where: { id: dto.packageSchemeId, packageId: source.packageId },
+        include: { scheme: { select: { isPostpaid: true } } },
+      });
+      if (!scheme) {
+        throw ValidationException.forField('packageSchemeId', 'Scheme must belong to same package');
+      }
+      const currentPsc = await this.prisma.packageSchemeCustomer.findFirst({
+        where: { customerId, packageScheme: { packageId: source.packageId } },
+        include: { packageScheme: { include: { scheme: { select: { isPostpaid: true } } } } },
+      });
+      if (
+        currentPsc?.packageScheme?.scheme?.isPostpaid === true &&
+        scheme.scheme.isPostpaid === false
+      ) {
+        throw ValidationException.forField(
+          'packageSchemeId',
+          'Changing from postpaid to prepaid scheme is not supported'
+        );
+      }
+    }
+
+    const productName = `${source.package.name} ${plan.name}`;
+    const paymentAcNumber = source.paymentAcNumber;
+    const now = new Date();
+
+    const result = await this.prisma.$transaction(async (tx) => {
+      // Deactivate source
+      await this.statusChangeService.record({
+        entityType: StatusChangeEntityType.POLICY,
+        customerId,
+        policyId,
+        fromStatus: source.status,
+        toStatus: PolicyStatus.DEACTIVATED,
+        reason: dto.reason,
+        trigger: StatusChangeTrigger.MODIFY_PRODUCT,
+        changedBy: userId,
+        correlationId,
+        tx,
+      });
+
+      await tx.policy.update({
+        where: { id: policyId },
+        data: {
+          status: PolicyStatus.DEACTIVATED,
+          deactivatedAt: now,
+          paymentAcNumber: null,
+        },
+      });
+
+      await this.syncCustomerStatusAfterPolicyChange(customerId, userId, correlationId, tx);
+
+      let policyNumber: string | null = source.policyNumber;
+      if (dto.policyNumberChoice === PolicyNumberChoice.GENERATE_NEW) {
+        policyNumber = await this.policyService.generatePolicyNumberForPackage(
+          source.packageId,
+          tx,
+          correlationId
+        );
+      } else if (dto.policyNumberChoice === PolicyNumberChoice.KEEP_EXISTING) {
+        policyNumber = source.policyNumber;
+      }
+
+      const newPolicy = await tx.policy.create({
+        data: {
+          customerId,
+          packageId: source.packageId,
+          packagePlanId: dto.packagePlanId,
+          productName,
+          premium: dto.premium,
+          frequency: dto.frequency,
+          paymentCadence,
+          paymentAcNumber,
+          policyNumber,
+          status: PolicyStatus.PENDING_ACTIVATION,
+          supersedesPolicyId: policyId,
+          startDate: null,
+          endDate: null,
+        },
+      });
+
+      await tx.policy.update({
+        where: { id: policyId },
+        data: { supersededByPolicyId: newPolicy.id },
+      });
+
+      if (dto.packageSchemeId != null) {
+        await tx.packageSchemeCustomer.updateMany({
+          where: { customerId, packageScheme: { packageId: source.packageId } },
+          data: { packageSchemeId: dto.packageSchemeId },
+        });
+      }
+
+      let placeholdersBackfilledCount = 0;
+
+      if (paymentsToMove.length > 0) {
+        const paymentIds = paymentsToMove.map((p) => p.id);
+        await tx.policyPayment.updateMany({
+          where: { id: { in: paymentIds } },
+          data: { policyId: newPolicy.id },
+        });
+
+        const firstPayment = paymentsToMove[0];
+        const anchor = firstPayment.actualPaymentDate ?? firstPayment.expectedPaymentDate;
+        const { startDate, endDate } = policyDatesFromPayment(anchor);
+
+        await tx.policy.update({
+          where: { id: newPolicy.id },
+          data: { startDate, endDate },
+        });
+
+        await this.policyService.activatePolicy(newPolicy.id, correlationId, tx);
+
+        const allPayments = await tx.policyPayment.findMany({
+          where: { policyId: newPolicy.id },
+        });
+
+        placeholdersBackfilledCount = await this.backfillOutstandingInstallments(
+          newPolicy.id,
+          Number(dto.premium),
+          paymentCadence,
+          startDate,
+          endDate,
+          allPayments,
+          tx
+        );
+      }
+
+      const finalPolicy = await tx.policy.findUniqueOrThrow({ where: { id: newPolicy.id } });
+
+      await this.statusChangeService.record({
+        entityType: StatusChangeEntityType.POLICY,
+        customerId,
+        policyId: newPolicy.id,
+        fromStatus: PolicyStatus.PENDING_ACTIVATION,
+        toStatus: finalPolicy.status,
+        reason: dto.reason,
+        trigger: StatusChangeTrigger.MODIFY_PRODUCT,
+        changedBy: userId,
+        correlationId,
+        metadata: {
+          operation: 'MODIFY_PRODUCT',
+          sourcePolicyId: policyId,
+          newPolicyId: newPolicy.id,
+          firstPaymentId: dto.firstPaymentId ?? null,
+          paymentsMovedCount: paymentsToMove.length,
+          placeholdersBackfilledCount,
+          planBefore: source.packagePlan?.name ?? null,
+          planAfter: plan.name,
+          packagePlanIdBefore: source.packagePlanId,
+          packagePlanIdAfter: dto.packagePlanId,
+          frequencyBefore: source.frequency,
+          frequencyAfter: dto.frequency,
+          cadenceBefore: source.paymentCadence,
+          cadenceAfter: paymentCadence,
+          premiumBefore: source.premium.toString(),
+          premiumAfter: dto.premium.toString(),
+          policyNumberChoice: dto.policyNumberChoice,
+        },
+        tx,
+      });
+
+      await this.syncCustomerStatusAfterPolicyChange(customerId, userId, correlationId, tx);
+
+      return finalPolicy;
+    });
+
+    return {
+      status: 200,
+      correlationId,
+      message: 'Policy modified successfully',
+      policy: {
+        id: result.id,
+        policyNumber: result.policyNumber,
+        status: result.status,
+      },
+      newPolicyId: result.id,
+    };
+  }
+
+  private async backfillOutstandingInstallments(
+    policyId: string,
+    premium: number,
+    paymentCadence: number,
+    startDate: Date,
+    endDate: Date,
+    existingPayments: Array<{
+      id: number;
+      expectedPaymentDate: Date;
+      actualPaymentDate: Date | null;
+      paymentStatus: PaymentStatus;
+    }>,
+    tx: Prisma.TransactionClient
+  ): Promise<number> {
+    const slots = computeInstallmentBackfillSlots({
+      policyId,
+      startDate,
+      endDate,
+      paymentCadence,
+      premium,
+      existingPayments,
+    });
+
+    for (const slot of slots) {
+      await tx.policyPayment.create({
+        data: {
+          policyId,
+          paymentType: PaymentType.MPESA,
+          transactionReference: buildOutstandingTransactionReference(
+            policyId,
+            slot.periodIndex
+          ),
+          amount: premium,
+          expectedPaymentDate: slot.slotStart,
+          actualPaymentDate: null,
+          paymentStatus: PaymentStatus.OUTSTANDING,
+        },
+      });
+    }
+
+    return slots.length;
+  }
+}

--- a/apps/api/src/services/policy-lifecycle.service.ts
+++ b/apps/api/src/services/policy-lifecycle.service.ts
@@ -23,10 +23,6 @@ import { ErrorCodes } from '../enums/error-codes.enum';
 import { PAYMENT_CADENCE } from '../constants/payment-cadence.constants';
 import { policyDatesFromPayment, policyEndDateFromStart } from '../utils/policy-dates.util';
 import {
-  buildOutstandingTransactionReference,
-  computeInstallmentBackfillSlots,
-} from '../utils/installment-backfill.util';
-import {
   getBasePolicyNumber,
   nextDisabledPolicyNumber,
 } from '../utils/disabled-policy-number.util';
@@ -42,7 +38,36 @@ import {
   PolicyLifecycleResponseDto,
   PolicyNumberChoice,
   ResetPolicyStartDateRequestDto,
+  TerminatePolicyRequestDto,
 } from '../dto/policy-lifecycle/policy-lifecycle.dto';
+import {
+  amountRequiredToRestoreInactive,
+  amountRequiredToRestoreSuspended,
+  daysOverdue,
+  isPolicyEndDatePassed,
+  nextUnpaidExpectedDueDate,
+  outstandingArrears,
+  utcCalendarDaysBetween,
+} from '../utils/policy-due-date.util';
+import { assertPolicyMayBecomeActive } from '../utils/policy-activation-gate.util';
+import {
+  addUtcCalendarDays,
+  buildOutstandingTransactionReference,
+  computeInstallmentBackfillSlots,
+} from '../utils/installment-backfill.util';
+import {
+  GRACE_SCHEDULE,
+  GRACE_TEMPLATE,
+  PENDING_ACTIVATION_SCHEDULE,
+  PENDING_ACTIVATION_TEMPLATE,
+  PolicyLifecycleMessagingService,
+  SUSPEND_SCHEDULE,
+  SUSPEND_TEMPLATE,
+} from '../modules/messaging/policy-lifecycle-messaging.service';
+import { utcDayStart, utcDayEnd, sumConfirmedPaidThroughAsOf, computeExpectedPremiumThroughAsOf } from '../utils/premium-statement-math';
+
+/** Well-known actor UUID for SYSTEM / payment-lifecycle automated transitions. */
+export const LIFECYCLE_SYSTEM_ACTOR_ID = '00000000-0000-0000-0000-000000000001';
 
 const CONFIRMED_PAYMENT_STATUSES: PaymentStatus[] = [
   PaymentStatus.COMPLETED,
@@ -58,7 +83,8 @@ export class PolicyLifecycleService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly statusChangeService: EntityStatusChangeService,
-    private readonly policyService: PolicyService
+    private readonly policyService: PolicyService,
+    private readonly lifecycleMessaging: PolicyLifecycleMessagingService
   ) {}
 
   assertAdmin(userRoles: string[]): void {
@@ -100,7 +126,7 @@ export class PolicyLifecycleService {
       include: {
         package: { select: { id: true, name: true } },
         packagePlan: { select: { id: true, name: true } },
-        customer: { select: { id: true, status: true } },
+        customer: { select: { id: true, status: true, firstName: true } },
       },
     });
     if (!policy) {
@@ -118,31 +144,1242 @@ export class PolicyLifecycleService {
     }
   }
 
+  /**
+   * Shared gate: policy must not become Active after end date, or from terminal statuses.
+   * Used by admin activate and payment restore paths.
+   */
+  private assertPolicyMayBecomeActive(policy: {
+    status: PolicyStatus;
+    endDate: Date | null;
+  }): void {
+    assertPolicyMayBecomeActive(policy);
+  }
+
+  /**
+   * Pending-activation D3/D7 reminders for policies still unpaid (callable from daily job stub).
+   */
+  async evaluatePendingActivationReminders(
+    asOfUtc: Date = new Date(),
+    correlationId: string
+  ): Promise<number> {
+    const pending = await this.prisma.policy.findMany({
+      where: { status: PolicyStatus.PENDING_ACTIVATION },
+      select: {
+        id: true,
+        createdAt: true,
+        productName: true,
+        customerId: true,
+        customer: { select: { firstName: true } },
+        policyPayments: {
+          where: {
+            paymentStatus: { in: CONFIRMED_PAYMENT_STATUSES },
+            actualPaymentDate: { not: null },
+          },
+          take: 1,
+          select: { id: true },
+        },
+      },
+    });
+
+    let queued = 0;
+    for (const policy of pending) {
+      if (policy.policyPayments.length > 0) {
+        continue;
+      }
+
+      const daysSinceCreation = utcCalendarDaysBetween(policy.createdAt, asOfUtc);
+      const placeholders = await this.lifecycleMessaging.buildPendingReminderPlaceholders({
+        firstName: policy.customer.firstName ?? '',
+        productName: policy.productName ?? '',
+      });
+
+      if (daysSinceCreation >= 3) {
+        const sent = await this.lifecycleMessaging.enqueueLifecycleNotification({
+          policyId: policy.id,
+          customerId: policy.customerId,
+          scheduleKey: PENDING_ACTIVATION_SCHEDULE.D3,
+          templateKey: PENDING_ACTIVATION_TEMPLATE.D3,
+          placeholderValues: placeholders,
+          correlationId,
+          metadata: { daysSinceCreation },
+        });
+        if (sent) queued += 1;
+      }
+
+      if (daysSinceCreation >= 7) {
+        const sent = await this.lifecycleMessaging.enqueueLifecycleNotification({
+          policyId: policy.id,
+          customerId: policy.customerId,
+          scheduleKey: PENDING_ACTIVATION_SCHEDULE.D7,
+          templateKey: PENDING_ACTIVATION_TEMPLATE.D7,
+          placeholderValues: placeholders,
+          correlationId,
+          metadata: { daysSinceCreation },
+        });
+        if (sent) queued += 1;
+      }
+    }
+
+    this.logger.log(
+      `[${correlationId}] Pending-activation reminder eval: ${queued} queued (${pending.length} pending policies)`
+    );
+    return queued;
+  }
+
+  /**
+   * Skip remaining pending-activation reminders after first payment activates the policy.
+   */
+  async suppressPendingActivationRemindersOnActivation(
+    policyId: string,
+    correlationId: string,
+    tx?: Prisma.TransactionClient
+  ): Promise<void> {
+    await this.lifecycleMessaging.suppressPendingActivationReminders(
+      policyId,
+      correlationId,
+      tx
+    );
+  }
+
+  /**
+   * Enter / update / clear grace overlay for Active policies (overdue 1–14 days).
+   * Does not suspend (US3) or expire (US4).
+   */
+  async evaluateGraceForActivePolicies(
+    asOfUtc: Date = new Date(),
+    correlationId: string
+  ): Promise<{ graceEntered: number; graceCleared: number; notificationsQueued: number }> {
+    const policies = await this.prisma.policy.findMany({
+      where: {
+        status: PolicyStatus.ACTIVE,
+        startDate: { not: null },
+      },
+      select: {
+        id: true,
+        customerId: true,
+        productName: true,
+        premium: true,
+        paymentCadence: true,
+        startDate: true,
+        endDate: true,
+        inGracePeriod: true,
+        overdueAnchorDueDate: true,
+        customer: { select: { firstName: true } },
+        policyPayments: {
+          select: {
+            amount: true,
+            paymentStatus: true,
+            expectedPaymentDate: true,
+          },
+        },
+      },
+    });
+
+    let graceEntered = 0;
+    let graceCleared = 0;
+    let notificationsQueued = 0;
+
+    for (const policy of policies) {
+      if (!policy.startDate) continue;
+      if (isPolicyEndDatePassed(policy.endDate, asOfUtc)) continue;
+
+      const installmentAmount = Number(policy.premium);
+      if (policy.paymentCadence <= 0 || installmentAmount <= 0) continue;
+
+      const policyStartDay = utcDayStart(
+        policy.startDate.getUTCFullYear(),
+        policy.startDate.getUTCMonth(),
+        policy.startDate.getUTCDate()
+      );
+      const asOfEnd = utcDayEnd(
+        asOfUtc.getUTCFullYear(),
+        asOfUtc.getUTCMonth(),
+        asOfUtc.getUTCDate()
+      );
+      const paidThroughAsOf = sumConfirmedPaidThroughAsOf(
+        policy.policyPayments,
+        policyStartDay,
+        asOfEnd,
+        CONFIRMED_PAYMENT_STATUSES
+      );
+
+      const nextDue = nextUnpaidExpectedDueDate({
+        policyStart: policy.startDate,
+        paymentCadenceDays: policy.paymentCadence,
+        installmentAmount,
+        paidThroughAsOf,
+        asOfUtc,
+      });
+      const overdue = daysOverdue({ nextUnpaidDueDate: nextDue, asOfUtc });
+      const arrears = outstandingArrears({
+        policyStart: policy.startDate,
+        paymentCadenceDays: policy.paymentCadence,
+        installmentAmount,
+        paidThroughAsOf,
+        asOfUtc,
+      });
+
+      // Fully current or not yet overdue → clear grace if set
+      if (overdue < 1 || arrears <= 0) {
+        if (policy.inGracePeriod) {
+          await this.clearGraceOverlay(policy, correlationId);
+          graceCleared += 1;
+        }
+        continue;
+      }
+
+      // Overdue >14 → leave for suspend evaluation (US3)
+      if (overdue > 14) {
+        continue;
+      }
+
+      // Overdue 1–14 → ensure grace overlay
+      const entered = await this.ensureGraceOverlay({
+        policy,
+        nextDue,
+        overdue,
+        arrears,
+        correlationId,
+        asOfUtc,
+      });
+      if (entered) graceEntered += 1;
+
+      const placeholders = await this.lifecycleMessaging.buildGraceReminderPlaceholders({
+        firstName: policy.customer.firstName ?? '',
+        productName: policy.productName ?? '',
+        arrears,
+        dueDate: nextDue,
+      });
+
+      const schedulePoints: Array<{ minDays: number; scheduleKey: string; templateKey: string }> = [
+        { minDays: 1, scheduleKey: GRACE_SCHEDULE.DUE, templateKey: GRACE_TEMPLATE.DUE },
+        { minDays: 7, scheduleKey: GRACE_SCHEDULE.D7, templateKey: GRACE_TEMPLATE.D7 },
+        { minDays: 10, scheduleKey: GRACE_SCHEDULE.D10, templateKey: GRACE_TEMPLATE.D10 },
+        { minDays: 13, scheduleKey: GRACE_SCHEDULE.D13, templateKey: GRACE_TEMPLATE.D13 },
+      ];
+
+      for (const point of schedulePoints) {
+        if (overdue < point.minDays) continue;
+        const sent = await this.lifecycleMessaging.enqueueLifecycleNotification({
+          policyId: policy.id,
+          customerId: policy.customerId,
+          scheduleKey: point.scheduleKey,
+          templateKey: point.templateKey,
+          placeholderValues: placeholders,
+          correlationId,
+          metadata: { overdueDays: overdue, anchorDueDate: nextDue.toISOString(), arrears },
+        });
+        if (sent) notificationsQueued += 1;
+      }
+    }
+
+    this.logger.log(
+      `[${correlationId}] Grace eval: entered=${graceEntered} cleared=${graceCleared} sms=${notificationsQueued}`
+    );
+    return { graceEntered, graceCleared, notificationsQueued };
+  }
+
+  private async ensureGraceOverlay(params: {
+    policy: {
+      id: string;
+      customerId: string;
+      inGracePeriod: boolean;
+      overdueAnchorDueDate: Date | null;
+    };
+    nextDue: Date;
+    overdue: number;
+    arrears: number;
+    correlationId: string;
+    asOfUtc: Date;
+  }): Promise<boolean> {
+    const { policy, nextDue, overdue, arrears, correlationId, asOfUtc } = params;
+    if (policy.inGracePeriod) {
+      // Update anchor if the unpaid slot moved earlier
+      if (
+        policy.overdueAnchorDueDate == null ||
+        nextDue.getTime() < policy.overdueAnchorDueDate.getTime()
+      ) {
+        await this.prisma.policy.update({
+          where: { id: policy.id },
+          data: { overdueAnchorDueDate: nextDue },
+        });
+      }
+      return false;
+    }
+
+    await this.prisma.$transaction(async (tx) => {
+      await this.statusChangeService.recordGraceEnter({
+        customerId: policy.customerId,
+        policyId: policy.id,
+        reason: `Premium overdue ${overdue} day(s); entered grace`,
+        trigger: StatusChangeTrigger.SYSTEM,
+        changedBy: LIFECYCLE_SYSTEM_ACTOR_ID,
+        correlationId,
+        metadata: {
+          overdueDays: overdue,
+          anchorDueDate: nextDue.toISOString(),
+          arrears,
+        },
+        tx,
+      });
+
+      await tx.policy.update({
+        where: { id: policy.id },
+        data: {
+          inGracePeriod: true,
+          graceEnteredAt: asOfUtc,
+          overdueAnchorDueDate: nextDue,
+        },
+      });
+    });
+
+    return true;
+  }
+
+  async clearGraceOverlay(
+    policy: { id: string; customerId: string; inGracePeriod: boolean },
+    correlationId: string,
+    trigger: StatusChangeTrigger = StatusChangeTrigger.SYSTEM,
+    changedBy: string = LIFECYCLE_SYSTEM_ACTOR_ID,
+    tx?: Prisma.TransactionClient
+  ): Promise<void> {
+    if (!policy.inGracePeriod) return;
+
+    const run = async (client: Prisma.TransactionClient) => {
+      await this.statusChangeService.recordGraceExit({
+        customerId: policy.customerId,
+        policyId: policy.id,
+        reason: 'Grace period cleared',
+        trigger,
+        changedBy,
+        correlationId,
+        tx: client,
+      });
+      await client.policy.update({
+        where: { id: policy.id },
+        data: {
+          inGracePeriod: false,
+          graceEnteredAt: null,
+          overdueAnchorDueDate: null,
+        },
+      });
+    };
+
+    if (tx) {
+      await run(tx);
+    } else {
+      await this.prisma.$transaction(run);
+    }
+  }
+
+  /**
+   * Active/Grace overdue &gt;14 days → Suspended (before end date).
+   */
+  async evaluateSuspendForActivePolicies(
+    asOfUtc: Date = new Date(),
+    correlationId: string
+  ): Promise<{ suspended: number; notificationsQueued: number }> {
+    const policies = await this.prisma.policy.findMany({
+      where: {
+        status: PolicyStatus.ACTIVE,
+        startDate: { not: null },
+      },
+      select: {
+        id: true,
+        customerId: true,
+        productName: true,
+        premium: true,
+        paymentCadence: true,
+        startDate: true,
+        endDate: true,
+        inGracePeriod: true,
+        customer: { select: { firstName: true } },
+        policyPayments: {
+          select: {
+            amount: true,
+            paymentStatus: true,
+            expectedPaymentDate: true,
+          },
+        },
+      },
+    });
+
+    let suspended = 0;
+    let notificationsQueued = 0;
+
+    for (const policy of policies) {
+      if (!policy.startDate) continue;
+      if (isPolicyEndDatePassed(policy.endDate, asOfUtc)) continue;
+
+      const installmentAmount = Number(policy.premium);
+      if (policy.paymentCadence <= 0 || installmentAmount <= 0) continue;
+
+      const paidThroughAsOf = this.paidThroughAsOf(
+        policy.startDate,
+        policy.policyPayments,
+        asOfUtc
+      );
+      const nextDue = nextUnpaidExpectedDueDate({
+        policyStart: policy.startDate,
+        paymentCadenceDays: policy.paymentCadence,
+        installmentAmount,
+        paidThroughAsOf,
+        asOfUtc,
+      });
+      const overdue = daysOverdue({ nextUnpaidDueDate: nextDue, asOfUtc });
+      if (overdue <= 14) continue;
+
+      const arrears = outstandingArrears({
+        policyStart: policy.startDate,
+        paymentCadenceDays: policy.paymentCadence,
+        installmentAmount,
+        paidThroughAsOf,
+        asOfUtc,
+      });
+
+      await this.prisma.$transaction(async (tx) => {
+        if (policy.inGracePeriod) {
+          await this.statusChangeService.recordGraceExit({
+            customerId: policy.customerId,
+            policyId: policy.id,
+            reason: 'Grace ended; suspending for overdue >14 days',
+            trigger: StatusChangeTrigger.SYSTEM,
+            changedBy: LIFECYCLE_SYSTEM_ACTOR_ID,
+            correlationId,
+            toStatus: PolicyStatus.SUSPENDED,
+            tx,
+          });
+        }
+
+        await this.statusChangeService.recordPolicyChange({
+          customerId: policy.customerId,
+          policyId: policy.id,
+          fromStatus: PolicyStatus.ACTIVE,
+          toStatus: PolicyStatus.SUSPENDED,
+          reason: `Premium overdue ${overdue} days; suspended`,
+          trigger: StatusChangeTrigger.SYSTEM,
+          changedBy: LIFECYCLE_SYSTEM_ACTOR_ID,
+          correlationId,
+          metadata: { overdueDays: overdue, arrears, anchorDueDate: nextDue.toISOString() },
+          tx,
+        });
+
+        await tx.policy.update({
+          where: { id: policy.id },
+          data: {
+            status: PolicyStatus.SUSPENDED,
+            suspendedAt: asOfUtc,
+            inGracePeriod: false,
+            graceEnteredAt: null,
+            overdueAnchorDueDate: null,
+          },
+        });
+
+        await this.syncCustomerStatusAfterPolicyChange(
+          policy.customerId,
+          LIFECYCLE_SYSTEM_ACTOR_ID,
+          correlationId,
+          tx
+        );
+      });
+
+      suspended += 1;
+
+      const placeholders = await this.lifecycleMessaging.buildGraceReminderPlaceholders({
+        firstName: policy.customer.firstName ?? '',
+        productName: policy.productName ?? '',
+        arrears,
+        dueDate: nextDue,
+      });
+      const sent = await this.lifecycleMessaging.enqueueLifecycleNotification({
+        policyId: policy.id,
+        customerId: policy.customerId,
+        scheduleKey: SUSPEND_SCHEDULE.D1,
+        templateKey: SUSPEND_TEMPLATE.NOTICE,
+        placeholderValues: placeholders,
+        correlationId,
+        metadata: { overdueDays: overdue, arrears },
+      });
+      if (sent) notificationsQueued += 1;
+    }
+
+    this.logger.log(`[${correlationId}] Suspend eval: suspended=${suspended} sms=${notificationsQueued}`);
+    return { suspended, notificationsQueued };
+  }
+
+  /**
+   * Suspended ≥30 days before end → Inactive.
+   */
+  async evaluateInactiveForSuspendedPolicies(
+    asOfUtc: Date = new Date(),
+    correlationId: string
+  ): Promise<{ inactivated: number; notificationsQueued: number }> {
+    const policies = await this.prisma.policy.findMany({
+      where: {
+        status: PolicyStatus.SUSPENDED,
+        suspendedAt: { not: null },
+      },
+      select: {
+        id: true,
+        customerId: true,
+        productName: true,
+        endDate: true,
+        suspendedAt: true,
+        customer: { select: { firstName: true } },
+      },
+    });
+
+    let inactivated = 0;
+    let notificationsQueued = 0;
+
+    for (const policy of policies) {
+      if (!policy.suspendedAt) continue;
+      if (isPolicyEndDatePassed(policy.endDate, asOfUtc)) continue;
+
+      const daysSuspended = utcCalendarDaysBetween(policy.suspendedAt, asOfUtc);
+      if (daysSuspended < 30) continue;
+
+      await this.prisma.$transaction(async (tx) => {
+        await this.statusChangeService.recordPolicyChange({
+          customerId: policy.customerId,
+          policyId: policy.id,
+          fromStatus: PolicyStatus.SUSPENDED,
+          toStatus: PolicyStatus.INACTIVE,
+          reason: `Suspended ${daysSuspended} days; inactivated before end date`,
+          trigger: StatusChangeTrigger.SYSTEM,
+          changedBy: LIFECYCLE_SYSTEM_ACTOR_ID,
+          correlationId,
+          metadata: { daysSuspended },
+          tx,
+        });
+        await tx.policy.update({
+          where: { id: policy.id },
+          data: {
+            status: PolicyStatus.INACTIVE,
+            inactivatedAt: asOfUtc,
+            suspendedAt: null,
+          },
+        });
+        await this.syncCustomerStatusAfterPolicyChange(
+          policy.customerId,
+          LIFECYCLE_SYSTEM_ACTOR_ID,
+          correlationId,
+          tx
+        );
+      });
+
+      inactivated += 1;
+      const placeholders = await this.lifecycleMessaging.buildPendingReminderPlaceholders({
+        firstName: policy.customer.firstName ?? '',
+        productName: policy.productName ?? '',
+      });
+      const sent = await this.lifecycleMessaging.enqueueLifecycleNotification({
+        policyId: policy.id,
+        customerId: policy.customerId,
+        scheduleKey: 'INACTIVE_NOTICE',
+        templateKey: 'policy_inactive',
+        placeholderValues: placeholders,
+        correlationId,
+      });
+      if (sent) notificationsQueued += 1;
+    }
+
+    this.logger.log(
+      `[${correlationId}] Inactive eval: inactivated=${inactivated} sms=${notificationsQueued}`
+    );
+    return { inactivated, notificationsQueued };
+  }
+
+  /**
+   * Term-end: Active/Grace → Expired; Inactive → Expired; Suspended unchanged.
+   */
+  async evaluateTermEndTransitions(
+    asOfUtc: Date = new Date(),
+    correlationId: string
+  ): Promise<{ expired: number }> {
+    const policies = await this.prisma.policy.findMany({
+      where: {
+        status: { in: [PolicyStatus.ACTIVE, PolicyStatus.INACTIVE] },
+        endDate: { not: null, lte: asOfUtc },
+      },
+      select: {
+        id: true,
+        customerId: true,
+        status: true,
+        inGracePeriod: true,
+        endDate: true,
+      },
+    });
+
+    let expired = 0;
+    for (const policy of policies) {
+      if (!isPolicyEndDatePassed(policy.endDate, asOfUtc)) continue;
+
+      await this.prisma.$transaction(async (tx) => {
+        if (policy.inGracePeriod) {
+          await this.statusChangeService.recordGraceExit({
+            customerId: policy.customerId,
+            policyId: policy.id,
+            reason: 'Grace cleared at term end → Expired',
+            trigger: StatusChangeTrigger.SYSTEM,
+            changedBy: LIFECYCLE_SYSTEM_ACTOR_ID,
+            correlationId,
+            toStatus: PolicyStatus.EXPIRED,
+            tx,
+          });
+        }
+        await this.statusChangeService.recordPolicyChange({
+          customerId: policy.customerId,
+          policyId: policy.id,
+          fromStatus: policy.status,
+          toStatus: PolicyStatus.EXPIRED,
+          reason: 'Policy end date passed',
+          trigger: StatusChangeTrigger.SYSTEM,
+          changedBy: LIFECYCLE_SYSTEM_ACTOR_ID,
+          correlationId,
+          tx,
+        });
+        await tx.policy.update({
+          where: { id: policy.id },
+          data: {
+            status: PolicyStatus.EXPIRED,
+            expiredAt: asOfUtc,
+            inGracePeriod: false,
+            graceEnteredAt: null,
+            overdueAnchorDueDate: null,
+          },
+        });
+        await this.syncCustomerStatusAfterPolicyChange(
+          policy.customerId,
+          LIFECYCLE_SYSTEM_ACTOR_ID,
+          correlationId,
+          tx
+        );
+      });
+      expired += 1;
+    }
+
+    this.logger.log(`[${correlationId}] Term-end eval: expired=${expired}`);
+    return { expired };
+  }
+
+  /**
+   * Renewal reminder schedule points before/after expiry (ledger-deduped).
+   * Before: 30/14/7/3 days and ~24h. After: 1/3/7/14/30 days.
+   */
+  async evaluateRenewalReminders(
+    asOfUtc: Date = new Date(),
+    correlationId: string
+  ): Promise<number> {
+    const policies = await this.prisma.policy.findMany({
+      where: {
+        endDate: { not: null },
+        status: {
+          in: [
+            PolicyStatus.ACTIVE,
+            PolicyStatus.SUSPENDED,
+            PolicyStatus.INACTIVE,
+            PolicyStatus.EXPIRED,
+          ],
+        },
+      },
+      select: {
+        id: true,
+        customerId: true,
+        productName: true,
+        endDate: true,
+        status: true,
+        customer: { select: { firstName: true } },
+      },
+    });
+
+    const beforePoints = [
+      { days: 30, key: 'RENEWAL_BEFORE_30', message: 'expires in 30 days' },
+      { days: 14, key: 'RENEWAL_BEFORE_14', message: 'expires in 14 days' },
+      { days: 7, key: 'RENEWAL_BEFORE_7', message: 'expires in 7 days' },
+      { days: 3, key: 'RENEWAL_BEFORE_3', message: 'expires in 3 days' },
+      { days: 1, key: 'RENEWAL_BEFORE_1', message: 'expires within 24 hours' },
+    ];
+    const afterPoints = [
+      { days: 1, key: 'RENEWAL_AFTER_1', message: 'expired yesterday — renew now' },
+      { days: 3, key: 'RENEWAL_AFTER_3', message: 'expired 3 days ago — renew now' },
+      { days: 7, key: 'RENEWAL_AFTER_7', message: 'expired 7 days ago — renew now' },
+      { days: 14, key: 'RENEWAL_AFTER_14', message: 'expired 14 days ago — renew now' },
+      { days: 30, key: 'RENEWAL_AFTER_30', message: 'expired 30 days ago — renew now' },
+    ];
+
+    let queued = 0;
+    for (const policy of policies) {
+      if (!policy.endDate) continue;
+      // Skip DEACTIVATED/TERMINATED via query; freeze Suspended past end for inactive only —
+      // renewal reminders still allowed for Suspended/Expired past end.
+      const daysToEnd = utcCalendarDaysBetween(asOfUtc, policy.endDate);
+      const daysAfterEnd = utcCalendarDaysBetween(policy.endDate, asOfUtc);
+
+      const settings = await this.systemSettingsPlaceholders(policy);
+
+      if (daysToEnd >= 0) {
+        for (const point of beforePoints) {
+          if (daysToEnd === point.days) {
+            const sent = await this.lifecycleMessaging.enqueueLifecycleNotification({
+              policyId: policy.id,
+              customerId: policy.customerId,
+              scheduleKey: point.key,
+              templateKey: 'renewal_reminder',
+              placeholderValues: {
+                ...settings,
+                renewal_message: point.message,
+              },
+              correlationId,
+              metadata: { daysToEnd },
+            });
+            if (sent) queued += 1;
+          }
+        }
+      } else {
+        for (const point of afterPoints) {
+          if (daysAfterEnd === point.days) {
+            const sent = await this.lifecycleMessaging.enqueueLifecycleNotification({
+              policyId: policy.id,
+              customerId: policy.customerId,
+              scheduleKey: point.key,
+              templateKey: 'renewal_reminder',
+              placeholderValues: {
+                ...settings,
+                renewal_message: point.message,
+              },
+              correlationId,
+              metadata: { daysAfterEnd },
+            });
+            if (sent) queued += 1;
+          }
+        }
+      }
+    }
+
+    this.logger.log(`[${correlationId}] Renewal reminder eval: queued=${queued}`);
+    return queued;
+  }
+
+  private async systemSettingsPlaceholders(policy: {
+    customer: { firstName: string | null };
+    productName: string;
+  }): Promise<Record<string, string>> {
+    return this.lifecycleMessaging.buildPendingReminderPlaceholders({
+      firstName: policy.customer.firstName ?? '',
+      productName: policy.productName ?? '',
+    });
+  }
+
+  /**
+   * Create a new Active renewal policy from a finished-cycle prior policy.
+   */
+  async renewPolicyFromPrior(
+    priorPolicyId: string,
+    paymentDate: Date,
+    correlationId: string
+  ): Promise<{ newPolicyId: string }> {
+    const prior = await this.prisma.policy.findUniqueOrThrow({
+      where: { id: priorPolicyId },
+      include: { customer: { select: { firstName: true } } },
+    });
+    if (!prior.endDate) {
+      throw ValidationException.forField('endDate', 'Prior policy must have an end date to renew');
+    }
+
+    const daysAfterEnd = utcCalendarDaysBetween(prior.endDate, paymentDate);
+    const within30 = daysAfterEnd <= 30;
+    const startDate = within30
+      ? addUtcCalendarDays(prior.endDate, 1)
+      : new Date(paymentDate);
+    const endDate = policyEndDateFromStart(startDate);
+
+    const newPolicy = await this.prisma.$transaction(async (tx) => {
+      const paymentAcNumber = prior.paymentAcNumber;
+      if (paymentAcNumber) {
+        await tx.policy.update({
+          where: { id: prior.id },
+          data: { paymentAcNumber: null },
+        });
+      }
+
+      const policyNumber = await this.policyService.generatePolicyNumberForPackage(
+        prior.packageId,
+        tx,
+        correlationId
+      );
+
+      const created = await tx.policy.create({
+        data: {
+          customerId: prior.customerId,
+          packageId: prior.packageId,
+          packagePlanId: prior.packagePlanId,
+          productName: prior.productName,
+          premium: prior.premium,
+          frequency: prior.frequency,
+          paymentCadence: prior.paymentCadence,
+          paymentAcNumber,
+          policyNumber,
+          status: PolicyStatus.ACTIVE,
+          startDate,
+          endDate,
+          supersedesPolicyId: prior.id,
+        },
+      });
+
+      await tx.policy.update({
+        where: { id: prior.id },
+        data: {
+          supersededByPolicyId: created.id,
+          ...(prior.status === PolicyStatus.SUSPENDED || prior.status === PolicyStatus.INACTIVE
+            ? { status: PolicyStatus.EXPIRED, expiredAt: paymentDate, suspendedAt: null }
+            : {}),
+        },
+      });
+
+      if (prior.status === PolicyStatus.SUSPENDED || prior.status === PolicyStatus.INACTIVE) {
+        await this.statusChangeService.recordPolicyChange({
+          customerId: prior.customerId,
+          policyId: prior.id,
+          fromStatus: prior.status,
+          toStatus: PolicyStatus.EXPIRED,
+          reason: 'Prior policy expired on renewal after debt cleared',
+          trigger: StatusChangeTrigger.PAYMENT_LIFECYCLE,
+          changedBy: LIFECYCLE_SYSTEM_ACTOR_ID,
+          correlationId,
+          metadata: { newPolicyId: created.id },
+          tx,
+        });
+      }
+
+      await this.statusChangeService.recordPolicyChange({
+        customerId: prior.customerId,
+        policyId: created.id,
+        fromStatus: PolicyStatus.PENDING_ACTIVATION,
+        toStatus: PolicyStatus.ACTIVE,
+        reason: within30
+          ? 'Renewal within 30 days of expiry'
+          : 'Renewal more than 30 days after expiry',
+        trigger: StatusChangeTrigger.PAYMENT_LIFECYCLE,
+        changedBy: LIFECYCLE_SYSTEM_ACTOR_ID,
+        correlationId,
+        metadata: {
+          priorPolicyId: prior.id,
+          within30,
+          startDate: startDate.toISOString(),
+        },
+        tx,
+      });
+
+      await this.syncCustomerStatusAfterPolicyChange(
+        prior.customerId,
+        LIFECYCLE_SYSTEM_ACTOR_ID,
+        correlationId,
+        tx
+      );
+
+      return created;
+    });
+
+    // Activate member records if needed (reuse existing principal when present)
+    try {
+      await this.policyService.activatePolicy(newPolicy.id, correlationId);
+    } catch (error) {
+      this.logger.warn(
+        `[${correlationId}] renewPolicyFromPrior activatePolicy note: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+
+    return { newPolicyId: newPolicy.id };
+  }
+
+  /**
+   * Payment-driven lifecycle: clear grace, restore Suspended/Inactive before end, or
+   * expire Suspended when debt cleared after end (surplus renew deferred to US4).
+   */
+  async applyPaymentToPolicyLifecycle(
+    policyId: string,
+    correlationId: string,
+    options?: { requireFullRestore?: boolean }
+  ): Promise<{ action: string }> {
+    const policy = await this.prisma.policy.findUnique({
+      where: { id: policyId },
+      include: {
+        customer: { select: { firstName: true } },
+        policyPayments: {
+          select: {
+            amount: true,
+            paymentStatus: true,
+            expectedPaymentDate: true,
+          },
+        },
+      },
+    });
+    if (!policy || !policy.startDate) {
+      return { action: 'noop' };
+    }
+    if (
+      policy.status === PolicyStatus.DEACTIVATED ||
+      policy.status === PolicyStatus.TERMINATED ||
+      policy.status === PolicyStatus.PENDING_ACTIVATION
+    ) {
+      return { action: 'noop' };
+    }
+
+    const asOfUtc = new Date();
+    const installmentAmount = Number(policy.premium);
+    const paidThroughAsOf = this.paidThroughAsOf(
+      policy.startDate,
+      policy.policyPayments,
+      asOfUtc
+    );
+    const arrears = outstandingArrears({
+      policyStart: policy.startDate,
+      paymentCadenceDays: policy.paymentCadence,
+      installmentAmount,
+      paidThroughAsOf,
+      asOfUtc,
+    });
+    const endPassed = isPolicyEndDatePassed(policy.endDate, asOfUtc);
+
+    // Active + grace: clear when current
+    if (policy.status === PolicyStatus.ACTIVE && policy.inGracePeriod && arrears <= 0) {
+      await this.clearGraceOverlay(
+        policy,
+        correlationId,
+        StatusChangeTrigger.PAYMENT_LIFECYCLE,
+        LIFECYCLE_SYSTEM_ACTOR_ID
+      );
+      return { action: 'grace_cleared' };
+    }
+
+    if (policy.status === PolicyStatus.SUSPENDED) {
+      if (endPassed) {
+        if (arrears <= 0) {
+          await this.expirePolicyFromSuspended(policy, correlationId, asOfUtc);
+          const surplus = this.estimatePostEndSurplus(
+            policy,
+            paidThroughAsOf,
+            installmentAmount,
+            asOfUtc
+          );
+          if (surplus > 0) {
+            const { newPolicyId } = await this.renewPolicyFromPrior(
+              policy.id,
+              asOfUtc,
+              correlationId
+            );
+            return { action: `expired_and_renewed:${newPolicyId}` };
+          }
+          return { action: 'expired_after_debt_cleared' };
+        }
+        return { action: 'debt_only_post_end' };
+      }
+
+      const required = amountRequiredToRestoreSuspended({
+        paymentCadenceDays: policy.paymentCadence,
+        installmentAmount,
+        arrears,
+      });
+      const twoWeek = amountRequiredToRestoreSuspended({
+        paymentCadenceDays: policy.paymentCadence,
+        installmentAmount,
+        arrears: 0,
+      });
+      const { expectedPremium } = computeExpectedPremiumThroughAsOf({
+        policyStart: policy.startDate,
+        statementGenerationUtc: asOfUtc,
+        paymentCadenceDays: policy.paymentCadence,
+        installmentAmount,
+      });
+      const coverageNeeded = expectedPremium + twoWeek;
+      const canRestore = paidThroughAsOf >= coverageNeeded;
+
+      if (!canRestore) {
+        if (options?.requireFullRestore) {
+          throw ValidationException.forField(
+            'amount',
+            `Insufficient payment to restore. Required at least ${required.toFixed(2)} (arrears + 2 weeks upfront)`
+          );
+        }
+        return { action: 'insufficient_restore' };
+      }
+
+      await this.restorePolicyToActive(policy, correlationId, asOfUtc);
+      return { action: 'restored_active' };
+    }
+
+    if (policy.status === PolicyStatus.INACTIVE) {
+      if (endPassed) {
+        await this.expirePolicyFromSuspended(
+          { ...policy, status: PolicyStatus.INACTIVE },
+          correlationId,
+          asOfUtc
+        );
+        const surplus = this.estimatePostEndSurplus(
+          policy,
+          paidThroughAsOf,
+          installmentAmount,
+          asOfUtc
+        );
+        if (surplus > 0 || arrears <= 0) {
+          const { newPolicyId } = await this.renewPolicyFromPrior(
+            policy.id,
+            asOfUtc,
+            correlationId
+          );
+          return { action: `inactive_expired_renewed:${newPolicyId}` };
+        }
+        return { action: 'inactive_expired' };
+      }
+
+      const daysSinceInactive = policy.inactivatedAt
+        ? utcCalendarDaysBetween(policy.inactivatedAt, asOfUtc)
+        : 0;
+      const required = amountRequiredToRestoreInactive({
+        paymentCadenceDays: policy.paymentCadence,
+        installmentAmount,
+        arrears,
+        daysSinceInactive,
+      });
+      const { expectedPremium } = computeExpectedPremiumThroughAsOf({
+        policyStart: policy.startDate,
+        statementGenerationUtc: asOfUtc,
+        paymentCadenceDays: policy.paymentCadence,
+        installmentAmount,
+      });
+      const oneMonth = amountRequiredToRestoreInactive({
+        paymentCadenceDays: policy.paymentCadence,
+        installmentAmount,
+        arrears: 0,
+        daysSinceInactive: 31,
+      });
+      const inactiveCanRestore =
+        daysSinceInactive <= 30
+          ? paidThroughAsOf >=
+            expectedPremium +
+              amountRequiredToRestoreSuspended({
+                paymentCadenceDays: policy.paymentCadence,
+                installmentAmount,
+                arrears: 0,
+              })
+          : paidThroughAsOf >= oneMonth;
+
+      if (!inactiveCanRestore) {
+        if (options?.requireFullRestore) {
+          throw ValidationException.forField(
+            'amount',
+            `Insufficient payment to restore inactive policy. Required at least ${required.toFixed(2)}`
+          );
+        }
+        return { action: 'insufficient_inactive_restore' };
+      }
+
+      await this.restorePolicyToActive(policy, correlationId, asOfUtc);
+      return { action: 'inactive_restored_active' };
+    }
+
+    if (policy.status === PolicyStatus.EXPIRED && endPassed) {
+      const { newPolicyId } = await this.renewPolicyFromPrior(
+        policy.id,
+        asOfUtc,
+        correlationId
+      );
+      return { action: `renewed_from_expired:${newPolicyId}` };
+    }
+
+    return { action: 'noop' };
+  }
+
+  /** Approximate surplus after clearing post-end debt using latest confirmed payment. */
+  private estimatePostEndSurplus(
+    policy: {
+      startDate: Date | null;
+      paymentCadence: number;
+      policyPayments: Array<{
+        amount: unknown;
+        paymentStatus: string;
+        expectedPaymentDate: Date;
+      }>;
+    },
+    paidThroughAsOf: number,
+    installmentAmount: number,
+    asOfUtc: Date
+  ): number {
+    if (!policy.startDate) return 0;
+    const confirmed = policy.policyPayments
+      .filter((p) => CONFIRMED_PAYMENT_STATUSES.includes(p.paymentStatus as PaymentStatus))
+      .sort((a, b) => b.expectedPaymentDate.getTime() - a.expectedPaymentDate.getTime());
+    if (confirmed.length === 0) return 0;
+    const lastAmt = Number(confirmed[0].amount);
+    const paidWithoutLast = Math.max(0, paidThroughAsOf - lastAmt);
+    const arrearsWithoutLast = outstandingArrears({
+      policyStart: policy.startDate,
+      paymentCadenceDays: policy.paymentCadence,
+      installmentAmount,
+      paidThroughAsOf: paidWithoutLast,
+      asOfUtc,
+    });
+    return Math.max(0, lastAmt - arrearsWithoutLast);
+  }
+
+  private paidThroughAsOf(
+    startDate: Date,
+    payments: Array<{ amount: unknown; paymentStatus: string; expectedPaymentDate: Date }>,
+    asOfUtc: Date
+  ): number {
+    const policyStartDay = utcDayStart(
+      startDate.getUTCFullYear(),
+      startDate.getUTCMonth(),
+      startDate.getUTCDate()
+    );
+    const asOfEnd = utcDayEnd(
+      asOfUtc.getUTCFullYear(),
+      asOfUtc.getUTCMonth(),
+      asOfUtc.getUTCDate()
+    );
+    return sumConfirmedPaidThroughAsOf(
+      payments,
+      policyStartDay,
+      asOfEnd,
+      CONFIRMED_PAYMENT_STATUSES
+    );
+  }
+
+  private async restorePolicyToActive(
+    policy: {
+      id: string;
+      customerId: string;
+      status: PolicyStatus;
+      endDate: Date | null;
+      productName: string;
+      customer: { firstName: string | null };
+    },
+    correlationId: string,
+    asOfUtc: Date
+  ): Promise<void> {
+    assertPolicyMayBecomeActive(policy);
+
+    await this.prisma.$transaction(async (tx) => {
+      await this.statusChangeService.recordPolicyChange({
+        customerId: policy.customerId,
+        policyId: policy.id,
+        fromStatus: policy.status,
+        toStatus: PolicyStatus.ACTIVE,
+        reason: 'Restored to Active after sufficient payment',
+        trigger: StatusChangeTrigger.PAYMENT_LIFECYCLE,
+        changedBy: LIFECYCLE_SYSTEM_ACTOR_ID,
+        correlationId,
+        tx,
+      });
+
+      await tx.policy.update({
+        where: { id: policy.id },
+        data: {
+          status: PolicyStatus.ACTIVE,
+          suspendedAt: null,
+          inactivatedAt: null,
+          inGracePeriod: false,
+          graceEnteredAt: null,
+          overdueAnchorDueDate: null,
+          deactivatedAt: null,
+        },
+      });
+
+      await this.syncCustomerStatusAfterPolicyChange(
+        policy.customerId,
+        LIFECYCLE_SYSTEM_ACTOR_ID,
+        correlationId,
+        tx
+      );
+    });
+
+    const settings = await this.lifecycleMessaging.buildPendingReminderPlaceholders({
+      firstName: policy.customer.firstName ?? '',
+      productName: policy.productName ?? '',
+    });
+    await this.lifecycleMessaging.enqueueLifecycleNotification({
+      policyId: policy.id,
+      customerId: policy.customerId,
+      scheduleKey: `REACTIVATE_${asOfUtc.toISOString().slice(0, 10)}`,
+      templateKey: SUSPEND_TEMPLATE.REACTIVATE,
+      placeholderValues: settings,
+      correlationId,
+    });
+  }
+
+  private async expirePolicyFromSuspended(
+    policy: { id: string; customerId: string; status: PolicyStatus },
+    correlationId: string,
+    asOfUtc: Date
+  ): Promise<void> {
+    await this.prisma.$transaction(async (tx) => {
+      await this.statusChangeService.recordPolicyChange({
+        customerId: policy.customerId,
+        policyId: policy.id,
+        fromStatus: policy.status,
+        toStatus: PolicyStatus.EXPIRED,
+        reason: 'Suspended past end date; debt cleared → Expired',
+        trigger: StatusChangeTrigger.PAYMENT_LIFECYCLE,
+        changedBy: LIFECYCLE_SYSTEM_ACTOR_ID,
+        correlationId,
+        tx,
+      });
+      await tx.policy.update({
+        where: { id: policy.id },
+        data: {
+          status: PolicyStatus.EXPIRED,
+          expiredAt: asOfUtc,
+          suspendedAt: null,
+        },
+      });
+      await this.syncCustomerStatusAfterPolicyChange(
+        policy.customerId,
+        LIFECYCLE_SYSTEM_ACTOR_ID,
+        correlationId,
+        tx
+      );
+    });
+  }
+
   private async syncCustomerStatusAfterPolicyChange(
     customerId: string,
     changedBy: string,
     correlationId: string,
-    tx: Prisma.TransactionClient
+    tx: Prisma.TransactionClient,
+    options?: { whenNoOpenPolicies?: CustomerStatus }
   ): Promise<void> {
     const policies = await tx.policy.findMany({
       where: {
         customerId,
-        status: { notIn: [PolicyStatus.DEACTIVATED, PolicyStatus.TERMINATED, PolicyStatus.EXPIRED] },
+        status: {
+          in: [
+            PolicyStatus.ACTIVE,
+            PolicyStatus.PENDING_ACTIVATION,
+            PolicyStatus.SUSPENDED,
+          ],
+        },
       },
       select: { status: true },
     });
 
     const hasActive = policies.some((p) => p.status === PolicyStatus.ACTIVE);
     const hasPending = policies.some((p) => p.status === PolicyStatus.PENDING_ACTIVATION);
+    const hasSuspended = policies.some((p) => p.status === PolicyStatus.SUSPENDED);
 
     const customer = await tx.customer.findUnique({ where: { id: customerId } });
     if (!customer) return;
+
+    const closedStatus = options?.whenNoOpenPolicies ?? CustomerStatus.DEACTIVATED;
 
     let nextStatus: CustomerStatus | null = null;
     if (hasActive) {
       if (
         customer.status === CustomerStatus.DEACTIVATED ||
-        customer.status === CustomerStatus.SUSPENDED
+        customer.status === CustomerStatus.SUSPENDED ||
+        customer.status === CustomerStatus.TERMINATED
       ) {
         nextStatus = CustomerStatus.ACTIVE;
       }
@@ -150,8 +1387,12 @@ export class PolicyLifecycleService {
       if (customer.status !== CustomerStatus.PENDING_ACTIVATION) {
         nextStatus = CustomerStatus.PENDING_ACTIVATION;
       }
+    } else if (hasSuspended) {
+      if (customer.status !== CustomerStatus.SUSPENDED) {
+        nextStatus = CustomerStatus.SUSPENDED;
+      }
     } else {
-      nextStatus = CustomerStatus.DEACTIVATED;
+      nextStatus = closedStatus;
     }
 
     if (nextStatus == null || nextStatus === customer.status) {
@@ -174,9 +1415,90 @@ export class PolicyLifecycleService {
       where: { id: customerId },
       data: {
         status: nextStatus,
-        deactivatedAt: nextStatus === CustomerStatus.DEACTIVATED ? new Date() : null,
+        deactivatedAt:
+          nextStatus === CustomerStatus.DEACTIVATED ||
+          nextStatus === CustomerStatus.TERMINATED
+            ? new Date()
+            : null,
       },
     });
+  }
+
+  async terminatePolicy(
+    customerId: string,
+    policyId: string,
+    dto: TerminatePolicyRequestDto,
+    userId: string,
+    userRoles: string[],
+    correlationId: string
+  ): Promise<PolicyLifecycleResponseDto> {
+    this.assertAdmin(userRoles);
+    const source = await this.loadPolicyForCustomer(customerId, policyId);
+
+    if (source.status === PolicyStatus.TERMINATED) {
+      throw ValidationException.forField('status', 'Policy is already terminated');
+    }
+
+    const now = new Date();
+    const updated = await this.prisma.$transaction(async (tx) => {
+      await this.statusChangeService.recordPolicyChange({
+        customerId,
+        policyId,
+        fromStatus: source.status,
+        toStatus: PolicyStatus.TERMINATED,
+        reason: dto.reason,
+        trigger: StatusChangeTrigger.MANUAL_ADMIN,
+        changedBy: userId,
+        correlationId,
+        metadata: { operation: 'TERMINATE' },
+        tx,
+      });
+
+      const policy = await tx.policy.update({
+        where: { id: policyId },
+        data: {
+          status: PolicyStatus.TERMINATED,
+          inGracePeriod: false,
+          graceEnteredAt: null,
+          overdueAnchorDueDate: null,
+          suspendedAt: null,
+        },
+      });
+
+      await this.syncCustomerStatusAfterPolicyChange(
+        customerId,
+        userId,
+        correlationId,
+        tx,
+        { whenNoOpenPolicies: CustomerStatus.TERMINATED }
+      );
+      return policy;
+    });
+
+    const placeholders = await this.lifecycleMessaging.buildPendingReminderPlaceholders({
+      firstName: source.customer.firstName ?? '',
+      productName: source.productName ?? '',
+    });
+    await this.lifecycleMessaging.enqueueLifecycleNotification({
+      policyId,
+      customerId,
+      scheduleKey: `TERMINATE_${now.toISOString().slice(0, 10)}`,
+      templateKey: 'policy_terminated',
+      placeholderValues: placeholders,
+      correlationId,
+      metadata: { reason: dto.reason },
+    });
+
+    return {
+      status: 200,
+      correlationId,
+      message: 'Policy terminated successfully',
+      policy: {
+        id: updated.id,
+        policyNumber: updated.policyNumber,
+        status: updated.status,
+      },
+    };
   }
 
   async deactivatePolicy(
@@ -200,8 +1522,7 @@ export class PolicyLifecycleService {
 
     const now = new Date();
     const updated = await this.prisma.$transaction(async (tx) => {
-      await this.statusChangeService.record({
-        entityType: StatusChangeEntityType.POLICY,
+      await this.statusChangeService.recordPolicyChange({
         customerId,
         policyId,
         fromStatus: source.status,
@@ -215,7 +1536,13 @@ export class PolicyLifecycleService {
 
       const policy = await tx.policy.update({
         where: { id: policyId },
-        data: { status: PolicyStatus.DEACTIVATED, deactivatedAt: now },
+        data: {
+          status: PolicyStatus.DEACTIVATED,
+          deactivatedAt: now,
+          inGracePeriod: false,
+          graceEnteredAt: null,
+          overdueAnchorDueDate: null,
+        },
       });
 
       await this.syncCustomerStatusAfterPolicyChange(customerId, userId, correlationId, tx);
@@ -253,9 +1580,50 @@ export class PolicyLifecycleService {
       );
     }
 
+    this.assertPolicyMayBecomeActive(source);
+
+    const asOfUtc = new Date();
+    if (!source.startDate) {
+      throw ValidationException.forField('startDate', 'Policy start date is required to activate');
+    }
+    const payments = await this.prisma.policyPayment.findMany({
+      where: { policyId },
+      select: { amount: true, paymentStatus: true, expectedPaymentDate: true },
+    });
+    const installmentAmount = Number(source.premium);
+    const paidThroughAsOf = this.paidThroughAsOf(source.startDate, payments, asOfUtc);
+    const arrears = outstandingArrears({
+      policyStart: source.startDate,
+      paymentCadenceDays: source.paymentCadence,
+      installmentAmount,
+      paidThroughAsOf,
+      asOfUtc,
+    });
+    const twoWeek = amountRequiredToRestoreSuspended({
+      paymentCadenceDays: source.paymentCadence,
+      installmentAmount,
+      arrears: 0,
+    });
+    const { expectedPremium } = computeExpectedPremiumThroughAsOf({
+      policyStart: source.startDate,
+      statementGenerationUtc: asOfUtc,
+      paymentCadenceDays: source.paymentCadence,
+      installmentAmount,
+    });
+    if (paidThroughAsOf < expectedPremium + twoWeek) {
+      const required = amountRequiredToRestoreSuspended({
+        paymentCadenceDays: source.paymentCadence,
+        installmentAmount,
+        arrears,
+      });
+      throw ValidationException.forField(
+        'amount',
+        `Insufficient payment to restore. Required at least ${required.toFixed(2)} (arrears + 2 weeks upfront)`
+      );
+    }
+
     const updated = await this.prisma.$transaction(async (tx) => {
-      await this.statusChangeService.record({
-        entityType: StatusChangeEntityType.POLICY,
+      await this.statusChangeService.recordPolicyChange({
         customerId,
         policyId,
         fromStatus: source.status,
@@ -269,7 +1637,14 @@ export class PolicyLifecycleService {
 
       const policy = await tx.policy.update({
         where: { id: policyId },
-        data: { status: PolicyStatus.ACTIVE, deactivatedAt: null },
+        data: {
+          status: PolicyStatus.ACTIVE,
+          deactivatedAt: null,
+          suspendedAt: null,
+          inGracePeriod: false,
+          graceEnteredAt: null,
+          overdueAnchorDueDate: null,
+        },
       });
 
       await this.syncCustomerStatusAfterPolicyChange(customerId, userId, correlationId, tx);
@@ -315,8 +1690,7 @@ export class PolicyLifecycleService {
     const newEnd = policyEndDateFromStart(newStart);
 
     const updated = await this.prisma.$transaction(async (tx) => {
-      await this.statusChangeService.record({
-        entityType: StatusChangeEntityType.POLICY,
+      await this.statusChangeService.recordPolicyChange({
         customerId,
         policyId,
         fromStatus: source.status,
@@ -550,8 +1924,7 @@ export class PolicyLifecycleService {
       }
 
       // Deactivate source
-      await this.statusChangeService.record({
-        entityType: StatusChangeEntityType.POLICY,
+      await this.statusChangeService.recordPolicyChange({
         customerId,
         policyId,
         fromStatus: source.status,
@@ -655,8 +2028,7 @@ export class PolicyLifecycleService {
 
       const finalPolicy = await tx.policy.findUniqueOrThrow({ where: { id: newPolicy.id } });
 
-      await this.statusChangeService.record({
-        entityType: StatusChangeEntityType.POLICY,
+      await this.statusChangeService.recordPolicyChange({
         customerId,
         policyId: newPolicy.id,
         fromStatus: PolicyStatus.PENDING_ACTIVATION,

--- a/apps/api/src/services/policy-lifecycle.service.ts
+++ b/apps/api/src/services/policy-lifecycle.service.ts
@@ -27,6 +27,10 @@ import {
   computeInstallmentBackfillSlots,
 } from '../utils/installment-backfill.util';
 import {
+  getBasePolicyNumber,
+  nextDisabledPolicyNumber,
+} from '../utils/disabled-policy-number.util';
+import {
   deriveFamilyCategoryFromDependants,
   hasAdditionalSpousePremium,
 } from '../utils/family-category.util';
@@ -418,6 +422,7 @@ export class PolicyLifecycleService {
         amount: Number(p.amount),
         expectedPaymentDate: p.expectedPaymentDate.toISOString(),
         actualPaymentDate: p.actualPaymentDate?.toISOString(),
+        paymentStatus: p.paymentStatus,
       })),
       schemes: packageSchemes.map((ps) => ({
         packageSchemeId: ps.id,
@@ -526,6 +531,24 @@ export class PolicyLifecycleService {
     const now = new Date();
 
     const result = await this.prisma.$transaction(async (tx) => {
+      let releasedPolicyNumber: string | null = null;
+      let sourcePolicyNumberAfterDeactivate: string | null | undefined = source.policyNumber;
+
+      if (
+        dto.policyNumberChoice === PolicyNumberChoice.KEEP_EXISTING &&
+        source.policyNumber
+      ) {
+        releasedPolicyNumber = getBasePolicyNumber(source.policyNumber);
+        const existingNumbers = await tx.policy.findMany({
+          where: { policyNumber: { not: null } },
+          select: { policyNumber: true },
+        });
+        sourcePolicyNumberAfterDeactivate = nextDisabledPolicyNumber(
+          source.policyNumber,
+          existingNumbers.map((row) => row.policyNumber)
+        );
+      }
+
       // Deactivate source
       await this.statusChangeService.record({
         entityType: StatusChangeEntityType.POLICY,
@@ -546,6 +569,9 @@ export class PolicyLifecycleService {
           status: PolicyStatus.DEACTIVATED,
           deactivatedAt: now,
           paymentAcNumber: null,
+          ...(sourcePolicyNumberAfterDeactivate !== source.policyNumber
+            ? { policyNumber: sourcePolicyNumberAfterDeactivate }
+            : {}),
         },
       });
 
@@ -559,7 +585,7 @@ export class PolicyLifecycleService {
           correlationId
         );
       } else if (dto.policyNumberChoice === PolicyNumberChoice.KEEP_EXISTING) {
-        policyNumber = source.policyNumber;
+        policyNumber = releasedPolicyNumber;
       }
 
       const newPolicy = await tx.policy.create({

--- a/apps/api/src/services/policy.service.ts
+++ b/apps/api/src/services/policy.service.ts
@@ -208,6 +208,17 @@ export class PolicyService {
   }
 
   /**
+   * Public wrapper for transaction-safe policy number generation (e.g. modify-product).
+   */
+  async generatePolicyNumberForPackage(
+    packageId: number,
+    tx: Prisma.TransactionClient,
+    correlationId: string
+  ): Promise<string> {
+    return this.generatePolicyNumberInTransaction(packageId, tx, correlationId);
+  }
+
+  /**
    * Calculate payment cadence from frequency
    * @param frequency - Payment frequency
    * @param customDays - Custom days for CUSTOM frequency
@@ -374,18 +385,17 @@ export class PolicyService {
         );
       }
 
-      // Check if customer already has a policy for this package (one policy per customer per package)
-      const existingPolicyForPackage = await this.prismaService.policy.findUnique({
+      // At most one non-terminal policy per customer per package
+      const existingPolicyForPackage = await this.prismaService.policy.findFirst({
         where: {
-          customerId_packageId: {
-            customerId: data.customerId,
-            packageId: data.packageId,
-          },
+          customerId: data.customerId,
+          packageId: data.packageId,
+          status: { in: ['ACTIVE', 'PENDING_ACTIVATION', 'SUSPENDED'] },
         },
       });
       if (existingPolicyForPackage) {
         throw new ConflictException(
-          `Customer already has a policy for this package (policy ID: ${existingPolicyForPackage.id})`
+          `Customer already has an active policy for this package (policy ID: ${existingPolicyForPackage.id})`
         );
       }
 

--- a/apps/api/src/services/policy.service.ts
+++ b/apps/api/src/services/policy.service.ts
@@ -6,7 +6,9 @@ import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 import * as Sentry from '@sentry/nestjs';
 import { PaymentAccountNumberService } from './payment-account-number.service';
 import { PaymentMessagingService } from '../modules/messaging/payment-messaging.service';
+import { PolicyLifecycleMessagingService } from '../modules/messaging/policy-lifecycle-messaging.service';
 import { policyDatesFromPayment, policyEndDateFromStart } from '../utils/policy-dates.util';
+import { assertPolicyMayBecomeActive } from '../utils/policy-activation-gate.util';
 
 /**
  * Policy Service
@@ -28,6 +30,7 @@ export class PolicyService {
     private readonly prismaService: PrismaService,
     private readonly paymentAccountNumberService: PaymentAccountNumberService,
     private readonly paymentMessagingService: PaymentMessagingService,
+    private readonly lifecycleMessaging: PolicyLifecycleMessagingService,
   ) {}
 
   /**
@@ -1117,6 +1120,11 @@ export class PolicyService {
           throw new NotFoundException(`Policy with ID ${policyId} not found`);
         }
 
+        assertPolicyMayBecomeActive({
+          status: policy.status,
+          endDate: policy.endDate,
+        });
+
         // Resolve scheme by package (for this policy's package)
         const customerScheme = await txClient.packageSchemeCustomer.findFirst({
           where: {
@@ -1178,6 +1186,12 @@ export class PolicyService {
             where: { id: policyId },
             data: updateData,
           });
+
+          await this.lifecycleMessaging.suppressPendingActivationReminders(
+            policyId,
+            correlationId,
+            txClient
+          );
 
           return updatedPolicy;
         }
@@ -1316,6 +1330,12 @@ export class PolicyService {
         }
 
         this.logger.log(`[${correlationId}] Policy ${policyId} fully activated successfully`);
+
+        await this.lifecycleMessaging.suppressPendingActivationReminders(
+          policyId,
+          correlationId,
+          txClient
+        );
 
         return updatedPolicy;
       };

--- a/apps/api/src/services/postpaid-scheme-payment.service.ts
+++ b/apps/api/src/services/postpaid-scheme-payment.service.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { PolicyService } from './policy.service';
+import { PolicyLifecycleService } from './policy-lifecycle.service';
 import { PaymentMessagingService } from '../modules/messaging/payment-messaging.service';
 import { SupabaseService } from './supabase.service';
 import { PaymentType } from '@prisma/client';
@@ -55,6 +56,7 @@ export class PostpaidSchemePaymentService {
     private readonly policyService: PolicyService,
     private readonly supabase: SupabaseService,
     private readonly paymentMessagingService: PaymentMessagingService,
+    private readonly policyLifecycleService: PolicyLifecycleService,
   ) {}
 
   /**
@@ -260,6 +262,7 @@ export class PostpaidSchemePaymentService {
 
     const paymentSmsQueue: Array<{
       policyPaymentId: number;
+      policyId: string;
       wasPendingActivation: boolean;
       activationSucceeded: boolean;
     }> = [];
@@ -358,6 +361,7 @@ export class PostpaidSchemePaymentService {
 
         paymentSmsQueue.push({
           policyPaymentId: policyPayment.id,
+          policyId: policy.id,
           wasPendingActivation,
           activationSucceeded,
         });
@@ -368,9 +372,22 @@ export class PostpaidSchemePaymentService {
 
     for (const item of paymentSmsQueue) {
       this.paymentMessagingService.notifyMatchedPaymentSmsAsync({
-        ...item,
+        policyPaymentId: item.policyPaymentId,
+        wasPendingActivation: item.wasPendingActivation,
+        activationSucceeded: item.activationSucceeded,
         correlationId,
       });
+      if (!item.wasPendingActivation || item.activationSucceeded) {
+        this.policyLifecycleService
+          .applyPaymentToPolicyLifecycle(item.policyId, correlationId)
+          .catch((error) => {
+            this.logger.warn(
+              `[${correlationId}] applyPaymentToPolicyLifecycle failed for policy ${item.policyId}: ${
+                error instanceof Error ? error.message : String(error)
+              }`
+            );
+          });
+      }
     }
 
     return {

--- a/apps/api/src/services/postpaid-scheme-payment.service.ts
+++ b/apps/api/src/services/postpaid-scheme-payment.service.ts
@@ -151,13 +151,13 @@ export class PostpaidSchemePaymentService {
         errors.push(`Row ${i + 1}: ID number "${row.idNumber}" is not enrolled in this scheme`);
         continue;
       }
-      const policy = await this.prisma.policy.findUnique({
+      const policy = await this.prisma.policy.findFirst({
         where: {
-          customerId_packageId: {
-            customerId: customer.id,
-            packageId: psc.packageScheme.packageId,
-          },
+          customerId: customer.id,
+          packageId: psc.packageScheme.packageId,
+          status: { in: ['ACTIVE', 'PENDING_ACTIVATION', 'SUSPENDED'] },
         },
+        orderBy: { createdAt: 'desc' },
         select: { id: true, paymentAcNumber: true },
       });
       if (!policy) {
@@ -298,13 +298,13 @@ export class PostpaidSchemePaymentService {
           include: { packageScheme: { select: { packageId: true } } },
         });
         if (!psc) continue;
-        const policy = await tx.policy.findUnique({
+        const policy = await tx.policy.findFirst({
           where: {
-            customerId_packageId: {
-              customerId: customer.id,
-              packageId: psc.packageScheme.packageId,
-            },
+            customerId: customer.id,
+            packageId: psc.packageScheme.packageId,
+            status: { in: ['ACTIVE', 'PENDING_ACTIVATION', 'SUSPENDED'] },
           },
+          orderBy: { createdAt: 'desc' },
         });
         if (!policy) continue;
 

--- a/apps/api/src/utils/__tests__/disabled-policy-number.util.spec.ts
+++ b/apps/api/src/utils/__tests__/disabled-policy-number.util.spec.ts
@@ -1,0 +1,44 @@
+import {
+  formatDisabledPolicyNumber,
+  getBasePolicyNumber,
+  nextDisabledPolicyNumber,
+} from '../disabled-policy-number.util';
+
+describe('disabled-policy-number.util', () => {
+  it('strips [DIS] and [DISn] prefixes', () => {
+    expect(getBasePolicyNumber('MP/MFG/001')).toBe('MP/MFG/001');
+    expect(getBasePolicyNumber('[DIS]MP/MFG/001')).toBe('MP/MFG/001');
+    expect(getBasePolicyNumber('[DIS2]MP/MFG/001')).toBe('MP/MFG/001');
+  });
+
+  it('formats disabled policy numbers', () => {
+    expect(formatDisabledPolicyNumber('MP/MFG/001', 1)).toBe('[DIS]MP/MFG/001');
+    expect(formatDisabledPolicyNumber('MP/MFG/001', 2)).toBe('[DIS2]MP/MFG/001');
+    expect(formatDisabledPolicyNumber('MP/MFG/001', 3)).toBe('[DIS3]MP/MFG/001');
+  });
+
+  it('picks [DIS] when base is unused', () => {
+    expect(nextDisabledPolicyNumber('MP/MFG/001', [])).toBe('[DIS]MP/MFG/001');
+  });
+
+  it('picks [DIS2] when [DIS]base already exists', () => {
+    expect(
+      nextDisabledPolicyNumber('MP/MFG/001', ['[DIS]MP/MFG/001'])
+    ).toBe('[DIS2]MP/MFG/001');
+  });
+
+  it('picks [DIS3] when [DIS] and [DIS2] exist', () => {
+    expect(
+      nextDisabledPolicyNumber('MP/MFG/001', [
+        '[DIS]MP/MFG/001',
+        '[DIS2]MP/MFG/001',
+      ])
+    ).toBe('[DIS3]MP/MFG/001');
+  });
+
+  it('does not double-prefix when source already has [DIS]', () => {
+    expect(
+      nextDisabledPolicyNumber('[DIS]MP/MFG/001', ['[DIS]MP/MFG/001'])
+    ).toBe('[DIS2]MP/MFG/001');
+  });
+});

--- a/apps/api/src/utils/__tests__/installment-backfill.util.spec.ts
+++ b/apps/api/src/utils/__tests__/installment-backfill.util.spec.ts
@@ -1,0 +1,70 @@
+import { PaymentStatus } from '@prisma/client';
+import {
+  computeInstallmentBackfillSlots,
+  buildOutstandingTransactionReference,
+} from '../installment-backfill.util';
+
+describe('installment-backfill.util', () => {
+  it('creates slots for missed weekly periods after daily payments migrated', () => {
+    const startDate = new Date(Date.UTC(2026, 0, 26, 10, 0, 0));
+    const endDate = new Date(Date.UTC(2027, 0, 25, 10, 0, 0));
+    const asOf = new Date(Date.UTC(2026, 1, 22, 12, 0, 0));
+
+    const existingPayments = [
+      {
+        id: 1,
+        expectedPaymentDate: new Date(Date.UTC(2026, 0, 26)),
+        actualPaymentDate: new Date(Date.UTC(2026, 0, 26)),
+        paymentStatus: PaymentStatus.COMPLETED,
+      },
+      {
+        id: 2,
+        expectedPaymentDate: new Date(Date.UTC(2026, 0, 27)),
+        actualPaymentDate: new Date(Date.UTC(2026, 0, 27)),
+        paymentStatus: PaymentStatus.COMPLETED,
+      },
+    ];
+
+    const slots = computeInstallmentBackfillSlots({
+      policyId: 'abc-def-1234-5678',
+      startDate,
+      endDate,
+      paymentCadence: 7,
+      premium: 980,
+      asOfUtc: asOf,
+      existingPayments,
+    });
+
+    expect(slots.length).toBeGreaterThan(0);
+    expect(buildOutstandingTransactionReference('abc-def-1234-5678', 0)).toMatch(
+      /^OUTSTANDING-/
+    );
+  });
+
+  it('returns no slots when every period is covered', () => {
+    const startDate = new Date(Date.UTC(2026, 0, 1));
+    const endDate = new Date(Date.UTC(2027, 0, 0));
+    const asOf = new Date(Date.UTC(2026, 0, 7));
+
+    const existingPayments = [
+      {
+        id: 1,
+        expectedPaymentDate: startDate,
+        actualPaymentDate: startDate,
+        paymentStatus: PaymentStatus.COMPLETED,
+      },
+    ];
+
+    const slots = computeInstallmentBackfillSlots({
+      policyId: 'p1',
+      startDate,
+      endDate,
+      paymentCadence: 7,
+      premium: 100,
+      asOfUtc: asOf,
+      existingPayments,
+    });
+
+    expect(slots).toHaveLength(0);
+  });
+});

--- a/apps/api/src/utils/__tests__/policy-due-date.util.spec.ts
+++ b/apps/api/src/utils/__tests__/policy-due-date.util.spec.ts
@@ -1,0 +1,64 @@
+import {
+  amountRequiredToRestoreInactive,
+  amountRequiredToRestoreSuspended,
+  ceilCadencePeriods,
+  daysOverdue,
+  isPolicyEndDatePassed,
+  nextUnpaidExpectedDueDate,
+  oneMonthPremiumAmount,
+  twoWeekUpfrontAmount,
+  utcCalendarDaysBetween,
+} from '../policy-due-date.util';
+
+describe('policy-due-date.util', () => {
+  describe('ceilCadencePeriods / restore amounts', () => {
+    it('computes 2-week and one-month upfront from cadence', () => {
+      expect(ceilCadencePeriods(14, 7)).toBe(2);
+      expect(twoWeekUpfrontAmount(7, 100)).toBe(200);
+      expect(oneMonthPremiumAmount(7, 100)).toBe(500); // ceil(31/7)=5
+      expect(amountRequiredToRestoreSuspended({ paymentCadenceDays: 7, installmentAmount: 100, arrears: 50 })).toBe(250);
+      expect(
+        amountRequiredToRestoreInactive({
+          paymentCadenceDays: 7,
+          installmentAmount: 100,
+          arrears: 50,
+          daysSinceInactive: 10,
+        })
+      ).toBe(250);
+      expect(
+        amountRequiredToRestoreInactive({
+          paymentCadenceDays: 7,
+          installmentAmount: 100,
+          arrears: 50,
+          daysSinceInactive: 31,
+        })
+      ).toBe(500);
+    });
+  });
+
+  describe('nextUnpaidExpectedDueDate / overdue', () => {
+    it('returns overdue days from unpaid due date', () => {
+      const start = new Date(Date.UTC(2026, 0, 1));
+      const asOf = new Date(Date.UTC(2026, 0, 20));
+      // 19 inclusive days from Jan 1 end-of-day math via periods: floor(19/7)=2 periods due = 200 expected
+      const nextDue = nextUnpaidExpectedDueDate({
+        policyStart: start,
+        paymentCadenceDays: 7,
+        installmentAmount: 100,
+        paidThroughAsOf: 0,
+        asOfUtc: asOf,
+      });
+      expect(nextDue.toISOString().startsWith('2026-01-01')).toBe(true);
+      expect(daysOverdue({ nextUnpaidDueDate: nextDue, asOfUtc: asOf })).toBe(19);
+    });
+  });
+
+  describe('isPolicyEndDatePassed / calendar days', () => {
+    it('detects end date and calendar day distance', () => {
+      const end = new Date(Date.UTC(2026, 5, 1, 10, 15, 0));
+      expect(isPolicyEndDatePassed(end, new Date(Date.UTC(2026, 5, 1, 10, 15, 0)))).toBe(true);
+      expect(isPolicyEndDatePassed(end, new Date(Date.UTC(2026, 4, 31)))).toBe(false);
+      expect(utcCalendarDaysBetween(new Date(Date.UTC(2026, 0, 1)), new Date(Date.UTC(2026, 0, 31)))).toBe(30);
+    });
+  });
+});

--- a/apps/api/src/utils/disabled-policy-number.util.ts
+++ b/apps/api/src/utils/disabled-policy-number.util.ts
@@ -1,0 +1,50 @@
+/** Matches [DIS], [DIS2], [DIS3], … prefix on stored policy numbers. */
+const DISABLED_PREFIX_REGEX = /^\[DIS(\d*)\]/;
+
+/** Strip [DIS] / [DISn] prefix to recover the assignable base policy number. */
+export function getBasePolicyNumber(policyNumber: string): string {
+  return policyNumber.replace(DISABLED_PREFIX_REGEX, '');
+}
+
+function parseDisabledPrefixIndex(policyNumber: string): number | null {
+  const match = policyNumber.match(DISABLED_PREFIX_REGEX);
+  if (!match) return null;
+  if (match[1] === '') return 1;
+  const parsed = parseInt(match[1], 10);
+  return Number.isFinite(parsed) && parsed >= 2 ? parsed : null;
+}
+
+/** Build disabled storage form: [DIS]base or [DIS2]base, [DIS3]base, … */
+export function formatDisabledPolicyNumber(base: string, index: number): string {
+  if (index < 1) {
+    throw new Error('Disabled policy number index must be >= 1');
+  }
+  return index === 1 ? `[DIS]${base}` : `[DIS${index}]${base}`;
+}
+
+/**
+ * Pick the next free disabled policy number for a base value.
+ * First use: [DIS]base; subsequent: [DIS2]base, [DIS3]base, …
+ */
+export function nextDisabledPolicyNumber(
+  currentPolicyNumber: string,
+  existingPolicyNumbers: Array<string | null | undefined>
+): string {
+  const base = getBasePolicyNumber(currentPolicyNumber);
+  const usedIndices = new Set<number>();
+
+  for (const existing of existingPolicyNumbers) {
+    if (!existing) continue;
+    if (getBasePolicyNumber(existing) !== base) continue;
+    if (existing === base) {
+      usedIndices.add(0);
+      continue;
+    }
+    const idx = parseDisabledPrefixIndex(existing);
+    if (idx !== null) usedIndices.add(idx);
+  }
+
+  let index = 1;
+  while (usedIndices.has(index)) index += 1;
+  return formatDisabledPolicyNumber(base, index);
+}

--- a/apps/api/src/utils/family-category.util.ts
+++ b/apps/api/src/utils/family-category.util.ts
@@ -1,0 +1,29 @@
+import { DependantRelationship } from '@prisma/client';
+
+export type InsuranceFamilyCategory = 'member_only' | 'up_to_5' | 'up_to_8';
+
+/**
+ * Derive insurance-pricing.json family category from active dependants.
+ * Principal + dependants: 1 → member_only, 2–5 → up_to_5, 6+ → up_to_8.
+ */
+export function deriveFamilyCategoryFromDependants(
+  dependants: Array<{ relationship: DependantRelationship; deletedAt?: Date | null }>
+): InsuranceFamilyCategory {
+  const active = dependants.filter((d) => d.deletedAt == null);
+  const total = 1 + active.length;
+  if (total <= 1) return 'member_only';
+  if (total <= 5) return 'up_to_5';
+  return 'up_to_8';
+}
+
+/** True when an additional-spouse premium applies (non–member-only with at least one spouse). */
+export function hasAdditionalSpousePremium(
+  category: InsuranceFamilyCategory,
+  dependants: Array<{ relationship: DependantRelationship; deletedAt?: Date | null }>
+): boolean {
+  if (category === 'member_only') return false;
+  const spouseCount = dependants.filter(
+    (d) => d.deletedAt == null && d.relationship === 'SPOUSE'
+  ).length;
+  return spouseCount > 1;
+}

--- a/apps/api/src/utils/installment-backfill.util.ts
+++ b/apps/api/src/utils/installment-backfill.util.ts
@@ -1,0 +1,144 @@
+import { PaymentStatus } from '@prisma/client';
+import { utcDayEnd, utcDayStart } from './premium-statement-math';
+
+const CONFIRMED: PaymentStatus[] = [
+  PaymentStatus.COMPLETED,
+  PaymentStatus.COMPLETED_PENDING_RECEIPT,
+];
+
+export interface InstallmentBackfillPayment {
+  id: number;
+  expectedPaymentDate: Date;
+  actualPaymentDate: Date | null;
+  paymentStatus: PaymentStatus;
+}
+
+export interface InstallmentBackfillParams {
+  policyId: string;
+  startDate: Date;
+  endDate: Date;
+  paymentCadence: number;
+  premium: number;
+  asOfUtc?: Date;
+  existingPayments: InstallmentBackfillPayment[];
+}
+
+export interface InstallmentBackfillSlot {
+  periodIndex: number;
+  slotStart: Date;
+  slotEnd: Date;
+}
+
+/** UTC calendar day offset (add days to UTC date parts). */
+export function addUtcCalendarDays(date: Date, days: number): Date {
+  const d = new Date(date);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d;
+}
+
+export function installmentWindowForSlot(slotStart: Date, paymentCadence: number): { start: Date; end: Date } {
+  const start = utcDayStart(
+    slotStart.getUTCFullYear(),
+    slotStart.getUTCMonth(),
+    slotStart.getUTCDate()
+  );
+  const end = utcDayEnd(
+    addUtcCalendarDays(start, paymentCadence - 1).getUTCFullYear(),
+    addUtcCalendarDays(start, paymentCadence - 1).getUTCMonth(),
+    addUtcCalendarDays(start, paymentCadence - 1).getUTCDate()
+  );
+  return { start, end };
+}
+
+function paymentCoversWindow(
+  payment: InstallmentBackfillPayment,
+  windowStart: Date,
+  windowEnd: Date
+): boolean {
+  if (!CONFIRMED.includes(payment.paymentStatus) || payment.actualPaymentDate == null) {
+    return false;
+  }
+  const anchor = payment.actualPaymentDate ?? payment.expectedPaymentDate;
+  const day = utcDayStart(anchor.getUTCFullYear(), anchor.getUTCMonth(), anchor.getUTCDate());
+  return day.getTime() >= windowStart.getTime() && day.getTime() <= windowEnd.getTime();
+}
+
+function hasOutstandingForSlot(
+  payments: InstallmentBackfillPayment[],
+  slotStart: Date
+): boolean {
+  const slotDay = utcDayStart(
+    slotStart.getUTCFullYear(),
+    slotStart.getUTCMonth(),
+    slotStart.getUTCDate()
+  );
+  return payments.some(
+    (p) =>
+      p.paymentStatus === PaymentStatus.OUTSTANDING &&
+      utcDayStart(
+        p.expectedPaymentDate.getUTCFullYear(),
+        p.expectedPaymentDate.getUTCMonth(),
+        p.expectedPaymentDate.getUTCDate()
+      ).getTime() === slotDay.getTime()
+  );
+}
+
+/** Enumerate installment slots that need OUTSTANDING placeholders. */
+export function computeInstallmentBackfillSlots(
+  params: InstallmentBackfillParams
+): InstallmentBackfillSlot[] {
+  if (params.paymentCadence <= 0 || params.premium <= 0) {
+    return [];
+  }
+
+  const asOf = params.asOfUtc ?? new Date();
+  const asOfEnd = utcDayEnd(asOf.getUTCFullYear(), asOf.getUTCMonth(), asOf.getUTCDate());
+  const policyEnd = utcDayEnd(
+    params.endDate.getUTCFullYear(),
+    params.endDate.getUTCMonth(),
+    params.endDate.getUTCDate()
+  );
+  const deadlineEnd = asOfEnd.getTime() <= policyEnd.getTime() ? asOfEnd : policyEnd;
+
+  let slotStart = utcDayStart(
+    params.startDate.getUTCFullYear(),
+    params.startDate.getUTCMonth(),
+    params.startDate.getUTCDate()
+  );
+  // Preserve time-of-day from policy start for first slot expectedPaymentDate
+  const startTime = params.startDate;
+
+  const slots: InstallmentBackfillSlot[] = [];
+  let periodIndex = 0;
+
+  while (slotStart.getTime() <= deadlineEnd.getTime()) {
+    const { start: windowStart, end: windowEnd } = installmentWindowForSlot(
+      slotStart,
+      params.paymentCadence
+    );
+
+    const covered = params.existingPayments.some((p) =>
+      paymentCoversWindow(p, windowStart, windowEnd)
+    );
+    const outstandingExists = hasOutstandingForSlot(params.existingPayments, slotStart);
+
+    if (!covered && !outstandingExists) {
+      const slotDate = periodIndex === 0 ? new Date(startTime) : new Date(slotStart);
+      slots.push({
+        periodIndex,
+        slotStart: slotDate,
+        slotEnd: windowEnd,
+      });
+    }
+
+    slotStart = addUtcCalendarDays(slotStart, params.paymentCadence);
+    periodIndex++;
+  }
+
+  return slots;
+}
+
+export function buildOutstandingTransactionReference(policyId: string, periodIndex: number): string {
+  const shortId = policyId.replace(/-/g, '').slice(0, 12);
+  return `OUTSTANDING-${shortId}-${periodIndex}`;
+}

--- a/apps/api/src/utils/policy-activation-gate.util.ts
+++ b/apps/api/src/utils/policy-activation-gate.util.ts
@@ -1,0 +1,29 @@
+import { PolicyStatus } from '@prisma/client';
+import { ValidationException } from '../exceptions/validation.exception';
+import { isPolicyEndDatePassed } from './policy-due-date.util';
+
+/**
+ * Shared gate: policy must not become Active after end date, or from terminal statuses.
+ * Used by admin activate, payment activation, and restore paths.
+ */
+export function assertPolicyMayBecomeActive(policy: {
+  status: PolicyStatus | string;
+  endDate: Date | null | undefined;
+}): void {
+  if (
+    policy.status === PolicyStatus.TERMINATED ||
+    policy.status === PolicyStatus.DEACTIVATED ||
+    policy.status === PolicyStatus.EXPIRED
+  ) {
+    throw ValidationException.forField(
+      'status',
+      'Policy cannot become Active from Terminated, Deactivated, or Expired status'
+    );
+  }
+  if (isPolicyEndDatePassed(policy.endDate)) {
+    throw ValidationException.forField(
+      'endDate',
+      'Policy cannot become Active after the policy end date'
+    );
+  }
+}

--- a/apps/api/src/utils/policy-display.util.ts
+++ b/apps/api/src/utils/policy-display.util.ts
@@ -1,0 +1,41 @@
+import type { PolicyStatus } from '@prisma/client';
+
+const MONTHS_SHORT = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+/** Format UTC date as `DD Mon` for policy dropdown labels. */
+export function formatPolicyLabelDate(date: Date): string {
+  const day = date.getUTCDate();
+  const month = MONTHS_SHORT[date.getUTCMonth()] ?? '';
+  return `${day} ${month}`;
+}
+
+export function buildPolicyDisplayText(params: {
+  packageName: string;
+  planName?: string | null;
+  status: PolicyStatus;
+  startDate?: Date | null;
+  endDate?: Date | null;
+  deactivatedAt?: Date | null;
+}): string {
+  const base = params.planName
+    ? `${params.packageName} - ${params.planName}`
+    : params.packageName;
+
+  const status = params.status;
+  if (status === 'DEACTIVATED' || status === 'TERMINATED') {
+    const ended = params.endDate ?? params.deactivatedAt;
+    const suffix = ended
+      ? `(${status}, ended ${formatPolicyLabelDate(ended)})`
+      : `(${status})`;
+    return `${base} ${suffix}`;
+  }
+
+  if (status === 'ACTIVE' || status === 'PENDING_ACTIVATION' || status === 'SUSPENDED') {
+    const suffix = params.startDate
+      ? `(${status}, from ${formatPolicyLabelDate(params.startDate)})`
+      : `(${status})`;
+    return `${base} ${suffix}`;
+  }
+
+  return `${base} (${status})`;
+}

--- a/apps/api/src/utils/policy-display.util.ts
+++ b/apps/api/src/utils/policy-display.util.ts
@@ -30,10 +30,18 @@ export function buildPolicyDisplayText(params: {
     return `${base} ${suffix}`;
   }
 
-  if (status === 'ACTIVE' || status === 'PENDING_ACTIVATION' || status === 'SUSPENDED') {
+  if (status === 'ACTIVE' || status === 'PENDING_ACTIVATION' || status === 'SUSPENDED' || status === 'INACTIVE') {
     const suffix = params.startDate
       ? `(${status}, from ${formatPolicyLabelDate(params.startDate)})`
       : `(${status})`;
+    return `${base} ${suffix}`;
+  }
+
+  if (status === 'EXPIRED') {
+    const ended = params.endDate;
+    const suffix = ended
+      ? `(EXPIRED, ended ${formatPolicyLabelDate(ended)})`
+      : '(EXPIRED)';
     return `${base} ${suffix}`;
   }
 

--- a/apps/api/src/utils/policy-due-date.util.ts
+++ b/apps/api/src/utils/policy-due-date.util.ts
@@ -1,0 +1,140 @@
+/**
+ * Policy due-date and restore-amount helpers for payment lifecycle (UTC calendar days).
+ * Next unpaid expected due date is derived from startDate + paymentCadence coverage.
+ */
+
+import {
+  computeExpectedPremiumThroughAsOf,
+  computePremiumDueAndExcess,
+  utcDayStart,
+  utcInclusiveCalendarDays,
+} from './premium-statement-math';
+import { addUtcCalendarDays } from './installment-backfill.util';
+
+export function ceilCadencePeriods(daysNeeded: number, paymentCadenceDays: number): number {
+  if (paymentCadenceDays <= 0) {
+    throw new Error('paymentCadenceDays must be positive');
+  }
+  return Math.ceil(daysNeeded / paymentCadenceDays);
+}
+
+/** 2-week upfront = ceil(14 / cadence) × installment */
+export function twoWeekUpfrontAmount(
+  paymentCadenceDays: number,
+  installmentAmount: number
+): number {
+  return ceilCadencePeriods(14, paymentCadenceDays) * installmentAmount;
+}
+
+/** One month ≈ ceil(31 / cadence) × installment */
+export function oneMonthPremiumAmount(
+  paymentCadenceDays: number,
+  installmentAmount: number
+): number {
+  return ceilCadencePeriods(31, paymentCadenceDays) * installmentAmount;
+}
+
+export function utcCalendarDaysBetween(from: Date, to: Date): number {
+  const a = utcDayStart(from.getUTCFullYear(), from.getUTCMonth(), from.getUTCDate());
+  const b = utcDayStart(to.getUTCFullYear(), to.getUTCMonth(), to.getUTCDate());
+  return Math.floor((b.getTime() - a.getTime()) / 86400000);
+}
+
+/**
+ * Earliest installment slot start that is not fully covered by confirmed paid amount
+ * through `asOf`, using the same period counting as premium-statement math.
+ *
+ * If current through `asOf` is fully paid (no arrears), returns the next future slot start.
+ */
+export function nextUnpaidExpectedDueDate(params: {
+  policyStart: Date;
+  paymentCadenceDays: number;
+  installmentAmount: number;
+  paidThroughAsOf: number;
+  asOfUtc?: Date;
+}): Date {
+  const asOf = params.asOfUtc ?? new Date();
+  const start = utcDayStart(
+    params.policyStart.getUTCFullYear(),
+    params.policyStart.getUTCMonth(),
+    params.policyStart.getUTCDate()
+  );
+  const { periods: periodsDue, expectedPremium } = computeExpectedPremiumThroughAsOf({
+    policyStart: start,
+    statementGenerationUtc: asOf,
+    paymentCadenceDays: params.paymentCadenceDays,
+    installmentAmount: params.installmentAmount,
+  });
+
+  const { premiumDue } = computePremiumDueAndExcess(expectedPremium, params.paidThroughAsOf);
+  const paidPeriods = Math.floor(params.paidThroughAsOf / params.installmentAmount);
+
+  if (premiumDue > 0) {
+    // First unpaid period index (0-based): paidPeriods
+    return addUtcCalendarDays(start, paidPeriods * params.paymentCadenceDays);
+  }
+
+  // Fully paid through asOf — next due is the next slot after periodsDue
+  return addUtcCalendarDays(start, periodsDue * params.paymentCadenceDays);
+}
+
+export function daysOverdue(params: {
+  nextUnpaidDueDate: Date;
+  asOfUtc?: Date;
+}): number {
+  const asOf = params.asOfUtc ?? new Date();
+  const days = utcCalendarDaysBetween(params.nextUnpaidDueDate, asOf);
+  return Math.max(0, days);
+}
+
+export function outstandingArrears(params: {
+  policyStart: Date;
+  paymentCadenceDays: number;
+  installmentAmount: number;
+  paidThroughAsOf: number;
+  asOfUtc?: Date;
+}): number {
+  const asOf = params.asOfUtc ?? new Date();
+  const { expectedPremium } = computeExpectedPremiumThroughAsOf({
+    policyStart: params.policyStart,
+    statementGenerationUtc: asOf,
+    paymentCadenceDays: params.paymentCadenceDays,
+    installmentAmount: params.installmentAmount,
+  });
+  return computePremiumDueAndExcess(expectedPremium, params.paidThroughAsOf).premiumDue;
+}
+
+/** Suspended restore before end: arrears + 2 weeks upfront */
+export function amountRequiredToRestoreSuspended(params: {
+  paymentCadenceDays: number;
+  installmentAmount: number;
+  arrears: number;
+}): number {
+  return params.arrears + twoWeekUpfrontAmount(params.paymentCadenceDays, params.installmentAmount);
+}
+
+/**
+ * Inactive restore before end:
+ * - within 30 days of becoming inactive: arrears + 2 weeks
+ * - after 30 days: one month premium
+ */
+export function amountRequiredToRestoreInactive(params: {
+  paymentCadenceDays: number;
+  installmentAmount: number;
+  arrears: number;
+  daysSinceInactive: number;
+}): number {
+  if (params.daysSinceInactive <= 30) {
+    return amountRequiredToRestoreSuspended(params);
+  }
+  return oneMonthPremiumAmount(params.paymentCadenceDays, params.installmentAmount);
+}
+
+export function isPolicyEndDatePassed(endDate: Date | null | undefined, asOfUtc?: Date): boolean {
+  if (endDate == null) return false;
+  const asOf = asOfUtc ?? new Date();
+  return asOf.getTime() >= endDate.getTime();
+}
+
+/** Re-export for callers that need inclusive day math */
+export { utcInclusiveCalendarDays };

--- a/apps/api/tests/unit/mpesa-ipn.service.spec.ts
+++ b/apps/api/tests/unit/mpesa-ipn.service.spec.ts
@@ -3,6 +3,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { MpesaIpnService } from '../../src/services/mpesa-ipn.service';
 import { PrismaService } from '../../src/prisma/prisma.service';
 import { PolicyService } from '../../src/services/policy.service';
+import { PolicyLifecycleService } from '../../src/services/policy-lifecycle.service';
 import { PaymentMessagingService } from '../../src/modules/messaging/payment-messaging.service';
 import { MpesaIpnPayloadDto, MpesaIpnResponseDto } from '../../src/dto/mpesa-ipn/mpesa-ipn.dto';
 import { MpesaPaymentSource, MpesaStkPushStatus, MpesaStatementReasonType } from '@prisma/client';
@@ -50,10 +51,15 @@ describe('MpesaIpnService', () => {
     tryEnqueueUnmatchedPaymentSms: jest.fn(),
   });
 
+  const createPolicyLifecycleServiceMock = () => ({
+    applyPaymentToPolicyLifecycle: jest.fn().mockResolvedValue({ action: 'noop' }),
+  });
+
   beforeEach(async () => {
     const prismaMock = createPrismaMock();
     const policyServiceMock = createPolicyServiceMock();
     const paymentMessagingServiceMock = createPaymentMessagingServiceMock();
+    const policyLifecycleServiceMock = createPolicyLifecycleServiceMock();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -69,6 +75,10 @@ describe('MpesaIpnService', () => {
         {
           provide: PaymentMessagingService,
           useValue: paymentMessagingServiceMock,
+        },
+        {
+          provide: PolicyLifecycleService,
+          useValue: policyLifecycleServiceMock,
         },
       ],
     })

--- a/apps/api/tests/unit/mpesa-stk-push.service.spec.ts
+++ b/apps/api/tests/unit/mpesa-stk-push.service.spec.ts
@@ -6,6 +6,7 @@ import { MpesaDarajaApiService } from '../../src/services/mpesa-daraja-api.servi
 import { MpesaErrorMapperService } from '../../src/services/mpesa-error-mapper.service';
 import { ConfigurationService } from '../../src/config/configuration.service';
 import { PolicyService } from '../../src/services/policy.service';
+import { PolicyLifecycleService } from '../../src/services/policy-lifecycle.service';
 import { PaymentMessagingService } from '../../src/modules/messaging/payment-messaging.service';
 import {
   InitiateStkPushDto,
@@ -78,6 +79,10 @@ describe('MpesaStkPushService', () => {
     tryEnqueueMatchedPaymentSms: jest.fn(),
   });
 
+  const createPolicyLifecycleServiceMock = () => ({
+    applyPaymentToPolicyLifecycle: jest.fn().mockResolvedValue({ action: 'noop' }),
+  });
+
   beforeEach(async () => {
     const prismaMock = createPrismaMock();
     const mpesaDarajaApiMock = createMpesaDarajaApiMock();
@@ -85,6 +90,7 @@ describe('MpesaStkPushService', () => {
     const configServiceMock = createConfigServiceMock();
     const policyServiceMock = createPolicyServiceMock();
     const paymentMessagingServiceMock = createPaymentMessagingServiceMock();
+    const policyLifecycleServiceMock = createPolicyLifecycleServiceMock();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -112,6 +118,10 @@ describe('MpesaStkPushService', () => {
         {
           provide: PaymentMessagingService,
           useValue: paymentMessagingServiceMock,
+        },
+        {
+          provide: PolicyLifecycleService,
+          useValue: policyLifecycleServiceMock,
         },
       ],
     })

--- a/specs/002-modify-product-policy/checklists/requirements.md
+++ b/specs/002-modify-product-policy/checklists/requirements.md
@@ -1,0 +1,82 @@
+# Requirements Checklist: Modify Product & Policy Lifecycle
+
+**Feature**: `002-modify-product-policy`  
+**Date**: 2026-07-09
+
+Use this checklist during spec review and before marking the feature complete.
+
+## Scope
+
+- [ ] Modify Product in scope; Add Product explicitly out of scope
+- [ ] Admin-only lifecycle actions on admin Customer Detail → Products
+- [ ] Agent customer page has read-only Products tab only
+
+## Schema
+
+- [ ] `DEACTIVATED` on PolicyStatus and CustomerStatus
+- [ ] `PaymentStatus.OUTSTANDING` for backfilled installments
+- [ ] `EntityStatusChange` table is source of truth for reasons
+- [ ] `Policy.deactivatedAt`, `Customer.deactivatedAt` denormalized
+- [ ] `supersedesPolicyId` / `supersededByPolicyId` on Policy
+- [ ] Partial unique index on `(customerId, packageId)` for non-terminal statuses only
+
+## Modify product
+
+- [ ] Dialog mirrors onboarding payment form; pricing from `insurance-pricing.json`
+- [ ] Family category read-only from dependants
+- [ ] May change plan, scheme, frequency, cadence
+- [ ] Same `packageId` required; deactivate old before create new
+- [ ] Payment migration: first selected + subsequent; source policy only
+- [ ] Postpaid linked payments: migration blocked; PENDING_ACTIVATION plan/scheme-only allowed
+- [ ] `paymentAcNumber` reused (transferred in transaction)
+- [ ] Policy number: required Keep Existing / Generate New
+- [ ] No STK on modify
+- [ ] Installment placeholder backfill runs after modify
+- [ ] SUSPENDED source: modify blocked until activated
+- [ ] DEACTIVATED / TERMINATED source: modify blocked
+
+## Deactivate / Activate / Reset
+
+- [ ] Deactivate: mandatory reason; ACTIVE, SUSPENDED, PENDING_ACTIVATION
+- [ ] Customer coupling: ACTIVE only counts; PENDING_ACTIVATION fallback; else DEACTIVATED
+- [ ] Activate: SUSPENDED→ACTIVE only; mandatory reason
+- [ ] Reset start date: ACTIVE or SUSPENDED; mandatory reason; payments not moved
+
+## TERMINATED
+
+- [ ] No lifecycle actions on TERMINATED customer/policy
+- [ ] Registration gate on idNumber and phoneNumber
+
+## Payments UX
+
+- [ ] Enriched dropdown labels for **all** policies (not only modified pairs)
+- [ ] Unfiltered payments: Policy column (number + status)
+- [ ] Auto-select new policy after modify
+- [ ] Payments on deactivated policy remain visible when filtered to that policy
+
+## Premium math
+
+- [ ] Expected uses new premium + cadence + startDate
+- [ ] Paid sums migrated amounts (historical values)
+- [ ] After backfill, missed count aligns with missed amount for modify scenarios
+
+## Audit
+
+- [ ] Every manual action writes `EntityStatusChange`
+- [ ] Modify metadata includes cadence/plan/scheme deltas
+- [ ] Future PAYMENT_LIFECYCLE auto-suspend spec documented
+
+## API & standards
+
+- [ ] Admin RBAC on all lifecycle endpoints
+- [ ] UTC date handling
+- [ ] ValidationException + ErrorCodes
+- [ ] Prisma migration (not db push)
+- [ ] Unit tests for coupling + backfill
+
+## Deferred (documented, not blocking)
+
+- [ ] Member card red inactive label UI
+- [ ] Portal TERMINATED access gate
+- [ ] Messaging for deactivated customers
+- [ ] Status history admin UI

--- a/specs/002-modify-product-policy/data-model.md
+++ b/specs/002-modify-product-policy/data-model.md
@@ -1,0 +1,414 @@
+# Data Model: Modify Product & Policy Lifecycle
+
+**Feature**: `002-modify-product-policy`  
+**Date**: 2026-07-09
+
+## Overview
+
+This feature extends the policy/customer lifecycle with **DEACTIVATED** status, an audit entity for all status transitions, policy supersession links for modify-product, schema constraint changes to allow historical policy rows per package, and **OUTSTANDING** payment placeholders for installment backfill.
+
+---
+
+## Enum changes
+
+### PolicyStatus (add value)
+
+```prisma
+enum PolicyStatus {
+  PENDING_ACTIVATION
+  ACTIVE
+  SUSPENDED
+  DEACTIVATED   // NEW — admin/business closure; reversible in future lifecycle
+  TERMINATED    // fraud/permanent
+  EXPIRED
+}
+```
+
+### CustomerStatus (add value)
+
+```prisma
+enum CustomerStatus {
+  PENDING_KYC
+  PENDING_ACTIVATION
+  KYC_VERIFIED
+  ACTIVE
+  SUSPENDED
+  DEACTIVATED   // NEW — no ACTIVE policies; distinct from TERMINATED
+  TERMINATED
+  DELETED
+}
+```
+
+### PaymentStatus (add value)
+
+```prisma
+enum PaymentStatus {
+  PENDING_STK_CALLBACK
+  COMPLETED_PENDING_RECEIPT
+  COMPLETED
+  OUTSTANDING   // NEW — backfilled expected installment not yet paid (not STK)
+}
+```
+
+`missedPayments` row count (Products tab) treats any row with `expectedPaymentDate < now` and `actualPaymentDate == null` as missed — **OUTSTANDING** rows satisfy this without impersonating STK placeholders.
+
+### StatusChangeEntityType
+
+```prisma
+enum StatusChangeEntityType {
+  POLICY
+  CUSTOMER
+}
+```
+
+### StatusChangeTrigger
+
+```prisma
+enum StatusChangeTrigger {
+  MANUAL_ADMIN
+  MODIFY_PRODUCT
+  PAYMENT_LIFECYCLE
+  SYSTEM
+}
+```
+
+---
+
+## Policy model changes
+
+```prisma
+model Policy {
+  // ... existing fields ...
+
+  deactivatedAt        DateTime?  // denormalized; set when status → DEACTIVATED
+
+  supersedesPolicyId   String?    @db.Uuid  // old policy this one replaced (modify)
+  supersededByPolicyId String?    @db.Uuid  // new policy that replaced this one
+
+  supersedesPolicy     Policy?  @relation("PolicySupersession", fields: [supersedesPolicyId], references: [id])
+  supersededByPolicy   Policy?  @relation("PolicySupersession", fields: [supersededByPolicyId], references: [id])
+  supersededPolicies   Policy[] @relation("PolicySupersession")
+
+  statusChanges        EntityStatusChange[]
+
+  // REMOVE: @@unique([customerId, packageId])
+  // ADD via raw SQL migration — partial unique index (see below)
+}
+```
+
+### Partial unique index (PostgreSQL)
+
+```sql
+CREATE UNIQUE INDEX policies_customer_package_active_unique
+ON policies ("customerId", "packageId")
+WHERE status IN ('ACTIVE', 'PENDING_ACTIVATION', 'SUSPENDED');
+```
+
+Allows multiple **DEACTIVATED** / **TERMINATED** / **EXPIRED** rows per `(customerId, packageId)` for modify history.
+
+---
+
+## Customer model changes
+
+```prisma
+model Customer {
+  // ... existing fields ...
+
+  deactivatedAt   DateTime?  // denormalized; set when status → DEACTIVATED
+
+  statusChanges   EntityStatusChange[]
+}
+```
+
+---
+
+## EntityStatusChange (source of truth)
+
+```prisma
+model EntityStatusChange {
+  id            String                  @id @default(uuid()) @db.Uuid
+  entityType    StatusChangeEntityType
+  customerId    String                  @db.Uuid
+  policyId      String?                 @db.Uuid
+
+  fromStatus    String                  @db.VarChar(50)
+  toStatus      String                  @db.VarChar(50)
+  reason        String                  @db.VarChar(1000)
+
+  trigger       StatusChangeTrigger
+  changedBy     String                  @db.Uuid
+  correlationId String?                 @db.VarChar(100)
+  metadata      Json?
+
+  createdAt     DateTime                @default(now())
+
+  customer Customer @relation(fields: [customerId], references: [id], onDelete: Cascade)
+  policy   Policy?  @relation(fields: [policyId], references: [id], onDelete: SetNull)
+
+  @@index([customerId, createdAt])
+  @@index([policyId, createdAt])
+  @@map("entity_status_changes")
+}
+```
+
+### Mandatory `reason`
+
+Required for:
+
+- Manual deactivate
+- Manual activate (SUSPENDED→ACTIVE)
+- Reset start date
+- Modify product (also used for deactivate step within modify)
+
+Not required for future `PAYMENT_LIFECYCLE` auto-suspend (system-generated reason in `reason` field).
+
+### Metadata examples
+
+**Modify product (`trigger: MODIFY_PRODUCT`):**
+
+```json
+{
+  "operation": "MODIFY_PRODUCT",
+  "sourcePolicyId": "uuid-old",
+  "newPolicyId": "uuid-new",
+  "firstPaymentId": 12345,
+  "paymentsMovedCount": 11,
+  "placeholdersBackfilledCount": 8,
+  "planBefore": "Silver",
+  "planAfter": "Gold",
+  "packagePlanIdBefore": 1,
+  "packagePlanIdAfter": 2,
+  "schemeIdBefore": 10,
+  "schemeIdAfter": 12,
+  "frequencyBefore": "DAILY",
+  "frequencyAfter": "WEEKLY",
+  "cadenceBefore": 1,
+  "cadenceAfter": 7,
+  "premiumBefore": "152.00",
+  "premiumAfter": "980.00",
+  "policyNumberChoice": "KEEP_EXISTING",
+  "familyCategory": "up_to_5"
+}
+```
+
+**Reset start date:**
+
+```json
+{
+  "operation": "RESET_START_DATE",
+  "previousStartDate": "2026-01-01T00:00:00.000Z",
+  "newStartDate": "2026-02-15T00:00:00.000Z",
+  "previousEndDate": "2026-12-31T23:59:59.999Z",
+  "newEndDate": "2027-02-14T23:59:59.999Z"
+}
+```
+
+---
+
+## Customer ↔ policy status coupling
+
+**Definition:** “Active policy” = `PolicyStatus.ACTIVE` only (excludes `PENDING_ACTIVATION`).
+
+### On policy deactivate
+
+After setting policy → `DEACTIVATED`:
+
+| Remaining policies (not DEACTIVATED/TERMINATED) | Customer status |
+|------------------------------------------------|-----------------|
+| ≥1 ACTIVE | unchanged |
+| 0 ACTIVE, ≥1 PENDING_ACTIVATION | `PENDING_ACTIVATION` |
+| otherwise | `DEACTIVATED` (+ `deactivatedAt`) |
+
+Includes: only SUSPENDED → deactivate → customer `DEACTIVATED`.
+
+### On modify (within same transaction)
+
+1. Deactivate source (rules above apply mid-transaction).
+2. Create new policy (ACTIVE or PENDING_ACTIVATION).
+3. If new policy is ACTIVE and customer was `DEACTIVATED` or `SUSPENDED` → customer `ACTIVE` (clear `deactivatedAt` if set).
+
+### On activate (SUSPENDED→ACTIVE)
+
+- Customer `SUSPENDED` → `ACTIVE`
+- Customer already `ACTIVE` → unchanged
+
+### TERMINATED
+
+- Immutable. Block all lifecycle mutations.
+
+---
+
+## Modify product transaction
+
+```
+BEGIN TRANSACTION
+  1. Validate admin, customer not TERMINATED, source eligible
+  2. Validate postpaid migration rules
+  3. Record EntityStatusChange: source policy → DEACTIVATED
+  4. Update source: status=DEACTIVATED, deactivatedAt=now, supersededByPolicyId=(pending)
+  5. Apply customer status coupling (step 3)
+  6. Resolve paymentAcNumber from source (transfer)
+  7. Create new policy (same packageId, new plan/scheme/frequency/cadence/premium/productName)
+  8. Link supersedesPolicyId / supersededByPolicyId
+  9. Update package_scheme_customers if scheme changed
+ 10. Move policy_payments (selected + subsequent) to new policyId
+ 11. Set new startDate/endDate from first migrated payment (or null if none)
+ 12. Set new status ACTIVE | PENDING_ACTIVATION
+ 13. If customer was DEACTIVATED/SUSPENDED and new ACTIVE → customer ACTIVE
+ 14. Run backfillMissedInstallmentPlaceholders(newPolicyId)
+ 15. Write EntityStatusChange for new policy activation / modify metadata
+COMMIT
+```
+
+### Payment migration rules
+
+- Source: only the policy being modified.
+- Eligible payments: `COMPLETED` or `COMPLETED_PENDING_RECEIPT` with `actualPaymentDate` set.
+- Block if any selected payment has `postpaidSchemePaymentItem` link.
+- Order by `expectedPaymentDate` asc (or `actualPaymentDate`); admin picks `firstPaymentId`; move that row and all later completed rows.
+
+### Policy number choice
+
+| Choice | Behavior |
+|--------|----------|
+| `KEEP_EXISTING` | Copy `policyNumber` from source to new policy |
+| `GENERATE_NEW` | Call `generatePolicyNumberInTransaction` for package |
+
+### paymentAcNumber
+
+- Clear on source policy (`null`) and set on new policy in same transaction (preserves global uniqueness).
+
+---
+
+## Installment placeholder backfill
+
+**Function:** `backfillMissedInstallmentPlaceholders(policyId, tx)`
+
+**When:** After modify (and optionally after reset start date — out of scope unless added later).
+
+**Inputs:** `startDate`, `endDate`, `paymentCadence`, `premium`, existing `policy_payments` on policy.
+
+**Algorithm (UTC calendar semantics):**
+
+```
+slotStart = utcDayStart(startDate)
+deadline = min(utcDayEnd(now), utcDayEnd(endDate))
+periodIndex = 0
+
+while slotStart <= deadline:
+  slotEnd = slotStart + (paymentCadence - 1) calendar days  // inclusive window
+
+  covered = any policy_payment on this policy where:
+    paymentStatus in (COMPLETED, COMPLETED_PENDING_RECEIPT)
+    AND actualPaymentDate is not null
+    AND coalesce(actualPaymentDate, expectedPaymentDate) within [slotStart, slotEnd] UTC day bounds
+
+  outstandingExists = any policy_payment where:
+    paymentStatus = OUTSTANDING
+    AND expectedPaymentDate = slotStart (or same period index)
+
+  if not covered and not outstandingExists:
+    INSERT policy_payment:
+      policyId, paymentType=MPESA (or policy default)
+      transactionReference = OUTSTANDING-{policyId}-{periodIndex}  // unique
+      amount = premium
+      expectedPaymentDate = slotStart (preserve time from startDate if non-midnight)
+      actualPaymentDate = null
+      paymentStatus = OUTSTANDING
+
+  slotStart += paymentCadence days
+  periodIndex++
+```
+
+**Notes:**
+
+- Migrated payments with **old** daily `expectedPaymentDate`s still **cover** their calendar window; backfill fills **gaps** at the **new** cadence grid.
+- Do not delete or rewrite migrated payment dates in v1.
+- Return `placeholdersBackfilledCount` in modify response metadata.
+
+---
+
+## Policy dropdown display (API)
+
+Extend `PolicyOptionDto`:
+
+```typescript
+{
+  id: string
+  displayText: string       // enriched per FR-020
+  packageName: string
+  planName?: string
+  status: PolicyStatus
+  policyNumber?: string | null
+  startDate?: string | null
+  endDate?: string | null
+  deactivatedAt?: string | null
+}
+```
+
+**Label rule (all policies):**
+
+| Status | Suffix |
+|--------|--------|
+| ACTIVE, PENDING_ACTIVATION, SUSPENDED | `({STATUS}, from {DD Mon})` if startDate; else `({STATUS})` |
+| DEACTIVATED, TERMINATED | `({STATUS}, ended {DD Mon})` using endDate ?? deactivatedAt |
+
+---
+
+## Payments list (unfiltered)
+
+Extend payment list DTO with:
+
+```typescript
+{
+  // ... existing payment fields ...
+  policy: {
+    id: string
+    policyNumber: string | null
+    status: PolicyStatus
+    displayText: string  // short: "{policyNumber ?? '—'} · {status}"
+  }
+}
+```
+
+Only include `policy` object when `policyId` filter is **omitted** (all-policies view).
+
+---
+
+## Pricing authority
+
+| Source | Used for |
+|--------|----------|
+| `insurance-pricing.json` | Daily/weekly installment calculation in modify dialog |
+| `package_plans` table | Plan **identity** (`id`, `name`) — map JSON plan name → `packagePlanId` |
+| `packages.totalPremium` | Display “total premium” on Products tab — **not** installment rates |
+| `policies.premium` | Stored installment amount used by premium math |
+
+---
+
+## TERMINATED registration gate
+
+On `createCustomer` (and id/phone update if applicable):
+
+```sql
+EXISTS customer WHERE status = 'TERMINATED'
+  AND (idNumber = :idNumber OR phoneNumber = :normalizedPhone)
+```
+
+→ `ValidationException` with field-specific errors.
+
+---
+
+## Member cards (API only in v1)
+
+`getMemberCards` already loops all policies. Expose `policy.status` on `MemberCardsByPolicyItemDto` for future inactive UI. No card suppression for DEACTIVATED in v1.
+
+---
+
+## Migration checklist
+
+1. Add enum values (`DEACTIVATED`, `OUTSTANDING`)
+2. Add columns: `Policy.deactivatedAt`, `supersedesPolicyId`, `supersededByPolicyId`; `Customer.deactivatedAt`
+3. Create `entity_status_changes` table
+4. Drop `policies_customerId_packageId_key`; create partial unique index
+5. Seed/backfill not required for new enums (no existing DEACTIVATED rows)

--- a/specs/002-modify-product-policy/plan.md
+++ b/specs/002-modify-product-policy/plan.md
@@ -1,0 +1,115 @@
+# Implementation Plan: Modify Product & Policy Lifecycle
+
+**Branch**: `002-modify-product-policy` | **Date**: 2026-07-09 | **Spec**: [spec.md](./spec.md)
+
+## Summary
+
+Admin-only policy lifecycle on Customer Detail → Products: **Modify product** (deactivate + create new same package, optional payment migration, installment backfill), **Deactivate**, **Activate** (SUSPENDED→ACTIVE), **Reset start date**. Schema adds `DEACTIVATED`, `EntityStatusChange` audit, policy supersession, partial unique index, `PaymentStatus.OUTSTANDING`. Payments UX: enriched policy labels for **all** policies, Policy column on unfiltered payments, auto-select new policy after modify. TERMINATED registration gate. Agent gets read-only Products tab.
+
+## Technical Context
+
+**Stack**: NestJS 11, Prisma 6, Next.js (agent-registration), PostgreSQL
+
+**Key files today**:
+
+- Products tab: `apps/agent-registration/.../products-tab.tsx`
+- Payments tab: `apps/agent-registration/.../payments-tab.tsx`
+- Onboarding payment UI: `apps/agent-registration/.../register/payment/page.tsx`
+- Policy create/activate: `apps/api/src/services/policy.service.ts`
+- Premium math: `apps/api/src/utils/premium-statement-math.ts`
+- Customer policies API: `apps/api/src/services/customer.service.ts`
+
+## Constitution Check
+
+| Gate | Status |
+|------|--------|
+| Prisma migrations (no db push) | Required |
+| UTC dates | Required |
+| ValidationException + ErrorCodes | Required |
+| Admin RBAC on lifecycle endpoints | Required |
+| Sentry on unexpected failures | Required |
+
+## Implementation Phases
+
+### Phase 1 — Schema & core services (API)
+
+1. Migration: enums, `EntityStatusChange`, Policy/Customer fields, partial unique index, `OUTSTANDING` payment status.
+2. `EntityStatusChangeService` — write records, optional list by customer.
+3. `PolicyLifecycleService` (or extend `PolicyService`):
+   - `deactivatePolicy`
+   - `activatePolicy` (SUSPENDED only)
+   - `resetPolicyStartDate`
+   - `modifyPolicy` (orchestrates transaction)
+   - `backfillMissedInstallmentPlaceholders`
+   - `resolveCustomerStatusAfterPolicyChange`
+4. TERMINATED gate in `CustomerService.createCustomer`.
+5. Internal controller routes + DTOs + Swagger.
+
+**Tests**: unit tests for coupling rules, backfill algorithm, partial unique constraint behavior.
+
+### Phase 2 — Modify options & payment migration
+
+1. `GET modify-options`: plans (JSON pricing + DB plan ids), schemes for package, completed payments list for picker.
+2. Postpaid migration guard (`postpaidSchemePaymentItem` check).
+3. `paymentAcNumber` transfer logic.
+4. Policy number keep vs generate.
+
+### Phase 3 — Admin UI
+
+1. Extract shared **ProductPaymentForm** from `register/payment/page.tsx` (plan, frequency, scheme, read-only category).
+2. `ModifyProductDialog` — payment picker, policy number choice, reason.
+3. `DeactivatePolicyDialog`, `ActivatePolicyDialog`, `ResetStartDateDialog`.
+4. Products tab row menu (admin `basePath` only) + `isAdmin` guard.
+5. Post-modify: refresh products/payments; pass `selectedPolicyId` to Payments tab (query param or shared state).
+
+### Phase 4 — Payments UX
+
+1. Enrich `getCustomerPolicies` `displayText` for **all** policies (FR-020).
+2. Extend `getCustomerPayments` with policy sub-object when unfiltered; add Policy column in `payments-tab.tsx`.
+3. Auto-select new policy after modify.
+
+### Phase 5 — Agent Products tab
+
+1. Add Products tab to `apps/agent-registration/.../customer/[customerId]/page.tsx` (read-only `ProductsTab`).
+
+### Phase 6 — Member cards API (minimal)
+
+1. Add `status` to `MemberCardsByPolicyItemDto` for future inactive label.
+
+## Shared component strategy
+
+```
+register/payment/page.tsx
+  └── uses ProductPaymentForm (extracted)
+
+admin/modify-product-dialog.tsx
+  └── uses ProductPaymentForm + payment picker + policy number + reason
+```
+
+Family category: compute from dependant counts using same logic as onboarding (`member_only`, `up_to_5`, `up_to_8`).
+
+## Risk & mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Partial unique index + Prisma | Raw SQL in migration; document in schema comments |
+| `paymentAcNumber` unique transfer | Null out old in same tx before insert new |
+| Backfill + migrated payment date mismatch | Window-based “covered” check (data-model algorithm) |
+| Dropdown label clutter | Consistent format; dates only when available |
+
+## Out of scope (this branch)
+
+- Add Product
+- Auto-SUSPEND lifecycle job
+- Member card red inactive text
+- Portal TERMINATED gate (spec FR-040 — separate PR if not exists)
+- Status history admin UI page (API optional)
+
+## Verification
+
+- [ ] Modify with cadence change: `missedPayments` count > 0 when financially behind
+- [ ] Both policies in dropdown with distinct labels
+- [ ] Unfiltered payments show Policy column
+- [ ] TERMINATED id/phone blocked on create
+- [ ] Agent Products tab read-only
+- [ ] `pnpm lint` clean

--- a/specs/002-modify-product-policy/quickstart.md
+++ b/specs/002-modify-product-policy/quickstart.md
@@ -1,0 +1,40 @@
+# Quickstart: Modify Product & Policy Lifecycle
+
+**Feature**: `002-modify-product-policy`
+
+## Prerequisites
+
+- Apply migration: `cd apps/api && npx prisma migrate deploy` (or `migrate dev` locally)
+- Admin user with `registration_admin` role
+
+## API endpoints
+
+| Method | Path |
+|--------|------|
+| `POST` | `/internal/customers/:customerId/policies/:policyId/deactivate` |
+| `POST` | `/internal/customers/:customerId/policies/:policyId/activate` |
+| `POST` | `/internal/customers/:customerId/policies/:policyId/reset-start-date` |
+| `GET` | `/internal/customers/:customerId/policies/:policyId/modify-options` |
+| `POST` | `/internal/customers/:customerId/policies/:policyId/modify` |
+
+All require Supabase bearer token and admin role.
+
+## Manual test flow
+
+1. Open **Admin → Customer → Products** tab.
+2. Row menu (⋮): **Modify product** on an ACTIVE prepaid policy with payments.
+3. Select plan, frequency, policy number option, first payment, reason → submit.
+4. Confirm old policy **DEACTIVATED**, new policy **ACTIVE**, payments split correctly.
+5. Open **Payments** tab — new policy should be pre-selected in dropdown (from session storage after modify).
+6. Select **All policies** → Filter → confirm **Policy** column shows number + status.
+7. Test **Deactivate**, **Activate** (suspended), **Reset start date**.
+
+## TERMINATED gate
+
+Create customer with same `idNumber` or `phoneNumber` as a TERMINATED customer → expect validation error.
+
+## Tests
+
+```bash
+cd apps/api && npx jest src/utils/__tests__/installment-backfill.util.spec.ts
+```

--- a/specs/002-modify-product-policy/spec.md
+++ b/specs/002-modify-product-policy/spec.md
@@ -1,0 +1,247 @@
+# Feature Specification: Modify Product & Policy Lifecycle (Admin)
+
+**Feature Branch**: `002-modify-product-policy`  
+**Created**: 2026-07-09  
+**Status**: Draft  
+**Input**: Admin ability to modify an existing customer policy (same package), deactivate/activate policies, reset policy start date, audit all status changes, TERMINATED registration gate, and correct premium/missed-payment accounting after modify (including installment placeholder backfill).
+
+## Clarifications
+
+### Session 2026-07-07 — Scope
+
+- **Q:** Add Product vs Modify Product? **→ A:** **Modify Product only** for this feature. Add Product is deferred.
+- **Q:** What does “DEACTIVATED” mean vs SUSPENDED / TERMINATED? **→ A:** **DEACTIVATED** = admin/business closure (reversible in future lifecycle work). **SUSPENDED** = system-driven (missed payments). **TERMINATED** = fraud/permanent; customer and policy never change again.
+- **Q:** Postpaid payment migration on modify? **→ A:** **Block** migrating postpaid bulk-linked payments. Modify without migration is allowed for **PENDING_ACTIVATION** postpaid (plan/scheme-only).
+
+### Session 2026-07-08 — Premium math & reporting
+
+- **Q:** After modify, will both policies appear in reporting? **→ A:** **Yes.** Deactivated and new policies are separate rows; payments are scoped per `policyId`. Unfiltered payment list shows a **Policy** column (policy number + status).
+- **Q:** Backfill missed installment placeholders after modify? **→ A:** **In scope for v1** (not deferred). After modify, backfill unpaid placeholder rows on the new policy so `missedPayments` count aligns with financial math.
+- **Q:** Policy dropdown labels with status/dates — only for modified pairs? **→ A:** **No.** Apply enriched labels to **all policies** in customer policy dropdowns (Payments tab and any shared policy selector). Superseded pairs benefit most, but a single rule avoids special cases and helps multi-package customers too.
+
+### Session 2026-07-09 — UX defaults
+
+- **Q:** Default Payments tab selection after modify? **→ A:** **Auto-select** the new **ACTIVE** policy (or new `PENDING_ACTIVATION` policy if no payments migrated).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Modify Product (Priority: P1)
+
+As an **admin** on **Customer Detail → Products**, I can open **Modify product** on an eligible policy, change plan/scheme/frequency/cadence (family category read-only from dependants), optionally migrate completed payments from that policy, and atomically deactivate the old policy and create a new one on the **same package**.
+
+**Why this priority**: Core business workflow for plan changes and payment continuity.
+
+**Independent Test**: Modify an ACTIVE prepaid policy with completed payments; confirm old policy DEACTIVATED, new policy ACTIVE, payments moved from cutoff forward, placeholders backfilled, Payments tab auto-selects new policy.
+
+**Acceptance Scenarios**:
+
+1. **Given** an admin on Products tab and a policy in **ACTIVE** or **PENDING_ACTIVATION**, **When** they choose **Modify product**, **Then** a dialog mirroring onboarding payment (`register/payment/page.tsx`) opens with plan, frequency/cadence, scheme, pricing from `insurance-pricing.json`, family category **read-only**, mandatory reason, and required policy-number choice (**Keep Existing** / **Generate New**, no default).
+2. **Given** source policy has completed prepaid payments, **When** modify proceeds, **Then** admin must pick **first payment to migrate** from that policy only; that payment and **all subsequent** completed payments move to the new policy.
+3. **Given** modify completes, **When** viewing Products tab, **Then** source policy is **DEACTIVATED** with `deactivatedAt` set; new policy is **ACTIVE** (if payments migrated) or **PENDING_ACTIVATION** (if none); `supersedesPolicyId` / `supersededByPolicyId` link the pair; `paymentAcNumber` is **reused** on the new policy.
+4. **Given** source policy is **SUSPENDED**, **When** admin opens Modify, **Then** modify is **blocked** until policy is **Activated** (manual or future lifecycle payment threshold).
+5. **Given** source is **DEACTIVATED** or **TERMINATED**, **When** admin views row actions, **Then** Modify is not offered.
+6. **Given** customer is **TERMINATED**, **When** admin attempts any product lifecycle action, **Then** request is rejected.
+7. **Given** postpaid policy with **postpaid_scheme_payment_item**-linked payments, **When** admin modifies with payment migration, **Then** migration is blocked; **PENDING_ACTIVATION** postpaid without such payments may modify plan/scheme only (no payment picker).
+8. **Given** modify changes plan, **When** new policy is created, **Then** `productName` reflects the new plan name from `insurance-pricing.json` + package naming rules.
+9. **Given** modify completes, **When** admin opens Payments tab, **Then** the **new** policy is **auto-selected** in the policy dropdown.
+
+---
+
+### User Story 2 - Deactivate Policy (Priority: P1)
+
+As an **admin**, I can deactivate a policy with a **mandatory reason**, with correct customer status coupling.
+
+**Acceptance Scenarios**:
+
+1. **Given** policy in **ACTIVE**, **SUSPENDED**, or **PENDING_ACTIVATION**, **When** admin deactivates with reason, **Then** policy → **DEACTIVATED**, `deactivatedAt` set, `EntityStatusChange` recorded.
+2. **Given** customer has another **ACTIVE** policy, **When** one policy is deactivated, **Then** customer status unchanged.
+3. **Given** customer has **ACTIVE** + **PENDING_ACTIVATION** and admin deactivates the **ACTIVE** one, **When** complete, **Then** customer → **PENDING_ACTIVATION**.
+4. **Given** customer has only **PENDING_ACTIVATION** policy(s) and admin deactivates the last one, **When** complete, **Then** customer → **DEACTIVATED**.
+5. **Given** customer has only **SUSPENDED** policy and admin deactivates it, **When** complete, **Then** customer → **DEACTIVATED**.
+6. **Given** customer has no **ACTIVE** and no **PENDING_ACTIVATION** after deactivate, **When** complete, **Then** customer → **DEACTIVATED** and `Customer.deactivatedAt` set.
+
+---
+
+### User Story 3 - Activate Policy (Priority: P1)
+
+As an **admin**, I can activate a **SUSPENDED** policy with mandatory reason (**SUSPENDED → ACTIVE** only).
+
+**Acceptance Scenarios**:
+
+1. **Given** policy **SUSPENDED**, **When** admin activates with reason, **Then** policy → **ACTIVE** and `EntityStatusChange` recorded.
+2. **Given** customer **SUSPENDED**, **When** a policy is activated, **Then** customer → **ACTIVE**.
+3. **Given** customer already **ACTIVE** (another active policy exists), **When** a suspended policy is activated, **Then** customer stays **ACTIVE**.
+4. **Given** policy **PENDING_ACTIVATION** or **TERMINATED**, **When** admin views actions, **Then** manual Activate is not offered.
+
+---
+
+### User Story 4 - Reset Start Date (Priority: P2)
+
+As an **admin**, I can reset `policy.startDate` and `policy.endDate` on **ACTIVE** or **SUSPENDED** policies without creating a new policy row.
+
+**Acceptance Scenarios**:
+
+1. **Given** policy **ACTIVE** or **SUSPENDED**, **When** admin resets start date with mandatory reason, **Then** only dates change; payments are **not** moved.
+2. **Given** reset pushes start after existing completed payments, **When** premium math runs, **Then** payments before new start remain on the policy but are **excluded** from coverage accounting (`expectedPaymentDate < policyStartDay`).
+3. **Given** reset completes, **When** viewing audit, **Then** `EntityStatusChange` records reason and metadata (`previousStartDate`, `newStartDate`).
+
+---
+
+### User Story 5 - Status audit trail (Priority: P1)
+
+As an **admin** or support user, I can see why policy and customer statuses changed.
+
+**Acceptance Scenarios**:
+
+1. **Given** any manual deactivate, activate, modify, or reset, **When** action completes, **Then** at least one `EntityStatusChange` row exists with `reason`, `changedBy`, `trigger`, and `metadata`.
+2. **Given** modify product, **When** complete, **Then** metadata includes plan/scheme/frequency/cadence before/after, `policyNumberChoice`, `paymentsMovedCount`, `firstPaymentId`, and cadence change details.
+3. **Given** future auto-**SUSPENDED** from missed payments, **When** lifecycle runs, **Then** it writes `EntityStatusChange` with `trigger = PAYMENT_LIFECYCLE` and system-generated reason (spec-ready; implementation may follow in lifecycle feature).
+
+---
+
+### User Story 6 - TERMINATED registration gate (Priority: P1)
+
+As the system, I reject new customer registration when identity matches a **TERMINATED** customer.
+
+**Acceptance Scenarios**:
+
+1. **Given** create-customer with `idNumber` matching any **TERMINATED** customer, **When** submitted, **Then** validation error (existing error-handling standards).
+2. **Given** create-customer with `phoneNumber` matching any **TERMINATED** customer, **When** submitted, **Then** validation error.
+
+---
+
+### User Story 7 - Payments & policy dropdown UX (Priority: P1)
+
+As an **admin** viewing Payments, I can distinguish policies and see payments across policies clearly after modify.
+
+**Acceptance Scenarios**:
+
+1. **Given** customer has multiple policies, **When** viewing policy dropdown, **Then** each option uses enriched label (see **FR-020**) for **every** policy, not only superseded pairs.
+2. **Given** Payments grid with **no policy filter** (all policies), **When** payments load, **Then** table includes **Policy** column: policy number (or "—") + status badge.
+3. **Given** policy filter selects one policy, **When** payments load, **Then** only that policy’s payments appear (unchanged behavior).
+
+---
+
+### User Story 8 - Installment placeholder backfill after modify (Priority: P1)
+
+As the system, after modify with payment migration, I backfill **outstanding installment** placeholder rows on the new policy so missed-payment **counts** match financial math.
+
+**Acceptance Scenarios**:
+
+1. **Given** modify creates new policy with `startDate`, `paymentCadence`, and `premium`, **When** backfill runs, **Then** for each expected installment slot from start through `min(now, endDate)` without a covering completed payment, an **OUTSTANDING** placeholder row is created (see data-model).
+2. **Given** migrated completed payments exist, **When** backfill runs, **Then** slots covered by those payments (by installment window) do not get duplicate placeholders.
+3. **Given** backfill completes, **When** Products tab shows `missedPayments` count, **Then** it aligns with unpaid slots past due relative to `missedPaymentsAmount` (no “0 count / large KES due” mismatch for modify scenarios).
+
+---
+
+### User Story 9 - Agent Products tab (Priority: P2)
+
+As an **agent** on customer detail, I see a **read-only Products** tab (no modify/deactivate/activate/reset).
+
+**Acceptance Scenarios**:
+
+1. **Given** agent customer detail page, **When** user opens Products tab, **Then** policy list matches admin data but **no** admin row actions appear.
+
+---
+
+## Functional Requirements
+
+### Schema & status model
+
+- **FR-001**: Add `DEACTIVATED` to `PolicyStatus` and `CustomerStatus` enums.
+- **FR-002**: Add `Policy.deactivatedAt`, `Customer.deactivatedAt` (denormalized); **`EntityStatusChange` is source of truth** for reasons and history.
+- **FR-003**: Add `Policy.supersedesPolicyId`, `Policy.supersededByPolicyId` for modify lineage.
+- **FR-004**: Replace `@@unique([customerId, packageId])` with partial unique index: at most one policy per `(customerId, packageId)` where status ∈ `{ ACTIVE, PENDING_ACTIVATION, SUSPENDED }`.
+- **FR-005**: System MUST implement `EntityStatusChange` per `data-model.md`.
+
+### Modify product
+
+- **FR-010**: Modify MUST be admin-only; entry on **admin** Customer Detail → Products row menu.
+- **FR-011**: Modify dialog MUST mirror onboarding payment UI; pricing from **`insurance-pricing.json`**; family category read-only from dependants.
+- **FR-012**: Modify MAY change plan, scheme (same package), frequency, and cadence; scheme change MUST follow existing postpaid→prepaid block.
+- **FR-013**: Modify MUST deactivate source → create new same `packageId` in one transaction; block if source is DEACTIVATED, TERMINATED, or SUSPENDED (without prior activate).
+- **FR-014**: `paymentAcNumber` MUST transfer from deactivated policy to new policy in same transaction.
+- **FR-015**: Admin MUST choose policy number: **Keep Existing** or **Generate New** (required, no default).
+- **FR-016**: Prepaid payment migration: pick first payment on source policy; move it and all subsequent completed payments; set dates from first migrated payment; new status ACTIVE. No STK on modify.
+- **FR-017**: PENDING_ACTIVATION with no payments: no picker; new policy PENDING_ACTIVATION.
+- **FR-018**: Block postpaid payment migration when `postpaidSchemePaymentItem` links exist; allow plan/scheme-only modify on PENDING_ACTIVATION postpaid without migration.
+- **FR-019**: After modify, run **installment placeholder backfill** per FR-030–FR-032.
+
+### Payments UX
+
+- **FR-020**: Policy dropdown `displayText` for **all policies** MUST append status and effective date:
+  - `ACTIVE` / `PENDING_ACTIVATION` / `SUSPENDED`: `{package} - {plan} ({STATUS}, from {startDate})` — if no `startDate`, omit “from …”
+  - `DEACTIVATED`: `{package} - {plan} (DEACTIVATED, ended {endDate|deactivatedAt})`
+  - `TERMINATED`: `{package} - {plan} (TERMINATED, ended {endDate|deactivatedAt})`
+  - Dates: `DD Mon` (e.g. `26 Jan`) in local display; store UTC in API.
+- **FR-021**: Unfiltered customer payments list MUST include **Policy** column: policy number (or "—") + status.
+- **FR-022**: After successful modify, Payments tab MUST auto-select new policy id.
+
+### Deactivate / Activate / Reset
+
+- **FR-023**: Deactivate: mandatory reason; allowed from ACTIVE, SUSPENDED, PENDING_ACTIVATION; customer coupling per clarifications.
+- **FR-024**: Activate: SUSPENDED→ACTIVE only; mandatory reason; customer SUSPENDED→ACTIVE when applicable.
+- **FR-025**: Reset start date: ACTIVE or SUSPENDED; mandatory reason; payments stay on policy; math excludes pre-start payments.
+- **FR-026**: TERMINATED customer or policy: no modify, deactivate, activate, or reset.
+
+### Registration gate
+
+- **FR-027**: Customer create MUST reject duplicate `idNumber` or `phoneNumber` on any **TERMINATED** customer.
+
+### Installment backfill
+
+- **FR-030**: Add `PaymentStatus.OUTSTANDING` for backfilled expected-unpaid installment slots (not STK-pending).
+- **FR-031**: Backfill algorithm: from `policy.startDate`, step by `paymentCadence` days until `min(now, endDate)`; for each slot, if no completed payment covers the installment window and no OUTSTANDING row exists for that slot, insert placeholder with `amount = policy.premium`, `expectedPaymentDate` = slot start (UTC), `actualPaymentDate` null, unique `transactionReference` pattern `OUTSTANDING-{policyId}-{periodIndex}`.
+- **FR-032**: Installment window for “covered by completed payment”: completed payment counts if `expectedPaymentDate` (or `actualPaymentDate` if set) falls in `[slotStart, slotStart + cadenceDays - 1]` UTC calendar days.
+
+### Portal & member cards (deferred UI)
+
+- **FR-040**: Deactivated customer retains portal access; TERMINATED loses portal (gate in portal auth).
+- **FR-041**: Deactivated policy member cards show inactive indicator (red) — UI text deferred; API exposes policy status.
+
+### Premium math (documented behavior)
+
+- **FR-050**: Expected premium uses **new** `policy.premium` and **new** `paymentCadence` from `startDate` through as-of.
+- **FR-051**: Paid side sums **actual migrated payment amounts** (historical amounts preserved); excess/deficit via `computePremiumDueAndExcess`.
+- **FR-052**: Cadence change on modify is allowed; cadence delta captured in `EntityStatusChange.metadata`, not as a status transition.
+
+## Non-Functional Requirements
+
+- **NFR-001**: All status mutations MUST be transactional (Prisma `$transaction`).
+- **NFR-002**: UTC for all date operations per project standards.
+- **NFR-003**: Errors use `ValidationException`, `status` field, existing `ErrorCodes`.
+- **NFR-004**: Prisma migrations only (no `db push` on tracked DBs).
+- **NFR-005**: Admin-only guards on lifecycle endpoints.
+
+## API Endpoints (planned)
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/internal/customers/:customerId/policies/:policyId/deactivate` | Standalone deactivate |
+| `POST` | `/internal/customers/:customerId/policies/:policyId/activate` | SUSPENDED→ACTIVE |
+| `POST` | `/internal/customers/:customerId/policies/:policyId/reset-start-date` | Reset dates |
+| `POST` | `/internal/customers/:customerId/policies/:policyId/modify` | Full modify transaction + backfill |
+| `GET` | `/internal/customers/:customerId/policies/:policyId/modify-options` | Plans, schemes, eligible payments |
+| `GET` | `/internal/customers/:customerId/status-history` | Optional v1 audit list |
+
+## Out of Scope
+
+- Add Product (new package enrollment for existing customer)
+- Auto-SUSPEND on missed payments (audit entity spec-ready only)
+- Member card inactive red label copy (API status exposure in scope)
+- Messaging rules for deactivated customers
+- Postpaid payment migration on modify
+
+## Success Criteria
+
+- Admin can modify prepaid policy with payment migration; old policy deactivated, new active, payments and placeholders correct.
+- `missedPayments` count and `missedPaymentsAmount` agree after modify with cadence change.
+- Both policies visible in Products and Payments with distinguishable dropdown labels.
+- TERMINATED identity blocked at registration.
+- All manual lifecycle actions produce `EntityStatusChange` rows with mandatory reasons.
+
+## Related Documents
+
+- [data-model.md](./data-model.md) — schema, entities, backfill algorithm
+- [plan.md](./plan.md) — implementation phases
+- [checklists/requirements.md](./checklists/requirements.md) — review checklist

--- a/specs/003-policy-lifecycle/checklists/requirements.md
+++ b/specs/003-policy-lifecycle/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Policy Lifecycle & Status Rules
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-07-10  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation iteration 1 (2026-07-10): All items passed.
+- Clarifications sessions 2026-07-10 and 2026-07-11: renewal = new policy + EXPIRED + supersession; renewal start dates; overdue = next unpaid expected due date; starter blacklist = admin Terminate (no Blacklisted status); waiting periods out of scope; multi-policy Terminate (C); term-end rules; renewal IDs (new policy #, reuse pay acct + member #s); no Active after end date (debt then surplus→new policy); Suspended stays Suspended forever after end date (analytics).
+- Ready for `/speckit.plan`.

--- a/specs/003-policy-lifecycle/contracts/openapi.yaml
+++ b/specs/003-policy-lifecycle/contracts/openapi.yaml
@@ -1,0 +1,159 @@
+openapi: 3.0.3
+info:
+  title: MicroBima Policy Payment Lifecycle (Internal)
+  version: 0.1.0
+  description: >
+    Payment-driven and daily policy status automation, admin Terminate,
+    and optional daily job trigger. Authenticated via staff bearer token + registration_admin.
+servers:
+  - url: /api/v1
+paths:
+  /internal/customers/{customerId}/policies/{policyId}/terminate:
+    post:
+      summary: Terminate policy (starter blacklist)
+      operationId: terminatePolicy
+      tags: [PolicyLifecycle]
+      parameters:
+        - $ref: '#/components/parameters/CustomerId'
+        - $ref: '#/components/parameters/PolicyId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TerminatePolicyRequest'
+      responses:
+        '200':
+          description: Policy terminated; customer may be Terminated if no open policies remain
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyLifecycleActionResponse'
+        '401':
+          description: Authentication error
+        '403':
+          description: Insufficient permissions
+        '404':
+          description: Customer or policy not found
+        '422':
+          description: Validation error (e.g. missing reason, already terminated)
+  /internal/customers/{customerId}/policies/{policyId}/activate:
+    post:
+      summary: Activate suspended policy (existing; tightened for end date)
+      operationId: activatePolicyLifecycle
+      tags: [PolicyLifecycle]
+      parameters:
+        - $ref: '#/components/parameters/CustomerId'
+        - $ref: '#/components/parameters/PolicyId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReasonRequest'
+      responses:
+        '200':
+          description: Policy activated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyLifecycleActionResponse'
+        '422':
+          description: Rejected when endDate has passed or status is not SUSPENDED
+  /internal/policies/lifecycle/run-daily:
+    post:
+      summary: Run daily policy lifecycle evaluation once (ops/dev)
+      operationId: runDailyPolicyLifecycle
+      tags: [PolicyLifecycle]
+      description: >
+        Batch for the current UTC day. Protected by admin role.
+        Production also schedules this via Nest cron.
+      responses:
+        '200':
+          description: Batch summary
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DailyLifecycleRunResponse'
+        '401':
+          description: Authentication error
+        '403':
+          description: Insufficient permissions
+components:
+  parameters:
+    CustomerId:
+      name: customerId
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+    PolicyId:
+      name: policyId
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+  schemas:
+    ReasonRequest:
+      type: object
+      required: [reason]
+      properties:
+        reason:
+          type: string
+          minLength: 1
+          description: Mandatory admin description
+    TerminatePolicyRequest:
+      allOf:
+        - $ref: '#/components/schemas/ReasonRequest'
+    PolicyLifecycleActionResponse:
+      type: object
+      properties:
+        policyId:
+          type: string
+          format: uuid
+        policyStatus:
+          type: string
+          enum:
+            - PENDING_ACTIVATION
+            - ACTIVE
+            - SUSPENDED
+            - INACTIVE
+            - DEACTIVATED
+            - TERMINATED
+            - EXPIRED
+        customerId:
+          type: string
+          format: uuid
+        customerStatus:
+          type: string
+        inGracePeriod:
+          type: boolean
+        correlationId:
+          type: string
+    DailyLifecycleRunResponse:
+      type: object
+      properties:
+        evaluatedAt:
+          type: string
+          format: date-time
+        graceEntered:
+          type: integer
+        suspended:
+          type: integer
+        inactivated:
+          type: integer
+        expired:
+          type: integer
+        notificationsQueued:
+          type: integer
+        correlationId:
+          type: string
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+security:
+  - BearerAuth: []

--- a/specs/003-policy-lifecycle/data-model.md
+++ b/specs/003-policy-lifecycle/data-model.md
@@ -1,0 +1,200 @@
+# Data Model: Policy Lifecycle & Status Rules
+
+**Feature**: `003-policy-lifecycle`  
+**Date**: 2026-07-11  
+**Depends on**: `002-modify-product-policy` foundation (`EntityStatusChange`, supersession, `DEACTIVATED`, `OUTSTANDING`)
+
+## Overview
+
+Add mid-term **INACTIVE** status, grace overlay fields, suspension clock, notification idempotency ledger, and document state transitions for daily + payment-driven lifecycle. Waiting periods are out of scope (no eligibility tables).
+
+---
+
+## Enum changes
+
+### PolicyStatus
+
+```prisma
+enum PolicyStatus {
+  PENDING_ACTIVATION
+  ACTIVE
+  SUSPENDED
+  INACTIVE      // NEW — mid-term non-payment stop (before end date only entry)
+  DEACTIVATED
+  TERMINATED
+  EXPIRED
+}
+```
+
+### CustomerStatus
+
+No new values. When syncing after policy changes:
+- Open policies: `ACTIVE` | `PENDING_ACTIVATION` | `SUSPENDED`
+- Non-open: `INACTIVE` | `EXPIRED` | `DEACTIVATED` | `TERMINATED` (do not keep customer “open”)
+- Terminate path may set customer `TERMINATED` when no open policies remain; otherwise reuse existing `syncCustomerStatusAfterPolicyChange` extended for `INACTIVE`
+
+### StatusChangeTrigger
+
+Reuse existing:
+
+```prisma
+enum StatusChangeTrigger {
+  MANUAL_ADMIN
+  MODIFY_PRODUCT
+  PAYMENT_LIFECYCLE   // payment-driven grace/suspend/restore/renew/expire
+  SYSTEM              // daily job / customer sync
+}
+```
+
+---
+
+## Policy model additions
+
+```prisma
+model Policy {
+  // ... existing ...
+
+  /// Grace overlay (status remains ACTIVE when true)
+  inGracePeriod          Boolean   @default(false)
+  graceEnteredAt         DateTime?
+  /// Anchor: next unpaid expected due date that opened this overdue episode
+  overdueAnchorDueDate   DateTime?
+  /// When status became SUSPENDED (for >30 day → INACTIVE clock; before end only)
+  suspendedAt            DateTime?
+  /// When status became INACTIVE
+  inactivatedAt          DateTime?
+  /// When status became EXPIRED
+  expiredAt              DateTime?
+
+  lifecycleNotifications PolicyLifecycleNotification[]
+}
+```
+
+**Partial unique index** (unchanged predicate):
+
+```sql
+-- ACTIVE | PENDING_ACTIVATION | SUSPENDED only
+-- INACTIVE not included
+```
+
+---
+
+## PolicyLifecycleNotification (new)
+
+Idempotent scheduled/event notification ledger.
+
+```prisma
+model PolicyLifecycleNotification {
+  id          String   @id @default(uuid()) @db.Uuid
+  policyId    String   @db.Uuid
+  scheduleKey String   // e.g. PENDING_D3, GRACE_D7, RENEWAL_BEFORE_30, SUSPEND_D1
+  templateKey String
+  sentAt      DateTime @default(now())
+  metadata    Json?
+
+  policy Policy @relation(fields: [policyId], references: [id])
+
+  @@unique([policyId, scheduleKey])
+  @@index([policyId])
+  @@map("policy_lifecycle_notifications")
+}
+```
+
+### Schedule keys (normative)
+
+| scheduleKey | When |
+|-------------|------|
+| `PENDING_D3` / `PENDING_D7` | Day 3 / Day 7 still pending (day-0 welcome = existing `customer_created`, not a new key) |
+| `GRACE_DUE` | Due date / enter grace |
+| `GRACE_D7` / `GRACE_D10` / `GRACE_D13` | Overdue day markers |
+| `SUSPEND_D1` / `SUSPEND_D7` / `SUSPEND_D13` | Suspended reminders |
+| `INACTIVE_NOTICE` | Entered Inactive |
+| `REACTIVATE` | Restored to Active before end |
+| `RENEWAL_BEFORE_30` … `RENEWAL_AFTER_30` | Expiry schedule points |
+| `TERMINATE` | Admin terminate |
+
+---
+
+## EntityStatusChange usage
+
+Every transition writes `EntityStatusChange` with:
+
+| Transition | trigger |
+|------------|---------|
+| Daily grace/suspend/inactive/expire | `SYSTEM` |
+| Payment activate/restore/renew | `PAYMENT_LIFECYCLE` |
+| Admin Terminate / Activate / Deactivate | `MANUAL_ADMIN` |
+
+Metadata examples: `{ overdueDays, anchorDueDate, arrears, surplus, newPolicyId, scheduleKey }`.
+
+---
+
+## State machine (policy)
+
+```text
+PENDING_ACTIVATION --first payment--> ACTIVE
+ACTIVE --overdue 1-14d--> ACTIVE + inGracePeriod
+ACTIVE+grace --overdue >14d--> SUSPENDED (clear grace; set suspendedAt)
+SUSPENDED --arrears+2w before end--> ACTIVE
+SUSPENDED --≥30d suspended AND before end--> INACTIVE
+SUSPENDED --end date passed--> SUSPENDED (frozen)
+INACTIVE --restore rules before end--> ACTIVE
+INACTIVE --end date passed--> EXPIRED
+ACTIVE/grace --end date passed--> EXPIRED
+EXPIRED --renewal payment / surplus--> new ACTIVE (+ supersession); old stays EXPIRED
+SUSPENDED past end --surplus after debt--> new ACTIVE; old stays SUSPENDED
+* --admin Terminate--> TERMINATED
+DEACTIVATED / TERMINATED --payment lifecycle--> ignored
+```
+
+**Invariant**: Never set `ACTIVE` if `endDate` has passed (calendar UTC).
+
+---
+
+## Renewal / supersession
+
+On new policy create (expiry renew or post–end surplus):
+
+| Field | Rule |
+|-------|------|
+| `policyNumber` | Generate new |
+| `paymentAcNumber` | Copy from prior (null prior first if unique constraint requires, same as modify) |
+| Member numbers | Copy principal/dependant member numbers onto new policy members |
+| `startDate` | Within 30d of expiry: day after old `endDate`; else payment date |
+| `endDate` | `policyEndDateFromStart(startDate)` (same time of day as start) |
+| `supersedesPolicyId` / `supersededByPolicyId` | Link pair |
+| Package/plan/scheme/cadence | Copy from prior unless product rules say otherwise |
+
+Surplus payment row(s) attach to **new** `policyId`; debt portion stays on old.
+
+---
+
+## Due date & amounts (logical)
+
+Not stored as a schedule table in v1; computed:
+
+- `nextUnpaidExpectedDueDate(policy, asOf)`
+- `daysOverdue(policy, asOf)`
+- `outstandingArrears(policy, asOf)`
+- `twoWeekUpfrontAmount(policy)`
+- `oneMonthPremiumAmount(policy)`
+- `amountRequiredToRestore(policy)` — Suspended: arrears + 2 weeks; Inactive &lt;30d: same; Inactive ≥30d: one month (before end only)
+
+---
+
+## Validation rules
+
+1. Terminate: non-empty `reason` / description required.
+2. Activate: status must be `SUSPENDED`, `endDate` not passed.
+3. Restore via payment: paid amount ≥ required; `endDate` not passed.
+4. Daily job: skip `DEACTIVATED`, `TERMINATED`; Suspended past end: no Inactive/Expired auto-change.
+5. Notification insert: ignore unique violation (already sent).
+
+---
+
+## Migration notes
+
+- `npx prisma migrate dev --name policy_payment_lifecycle` (never `db push`).
+- Add enum value `INACTIVE` with PostgreSQL `ALTER TYPE ... ADD VALUE`.
+- Backfill: `suspendedAt` null OK; job sets on next suspend.
+- Seed messaging templates in `seed-messaging.sql` (idempotent `ON CONFLICT`).

--- a/specs/003-policy-lifecycle/plan.md
+++ b/specs/003-policy-lifecycle/plan.md
@@ -1,0 +1,153 @@
+# Implementation Plan: Policy Lifecycle & Status Rules
+
+**Branch**: `003-policy-lifecycle` | **Date**: 2026-07-11 | **Spec**: [spec.md](./spec.md)  
+**Input**: Feature specification from `/specs/003-policy-lifecycle/spec.md`
+
+## Summary
+
+Automate **payment-driven and daily** policy status transitions (Pending Activation → Active → Grace overlay → Suspended → Inactive / Expired), **expiry renewal** as a new superseded policy, **admin Terminate** (starter “blacklist”), and **lifecycle SMS** — building on the admin foundation in `002-modify-product-policy` (`PolicyLifecycleService`, `EntityStatusChange`, supersession fields). Waiting periods and claims-based post–end-date routing stay out of scope.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.3.x, Node.js >= 18  
+**Primary Dependencies**: NestJS 11.x, Prisma 6.x, `@nestjs/schedule`, existing messaging outbox, Next.js agent-registration (admin UI)  
+**Storage**: PostgreSQL via Prisma migrations (no `db push`)  
+**Testing**: Jest unit + integration tests under `apps/api`  
+**Target Platform**: Fly.io-hosted NestJS API + agent-registration admin  
+**Project Type**: Monorepo web (API + Next.js admin)  
+**Performance Goals**: Daily batch completes before next business day (SC-008); payment-driven transitions synchronous with confirmed payment path  
+**Constraints**: UTC date math; `ValidationException` + `ErrorCodes`; RBAC `registration_admin` for Terminate; no Active after `endDate`; Suspended frozen after end date for analytics  
+**Scale/Scope**: Production policy book overnight evaluation; idempotent notification schedule points
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Gate | Status | Notes |
+|------|--------|-------|
+| I. API-First | Pass | Terminate + optional job trigger via Internal REST; payment hooks in existing payment services |
+| II. Prisma migrations / UTC | Pass | Migration for `INACTIVE`, grace fields, notification ledger; all day counts UTC |
+| III. Error handling | Pass | ValidationException for Activate-after-end, Terminate reason, insufficient restore amount |
+| IV. Code quality | Pass | Strict TS; `pnpm lint` after changes |
+| V. Workflow | Pass | Feature branch → PR to staging |
+| VI. Stack | Pass | NestJS / Prisma / pnpm |
+| VII. Security | Pass | Authentik admin RBAC on Terminate; no public partner terminate |
+| VIII. Observability | Pass | EntityStatusChange + Sentry on job failures; correlation IDs on admin calls |
+
+**Post-design re-check**: Pass — design uses migrations, UTC, existing messaging/outbox, admin RBAC; no constitution violations requiring Complexity Tracking.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/003-policy-lifecycle/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── openapi.yaml
+├── checklists/
+│   └── requirements.md
+└── tasks.md              # /speckit.tasks (not this command)
+```
+
+### Source Code (repository root)
+
+```text
+apps/api/
+├── prisma/
+│   ├── schema.prisma
+│   ├── migrations/YYYYMMDDHHMMSS_policy_payment_lifecycle/
+│   └── seed-messaging.sql          # lifecycle SMS templates
+├── src/
+│   ├── services/
+│   │   ├── policy-lifecycle.service.ts   # extend: terminate, renew, payment apply, daily eval helpers
+│   │   ├── policy-lifecycle-job.service.ts  # NEW @Cron daily
+│   │   ├── policy-lifecycle-messaging.service.ts  # NEW enqueue lifecycle SMS
+│   │   ├── policy.service.ts             # activation dates; block activate after end
+│   │   ├── entity-status-change.service.ts
+│   │   └── mpesa-*.service.ts            # hook payment-driven transitions
+│   ├── utils/
+│   │   ├── policy-dates.util.ts          # keep existing same-time-of-day end date
+│   │   ├── premium-statement-math.ts     # arrears / 2-week / 1-month amounts
+│   │   └── policy-due-date.util.ts       # NEW next unpaid expected due date
+│   ├── controllers/internal/
+│   │   └── policy-lifecycle.controller.ts  # + terminate; optional job run
+│   └── dto/policy-lifecycle/
+apps/agent-registration/
+└── src/app/(main)/customer/[customerId]/_components/
+    ├── products-tab.tsx                  # Terminate menu item
+    └── policy-reason-dialog.tsx          # reuse for Terminate
+```
+
+**Structure Decision**: Extend existing NestJS API + admin Products tab; no new apps. Daily job via `@nestjs/schedule` (same pattern as attachment retention cleanup).
+
+## Implementation Phases
+
+### Phase A — Schema & due-date primitives
+
+1. Migration: `PolicyStatus.INACTIVE`; Policy grace/suspension clock fields; `PolicyLifecycleNotification` (idempotency); ensure partial unique index still only `ACTIVE|PENDING_ACTIVATION|SUSPENDED`.
+2. `policy-due-date.util.ts`: next unpaid expected due date from cadence + paid coverage (reuse premium-statement math / installment slots).
+3. Confirm `policyEndDateFromStart` keeps start time-of-day (no 23:59:59 change per FR-001 clarification).
+
+### Phase B — Daily evaluation job
+
+1. `PolicyLifecycleJobService` `@Cron('0 1 * * *')` UTC (configurable): grace enter/exit flags; Active→Suspended; Suspended→Inactive (before end only); Active/Grace→Expired; Inactive→Expired; skip Suspended/Terminated/Deactivated term mutations per spec.
+2. Queue scheduled SMS (pending activation D3/D7, grace reminders, suspension, inactive, renewal schedule) with ledger dedupe.
+3. Admin/dev `POST .../lifecycle/run-daily` (guarded) for testability.
+
+### Phase C — Payment-driven transitions
+
+1. Central `applyPaymentToPolicyLifecycle(payment)` called from IPN/STK/completed payment paths:
+   - First payment → activate (existing) + clear pending reminders
+   - Before end: Suspended restore if arrears+2 weeks; Inactive restore rules
+   - On/after end: debt first; Suspended debt cleared → Expired; surplus → `renewPolicyFromExpiredOrPostEnd` (new policy #, reuse `paymentAcNumber` + member numbers, supersession)
+2. Block admin `activatePolicy` when `endDate` passed (FR-012a).
+3. Audit all with `StatusChangeTrigger.PAYMENT_LIFECYCLE` or `SYSTEM`.
+
+### Phase D — Admin Terminate + messaging seed
+
+1. `terminatePolicy` + UI menu next to Reset Start Date (mandatory description).
+2. Customer coupling: Terminated only if no remaining Active/Pending/Suspended (Inactive/Expired/Deactivated do not keep customer open); extend sync helper for `INACTIVE`.
+3. Seed lifecycle message templates + `PolicyLifecycleMessagingService` (update `MessagingSettingsSnapshot` only if new system_settings keys are required — prefer message_templates only).
+
+### Phase E — Tests & verification
+
+1. Unit: due-date, day boundaries, restore amounts, renew start dates, Suspended-after-end freeze, Terminate multi-policy.
+2. Integration: daily job idempotency; payment surplus split; notification ledger unique constraint.
+
+## Risk & mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| No forward schedule table today | Derive next due from cadence + paid windows; optionally ensure `OUTSTANDING` placeholders for Active policies in job |
+| Partial unique + renew | New Active row + old Expired/Suspended; index allows multiple terminal rows |
+| Double SMS | Unique `(policyId, scheduleKey)` ledger |
+| Surplus split accounting | Single transaction: allocate debt to old `policyId`, create new policy, attach surplus payment row to new |
+| Admin Activate vs automation | Shared `assertCanBecomeActive(policy)` gate |
+
+## Out of scope (this branch)
+
+- Waiting periods / service-access evaluation
+- Claims-based post–end-date payment routing
+- Auto-terminate from utilization + default
+- Separate Blacklisted status
+- Status history admin UI page (API audit writes only)
+- New payment rails
+
+## Complexity Tracking
+
+> None — no constitution violations.
+
+## Verification
+
+- [ ] First payment activates + dates; pending reminders stop
+- [ ] Overdue 1–14 → grace; >14 → Suspended; >30 Suspended before end → Inactive
+- [ ] Active past end → Expired; Suspended past end stays Suspended; Inactive past end → Expired
+- [ ] No Active after end (admin + payment)
+- [ ] Surplus after debt creates new policy with new number, reused pay acct + members, supersession
+- [ ] Terminate selected policy; customer Terminated only when no open policies
+- [ ] Notification schedule points not duplicated
+- [ ] `pnpm lint` clean

--- a/specs/003-policy-lifecycle/quickstart.md
+++ b/specs/003-policy-lifecycle/quickstart.md
@@ -1,0 +1,77 @@
+# Quickstart: Policy Lifecycle & Status Rules
+
+**Feature**: `003-policy-lifecycle`  
+**Depends on**: `002-modify-product-policy` foundation applied
+
+## Prerequisites
+
+```bash
+cd apps/api
+npx prisma migrate dev --name policy_payment_lifecycle
+# apply messaging template seed additions (idempotent)
+psql "$DATABASE_URL" -f prisma/seed-messaging.sql   # or project seed script
+```
+
+- Admin user with `registration_admin`
+- UTC clock for day-boundary tests
+
+## New / changed API
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/internal/customers/:customerId/policies/:policyId/terminate` | Admin terminate (mandatory reason) |
+| `POST` | `/internal/customers/:customerId/policies/:policyId/activate` | Existing; **422** if `endDate` passed |
+| `POST` | `/internal/policies/lifecycle/run-daily` | Manual daily evaluation |
+
+See [contracts/openapi.yaml](./contracts/openapi.yaml).
+
+## Manual test flows
+
+### 1. Grace → Suspend → Inactive (before end)
+
+1. Active prepaid policy with known cadence; ensure unpaid expected due is in the past.
+2. `POST .../lifecycle/run-daily` with overdue 1–7 days → `inGracePeriod=true`, status still `ACTIVE`.
+3. Advance overdue &gt;14 days → run daily → `SUSPENDED`, grace cleared.
+4. Set `suspendedAt` &gt;30 days ago, end date still future → run daily → `INACTIVE`.
+
+### 2. Term end rules
+
+1. Active policy with `endDate` yesterday → daily → `EXPIRED`.
+2. Suspended policy with `endDate` yesterday → daily → still `SUSPENDED`.
+3. Inactive policy with `endDate` yesterday → daily → `EXPIRED`.
+4. Attempt Activate on Suspended past end → **422**.
+
+### 3. Post–end-date payment
+
+1. Suspended past end with arrears A; pay `A` → debt reduced; status still Suspended; not Active.
+2. Pay `A + surplus` → new Active policy (new number, same pay acct / member numbers); old remains Suspended; supersession linked.
+
+### 4. Expiry renewal
+
+1. Expired policy; payment within 30 days of end → new policy start = day after old end.
+2. Payment after 30 days → new start = payment date.
+
+### 5. Admin Terminate
+
+1. Admin → Customer → Products → ⋮ → **Terminate** (same menu as Reset Start Date).
+2. Mandatory description → selected policy `TERMINATED`.
+3. Second open policy remains; customer not Terminated until last open policy closed.
+
+### 6. Notifications
+
+1. Confirm schedule keys not double-queued on second `run-daily` same UTC day.
+2. SMS/outbox rows for grace/suspend/renewal templates present when messaging enabled.
+
+## Unit tests (examples)
+
+```bash
+cd apps/api
+npx jest src/utils/__tests__/policy-due-date.util.spec.ts
+npx jest src/services/__tests__/policy-lifecycle*.spec.ts
+```
+
+## Lint
+
+```bash
+cd ~/Projects/microbima && pnpm lint
+```

--- a/specs/003-policy-lifecycle/research.md
+++ b/specs/003-policy-lifecycle/research.md
@@ -1,0 +1,117 @@
+# Research: Policy Lifecycle & Status Rules
+
+**Feature**: `003-policy-lifecycle`  
+**Date**: 2026-07-11
+
+## R1 — Grace representation
+
+**Decision**: Keep member-facing `PolicyStatus.ACTIVE` during grace; store overlay on Policy (`inGracePeriod`, `graceEnteredAt`, `overdueAnchorDueDate`).
+
+**Rationale**: Spec FR-004; avoids enum churn and partner confusion; dashboard can filter `inGracePeriod = true`.
+
+**Alternatives considered**: Separate `GRACE` status (rejected — contradicts clarifications); compute grace only at read time (rejected — harder for SMS schedule and audits).
+
+---
+
+## R2 — `INACTIVE` status
+
+**Decision**: Add `PolicyStatus.INACTIVE` via Prisma migration. Treat like terminal for partial unique index (not in `ACTIVE|PENDING_ACTIVATION|SUSPENDED` set). Customer sync treats `INACTIVE` like `EXPIRED`/`DEACTIVATED` (does not keep customer “open”).
+
+**Rationale**: Spec distinguishes mid-term non-payment stop from `EXPIRED` (finished cycle / Inactive past end).
+
+**Alternatives considered**: Reuse `EXPIRED` for both (rejected — breaks analytics and reactivation rules); reuse `DEACTIVATED` (rejected — admin/business closure from 002).
+
+---
+
+## R3 — Next unpaid expected premium due date
+
+**Decision**: Compute from policy `startDate` + `paymentCadence` days and completed/outstanding payment coverage using existing premium-statement / installment-slot math (`premium-statement-math.ts`, `installment-backfill.util.ts`). “Next unpaid due” = earliest expected installment slot date ≤ today that is not covered by confirmed paid amount (or earliest future uncovered slot if current). Overdue days = UTC calendar days from that anchor when unpaid.
+
+**Rationale**: Spec Option B; no separate schedule table in codebase today; math already used for missed amounts.
+
+**Alternatives considered**: Fixed monthly due day (rejected); days-since-last-payment only (rejected); mandatory always-materialized `OUTSTANDING` rows for every slot (optional enhancement later — job may backfill missing placeholders for Active policies to keep Products tab aligned).
+
+---
+
+## R4 — Daily job mechanism
+
+**Decision**: NestJS `@Cron` service (UTC), same stack as attachment retention cleanup — not Bull. Optional internal `POST` to run once for staging/tests.
+
+**Rationale**: Already in monorepo; simple idempotent daily pass; messaging outbox already drains every 5s.
+
+**Alternatives considered**: BullMQ (rejected — not in API today); external cron hitting HTTP only (keep as supplement, not sole mechanism).
+
+---
+
+## R5 — Policy end time-of-day
+
+**Decision**: Keep existing `policyEndDateFromStart`: end = start + 1 calendar year − 1 day at the **same time of day** as start (e.g. 10:15 → 10:15). Do **not** force 23:59:59.999 UTC.
+
+**Rationale**: Stakeholder accepted current util behavior (A1 remediation).
+
+**Alternatives considered**: Force 23:59:59.999 UTC on end day (rejected).
+
+---
+
+## R7 — Post–end-date surplus renewal from Suspended
+
+**Decision**: Allocate payment to old policy debt first. When Suspended-past-end **debt reaches zero** → set prior to **EXPIRED** (never Active). Surplus above debt creates new Active renewal policy (new policy number; reuse `paymentAcNumber` + member numbers; supersession). If debt never fully paid → stay **Suspended** forever.
+
+**Rationale**: Clarification remediation 2026-07-11 — analytics retain Suspended while owing; finished premiums close the term as Expired.
+
+**Alternatives considered**: Leave Suspended forever even after debt cleared (rejected by stakeholder); force Expired at term end while still owing (rejected — obscures unpaid suspended book).
+
+---
+
+## R6 — Restore / renew payment amounts
+
+**Decision**:
+- Arrears = outstanding premium due from statement math.
+- **2 weeks upfront** = `ceil(14 / paymentCadenceDays) × installmentAmount`.
+- **One month** = `ceil(31 / paymentCadenceDays) × installmentAmount`.
+
+**Rationale**: Spec remediation U1; integer installment products.
+
+**Alternatives considered**: Hardcoded KES; pure calendar pro-rate without ceil (rejected for cadence products).
+
+---
+
+## R8 — Admin Activate after end date
+
+**Decision**: `activatePolicy` and any payment restore path call shared `assertPolicyMayBecomeActive` — throws `ValidationException` if `endDate` passed or status is Terminated/Deactivated/Expired (Expired uses renew path only).
+
+**Rationale**: FR-012a.
+
+---
+
+## R9 — Lifecycle SMS
+
+**Decision**: Add `message_templates` rows (seed SQL) + enqueue via existing messaging outbox. Idempotency via `policy_lifecycle_notifications` unique `(policyId, scheduleKey)`. Prefer template keys over new `system_settings` unless branding toggles needed (then follow MessagingSettingsSnapshot sync rule).
+
+**Rationale**: Matches customer-messaging architecture; FR-024.
+
+**Alternatives considered**: Inline SMS send in job (rejected — bypasses outbox/retries).
+
+---
+
+## R10 — Terminate vs 002 Activate
+
+**Decision**: New `terminatePolicy`; UI beside Reset Start Date using reason dialog. Customer Terminated only if no remaining Active/Pending Activation/Suspended. Do not auto-terminate other policies.
+
+**Rationale**: Spec FR-019–020 Option C.
+
+---
+
+## R11 — Partial unique index
+
+**Decision**: Keep index predicate `status IN ('ACTIVE','PENDING_ACTIVATION','SUSPENDED')`. `INACTIVE` / `EXPIRED` / `TERMINATED` / `DEACTIVATED` unrestricted for history + renew.
+
+**Rationale**: Same as 002; renew needs new Active while old terminal/suspended rows remain.
+
+---
+
+## Open items deferred to implementation tasks (not blocking plan)
+
+- Exact cron hour (default 01:00 UTC) — config flag OK.
+- Whether to eagerly materialize `OUTSTANDING` rows each night — start with compute-only; add backfill if Products missed counts drift.
+- Portal TERMINATED gate (002 FR-040) — still separate if not done.

--- a/specs/003-policy-lifecycle/spec.md
+++ b/specs/003-policy-lifecycle/spec.md
@@ -1,0 +1,294 @@
+# Feature Specification: Policy Lifecycle & Status Rules
+
+**Feature Branch**: `003-policy-lifecycle`  
+**Created**: 2026-07-10  
+**Status**: Draft  
+**Input**: User description: "I want to build a policy lifecycle process" with starter document *Mfanisi Go Policy Lifecycle & Status Rules* (policy term, statuses, grace, waiting periods, renewal, blacklist, daily automation, and notification templates).
+
+## Clarifications
+
+### Session 2026-07-10
+
+- **Q:** On renewal/reactivation to Active, same policy vs new record, and how is the cover term set? **→ A:** **Option D (refined):** Suspension restore stays on the **same** policy (original start/end unchanged). When a policy has **finished its cycle** (term ended), renewal creates a **new policy record**; the old policy is marked **EXPIRED**; payments for the new period link to the new policy; `supersedesPolicyId` / `supersededByPolicyId` link the pair. Within vs after 30 days after expiry changes new-policy **start date** (and formerly waiting-period intent in the starter doc; waiting periods are out of scope for this feature).
+- **Q:** What is the new policy’s start date on expiry renewal? **→ A:** **Option A:** Both within-30-day and after-30-day renewals create a **new policy record**. Within 30 days: new start = **day after old end** (continuous cover). After 30 days: new start = **payment date**. End date follows the 12-month term rule from that start.
+- **Q:** What starts the grace / suspension clock? **→ A:** **Option B:** Overdue is measured from the policy’s **next unpaid expected premium due date** on its payment schedule (daily/weekly/monthly/etc.), not a fixed calendar month or “days since last payment” alone.
+
+### Session 2026-07-11
+
+- **Q:** What happens on “blacklist” / abuse permanent close? **→ A:** **Option D (refined):** No separate Blacklisted status. Before claims-processor integration, permanent restriction is **manual admin only**. Admin action lives in the same policy actions menu as **Reset Start Date**, with a confirmation popup and **mandatory description**. Sets the **selected policy** to **TERMINATED**; customer Terminated only per multi-policy rule (see later clarification). Starter-doc “blacklisted” maps to system **Terminated** (existing registration gate). Automatic default+utilization blacklist is **out of scope** until claims integration.
+- **Q:** Are waiting periods / service-access evaluation in scope? **→ A:** **Option D:** Waiting periods are **entirely out of scope** for this feature. This feature covers **status transitions only** (plus related dates, notifications, renewal/supersession, and admin Terminate). Benefit eligibility / waiting-period enforcement is deferred (e.g., with claims integration).
+- **Q:** Terminate when the customer has multiple policies? **→ A:** **Option C:** Terminate **only the selected policy**. Customer becomes **Terminated** only if they have **no remaining** Active, Pending Activation, or Suspended policies; otherwise customer status is recalculated from remaining open policies (same coupling idea as deactivate in 002).
+- **Q:** Inactive policy whose term end date also passes? **→ A:** **Option A (refined):** Inactive + end date passed → **Expired** (renewal/new-policy rules then apply). **Suspended** + end date passed → stays **Suspended** (no automatic status change at term end). **Terminated** + end date passed → stays **Terminated**. Active/Grace + end date passed without renewal → **Expired**.
+- **Q:** On expiry renewal, policy number and payment account number? **→ A:** **Option B (refined):** Generate a **new policy number**; **reuse** `paymentAcNumber` and **member numbers** on the new policy.
+- **Q:** Can a Suspended (or any) policy be restored to Active after end date? **→ A:** **No.** After end date a policy **cannot** return to Active (member treatment would not be valid; **admin Activate is also blocked**). Payments after end date still **collect premium debt** on the existing policy first; **any amount above outstanding debt** creates a **new** renewal policy (new policy number; reuse pay account + member numbers; supersession). Future claims-based rule (if no utilization, after one month all payment → new policy; before that → old debt) is **deferred** until claim data exists.
+- **Q:** After end date, does Suspended → Inactive (>30 days) still run? **→ A:** **No** auto Suspended → Inactive after end date. **Refined (Session 2026-07-11 remediation):** Suspended past end **stays Suspended while premium debt remains**. When the customer **finishes paying outstanding premium debt** on that Suspended-past-end policy, status becomes **EXPIRED** (still never Active). Surplus above debt still creates a **new** renewal policy. If they never finish paying debt, status stays **Suspended** forever (analytics).
+
+### Session 2026-07-11 — Analysis remediation
+
+- **Q:** I1 job service ordering? **→ A:** Pending reminders wired via messaging/lifecycle helpers in US1; `PolicyLifecycleJobService` created in Foundational as stub / fully implemented in US6.
+- **Q:** U4 pending D0 welcome template? **→ A:** Keep existing `customer_created` only; do **not** add a separate pending-activation welcome template. Day 3 / Day 7 reminders are new.
+- **Q:** U1 restore amount formula? **→ A:** Use **ceil(daysNeeded / paymentCadenceDays) × installmentAmount** for 14-day upfront and one-month (~31 days) amounts.
+- **Q:** Post–end Suspended when debt cleared? **→ A:** Suspended past end + debt fully paid → **EXPIRED**; unpaid debt remaining → stay **Suspended**.
+- **Q:** A1 end time-of-day vs FR-001? **→ A:** Keep existing util: end = start + 1 year − 1 day at the **same time of day** as start (e.g. 10:15 → 10:15). Do not force 23:59:59.
+- **Q:** U3 prepaid vs postpaid? **→ A:** Lifecycle rules (grace, suspend, inactive, expire, renew, payments) apply to **both prepaid and postpaid**.
+- **Q:** C3 partial restore messaging? **→ A:** `ValidationException` only; no dedicated “amount too low” SMS.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Activate policy on first payment (Priority: P1)
+
+A newly registered customer has a policy in **Pending Activation**. When their first premium payment is received, the policy becomes **Active**, cover dates are set for a full 12-month term, and they receive confirmation.
+
+**Why this priority**: Without activation, no cover exists; this is the entry point of the entire lifecycle.
+
+**Independent Test**: Create a customer/policy without payment; record first payment; confirm status Active, start/end dates correct, and activation messages sent.
+
+**Acceptance Scenarios**:
+
+1. **Given** a policy in Pending Activation with no completed premium, **When** the first qualifying premium payment is received, **Then** the policy status becomes Active and the customer is notified that cover is active.
+2. **Given** activation on date D at time T, **When** start and end dates are assigned, **Then** cover begins at D+T and ends at the same clock time T on the calendar day before the one-year anniversary of D (existing date util).
+3. **Given** a policy still in Pending Activation, **When** day 3 / day 7 after creation elapse without first payment, **Then** activation reminder messages are sent (day 0 welcome is covered by existing `customer_created`, not a new template).
+
+---
+
+### User Story 2 - Grace period while cover remains active (Priority: P1)
+
+An Active policyholder misses a premium due date on their payment schedule. For up to 14 days after that unpaid expected due date they remain **Active** (grace overlay), receive escalating reminders, and keep cover for lifecycle purposes.
+
+**Why this priority**: Protects members briefly after a missed payment and drives collection before suspension.
+
+**Independent Test**: Set an Active policy with a due date in the past by 1–14 days; run the daily lifecycle check; confirm grace overlay and correct reminder on the matching day.
+
+**Acceptance Scenarios**:
+
+1. **Given** an Active policy whose **next unpaid expected premium due date** (from the policy’s payment schedule) is overdue by 1–14 days, **When** the daily status check runs, **Then** the policy remains Active but is marked internally as in Grace Period.
+2. **Given** a policy in Grace Period, **When** the due date, day 7, day 10, or day 13 of overdue elapses, **Then** the corresponding premium reminder is sent (due-date, overdue, urgent, final-before-suspension).
+3. **Given** a policy in Grace Period, **When** the member pays the outstanding premium before day 15 of overdue, **Then** grace ends, the policy stays Active, and cover continues without suspension.
+
+---
+
+### User Story 3 - Suspend for non-payment and restore on arrears (Priority: P1)
+
+If premium remains unpaid after 14 days of grace, the policy becomes **Suspended** and cover is treated as stopped for lifecycle purposes. Paying all arrears plus 2 weeks of upfront premium restores Active cover.
+
+**Why this priority**: Core collection enforcement and the primary path back to cover after missed payments.
+
+**Independent Test**: Advance overdue past 14 days → Suspended; pay arrears + 14 days premium → Active again with reactivation message.
+
+**Acceptance Scenarios**:
+
+1. **Given** an Active (grace) policy with premium overdue more than 14 days, **When** the daily status check runs, **Then** status becomes Suspended and a suspension notice is sent.
+2. **Given** a Suspended policy, **When** day 1 / day 7 / day 13 of suspension elapse without restoration, **Then** suspension notice / arrears reminder / final-before-inactive reminders are sent.
+3. **Given** a Suspended policy **before** its end date, **When** the member pays all outstanding arrears plus 2 weeks of premium at the policy’s rate, **Then** status becomes Active and a reactivation message is sent.
+4. **Given** a Suspended (or Inactive) policy **on or after** its end date, **When** an admin or payment flow would otherwise activate it, **Then** the policy does **not** become Active.
+
+---
+
+### User Story 4 - Move to Inactive / Expired after prolonged suspension or term end (Priority: P1)
+
+A policy becomes **Inactive** when it remains Suspended for more than 30 days (mid-term non-payment path). When the **policy term ends** without renewal, the policy becomes **Expired**. Renewal after a finished cycle always creates a **new** policy record; mid-term reactivation from Inactive stays on the **same** policy. Within vs after 30 days after expiry changes the **new policy start date** only (waiting-period effects are out of scope).
+
+**Why this priority**: Closes the non-payment and expiry paths and defines how members return to cover.
+
+**Independent Test**: Leave a policy Suspended >30 days → Inactive (same policy restore on payment); expire a term → Expired; renew within vs after 30 days and verify new policy, start dates, and supersession links.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Suspended policy overdue (or suspended) for more than 30 days, **When** the daily status check runs, **Then** status becomes Inactive and an inactive notification is sent.
+2. **Given** an Active or Grace policy whose end date has passed without renewal, **When** the daily status check runs, **Then** status becomes **Expired**.
+3. **Given** a Suspended policy whose end date has passed, **When** the daily status check runs (including after >30 days suspended), **Then** status remains **Suspended** forever (no Inactive/Expired auto-transition after end date).
+4. **Given** an Inactive policy whose end date has passed, **When** the daily status check runs, **Then** status becomes **Expired**.
+5. **Given** a Terminated policy whose end date has passed, **When** the daily status check runs, **Then** status remains **Terminated** (no change).
+6. **Given** an Inactive policy from prolonged non-payment **and end date not yet passed**, **When** payment is made within 30 days of becoming Inactive, **Then** paying arrears plus 2 weeks upfront restores **the same** policy to Active (original term dates unchanged).
+7. **Given** an Inactive policy from prolonged non-payment **and end date not yet passed**, **When** payment is made more than 30 days after becoming Inactive, **Then** paying one month of premium restores **the same** policy to Active (original term dates unchanged).
+8. **Given** any policy **on or after** its end date with outstanding premium debt, **When** a payment is received, **Then** the payment is applied to that policy’s outstanding debt first and the policy does **not** become Active.
+9. **Given** a payment on or after end date that exceeds outstanding debt, **When** the surplus is applied, **Then** a **new** renewal policy is created (new policy number; reused payment account number and member numbers; supersession links; start-date rules per within/after 30 days of expiry as applicable); the prior policy does not become Active; if prior was Suspended it remains Suspended.
+10. **Given** an Expired policy (finished cycle), **When** the holder renews within 30 days after expiry (including via surplus-after-debt payment), **Then** a **new** policy is created as Active with a **new policy number**, **reused** payment account number and member numbers, start date = **day after the old policy’s end date**, end date per the 12-month rule, payments for the new period link to the new policy, the old policy remains Expired, and supersession links connect the pair.
+11. **Given** an Expired (or post–end-date) policy, **When** the holder renews more than 30 days after expiry, **Then** a **new** policy is created as Active with start date = **payment date**, new policy number, reused pay account and member numbers, supersession links, and prior policy not Active.
+12. **Given** a policy approaching or past expiry, **When** the renewal notification schedule fires (30d, 14d, 7d, 3d, 24h before; 24h, 3d, 7d, 14d, 30d after), **Then** the corresponding renewal message is sent once per schedule point.
+
+---
+
+### User Story 5 - Admin terminate (starter “blacklist”) (Priority: P2)
+
+Administrators can permanently **Terminate** a selected policy (fraud, regulatory, customer request, product discontinuation, or abuse formerly called “blacklist” in the starter doc). The action sits in the same policy actions menu as **Reset Start Date**, requires confirmation and a **mandatory description**, and sets the **selected policy** to **Terminated**. The **customer** becomes Terminated only when they have no remaining Active, Pending Activation, or Suspended policies; otherwise customer status follows remaining open policies. There is no separate Blacklisted status. Automatic termination from default + utilization is deferred until claims-processor integration.
+
+**Why this priority**: Protects the book and supports compliance via an explicit admin control; less frequent than payment-driven transitions.
+
+**Independent Test**: Terminate one of two open policies → selected policy Terminated, customer not Terminated; terminate the last open policy → customer Terminated; registration gate blocks when customer is Terminated.
+
+**Acceptance Scenarios**:
+
+1. **Given** an admin on a policy’s actions menu (same menu as Reset Start Date), **When** they choose Terminate, **Then** a confirmation popup requires a mandatory description before submit.
+2. **Given** a customer with multiple open policies (Active, Pending Activation, and/or Suspended), **When** admin confirms Terminate on one policy with description, **Then** only that policy becomes **Terminated**, an audit record stores the description/reason, a termination notification is sent for that policy, and the customer remains non-Terminated with status derived from remaining open policies.
+3. **Given** a customer whose only remaining open policy (Active, Pending Activation, or Suspended) is terminated, **When** admin confirms Terminate with description, **Then** that policy and the **customer** both become **Terminated**, and neither can automatically return to Active.
+4. **Given** a Terminated customer, **When** anyone attempts new registration or new policy creation matching that identity, **Then** the request is rejected by the existing Terminated registration gate (no separate blacklist override flow in this feature).
+5. **Given** payment or daily lifecycle automation, **When** evaluating policies, **Then** the system does **not** auto-terminate (or “blacklist”) solely because of default >30 days plus prior utilization.
+
+---
+
+### User Story 6 - Daily automated status processing (Priority: P1)
+
+Operations rely on a once-per-day automated pass that evaluates Active (including grace), Suspended, and expiring policies, applies status transitions, and queues the right notifications. Payment events also drive immediate transitions (first payment, arrears clearance, renewal).
+
+**Why this priority**: Without reliable automation, grace/suspension/inactive/renewal rules will not hold at scale.
+
+**Independent Test**: Seed policies in each boundary state; run the daily process once; verify expected status changes and that duplicate runs the same day do not double-send the same scheduled notification.
+
+**Acceptance Scenarios**:
+
+1. **Given** Active policies with overdue premiums, **When** the daily check runs, **Then** overdue 1–14 days → Grace; overdue >14 days → Suspended.
+2. **Given** Suspended policies **before** end date, **When** the daily check runs, **Then** those past 30 days of suspension/non-payment path → Inactive.
+3. **Given** policies nearing or past end date, **When** the daily check runs, **Then** renewal notifications for due schedule points are queued; Active/Grace past end → **Expired**; Inactive past end → **Expired**; Suspended past end → remains **Suspended** (including no >30-day Inactive transition after end date); Terminated past end → unchanged.
+4. **Given** a payment event (first payment / arrears+2 weeks / renewal), **When** payment is confirmed, **Then** the status change from the developer decision table applies without waiting for the next daily run.
+5. **Given** any automated or payment-driven status change, **When** it completes, **Then** an auditable status-change record exists with reason and trigger (system payment lifecycle vs admin).
+
+---
+
+### Edge Cases
+
+- Policy created and first payment received on the same day: activate immediately; skip remaining pending-activation reminders.
+- Payment received on the exact grace boundary (end of day 14 vs start of day 15): day 1–14 inclusive stay in grace; after 14 full days overdue → Suspended on the next daily evaluation (or immediately if evaluation is event-driven).
+- Multiple premiums owed (several missed cycles): arrears means the full outstanding balance; “2 weeks upfront” is additional to that balance.
+- Leap years / anniversary: end date is start + 1 calendar year − 1 day at the **same time of day** as start (UTC), so the term is one full year of cover.
+- Member in Grace who also hits policy end date: term expiry to **Expired** takes precedence over remaining grace.
+- Suspended policy that reaches end date: status remains **Suspended** while debt remains (no auto Inactive). It cannot become Active after end date. When debt is **fully paid**, status → **EXPIRED**; surplus above debt creates a new renewal policy.
+- Terminated policy at term end: status does **not** change (stays Terminated).
+- Inactive policy past end date: becomes **Expired**.
+- Post–end-date payment: applied to outstanding premium debt on the existing policy first; policy never returns to Active (including admin Activate). Amount above debt creates a new renewal policy (new policy number; reuse pay account + member numbers; supersession). **Suspended past end + debt fully cleared → EXPIRED**; unpaid debt remaining → stay Suspended.
+- Claims-based post–end-date allocation (utilization check; after one month all to new policy) is deferred until claim data exists.
+- Blacklist vs Terminate: Starter-doc “blacklisted” **is** system **Terminated** (customer + policy). No separate Blacklisted status. Auto-terminate from default + utilization is deferred until claims integration.
+- Customer with multiple policies: lifecycle rules evaluate per policy; admin Terminate applies to the **selected policy only**; customer becomes Terminated only when no Active / Pending Activation / Suspended policies remain (Inactive, Expired, Deactivated do not keep the customer “open”).
+- Partial payment that does not clear required arrears (+ 2 weeks when required): status does not improve; member is informed that the required amount was not met (no silent partial reactivation).
+- Admin DEACTIVATED policies (from modify/deactivate product flows): excluded from payment-driven reactivation; not overwritten by grace/suspend automation.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Policy term
+
+- **FR-001**: System MUST assign policy start and end dates on first activation such that cover runs for one full year: start date inclusive; end date = start + 1 calendar year − 1 day, **preserving the start time of day** (existing `policyEndDateFromStart` behavior).
+- **FR-002**: When a policy’s end date has passed without successful renewal, System MUST apply: Active or Grace → **Expired**; Inactive → **Expired**; Suspended → **no change** (remains Suspended permanently after end date, including no Suspended → Inactive after end date); Terminated → **no change**; Deactivated → **no change** (unless already specified elsewhere).
+
+#### Status model
+
+- **FR-003**: System MUST support the following lifecycle statuses for policies: Pending Activation, Active, Suspended, Inactive (mid-term non-payment end), Expired (finished term), Terminated, and admin Deactivated (from product modify/deactivate). System MUST NOT introduce a separate Blacklisted status.
+- **FR-004**: System MUST represent Grace Period as an internal overlay on Active (member-facing status remains Active; cover continues) for days 1–14 of premium overdue.
+- **FR-005**: System MUST NOT allow automatic transition from Terminated back to Active; a new policy is required.
+- **FR-006**: System MUST record every status transition (manual or automated) with timestamp, from/to status, trigger, and reason.
+
+#### Pending Activation
+
+- **FR-007**: System MUST create new policies in Pending Activation when the customer is registered without completed first premium.
+- **FR-008**: System MUST transition Pending Activation → Active on first qualifying premium payment and send activation confirmation messaging (existing payment/activation templates as applicable).
+- **FR-009**: System MUST send Pending Activation reminders on day 3 and day 7 if still unpaid. Day-0 welcome uses the existing `customer_created` message (no duplicate welcome template).
+
+#### Grace, Suspend, Inactive (non-payment)
+
+- **FR-010**: System MUST mark Active policies as in Grace when the **next unpaid expected premium due date** from the policy’s payment schedule is overdue 1–14 days.
+- **FR-011**: System MUST transition Active/Grace → Suspended when that same unpaid expected due date is overdue more than 14 days.
+- **FR-012**: System MUST transition Suspended → Active when all arrears plus 2 weeks of premium (at the policy’s rate) are paid **only if the policy end date has not passed**.
+- **FR-012a**: System MUST NOT set a policy to Active on or after its end date for any reason, including admin Activate and payment-driven restore.
+- **FR-012b**: On or after end date, System MUST apply incoming payments to outstanding premium debt on that policy first; any amount above outstanding debt MUST create a new renewal policy per FR-016/FR-017 (new policy number; reuse payment account number and member numbers; supersession). Debt-only payments MUST NOT activate the old policy. **If the prior policy is Suspended past end and outstanding debt reaches zero, System MUST set it to EXPIRED** (not Active). If debt remains, it MUST stay Suspended.
+- **FR-013**: System MUST transition Suspended → Inactive when the suspension/non-payment path exceeds 30 days **only if the policy end date has not passed**. After end date, Suspended MUST NOT auto-move to Inactive; it stays Suspended until debt is cleared (then Expired) or remains Suspended if debt is never cleared.
+- **FR-014**: System MUST send grace, suspension, inactive, and reactivation messages according to the schedules and intents in the starter notification set (channels per Assumptions).
+
+#### Renewal
+
+- **FR-015**: System MUST send renewal reminders at: 30 days, 14 days, 7 days, 3 days, and 24 hours before expiry; and 24 hours, 3 days, 7 days, 14 days, and 30 days after expiry.
+- **FR-016**: System MUST, on renewal payment within 30 days after expiry, create a **new** Active policy with a **new policy number**, **reused** payment account number and member numbers, start date = day after the prior policy’s end date and end date per the 12-month term rule; keep the prior policy **Expired** when renewing from Expired (or set prior to **Expired** when renewing from Suspended-past-end after debt is cleared); link the pair via `supersedesPolicyId` / `supersededByPolicyId`; attach new-period payments only to the new policy.
+- **FR-017**: System MUST, on renewal payment more than 30 days after expiry, create a **new** Active policy with a **new policy number**, **reused** payment account number and member numbers, start date = payment date and end date per the 12-month term rule; keep the prior policy **Expired**; link via supersession fields; attach new-period payments only to the new policy.
+- **FR-018**: For Inactive-from-non-payment **before** end date (same policy), System MUST apply: within 30 days → arrears + 2 weeks → Active on the **same** policy (original term dates unchanged); after 30 days → one month premium → Active on the **same** policy. On or after end date, FR-012a/FR-012b apply instead (no same-policy Active).
+
+#### Terminate (starter “blacklist”)
+
+- **FR-019**: System MUST provide an admin **Terminate** action in the same policy actions menu as **Reset Start Date**, with a confirmation popup and **mandatory description** before apply.
+- **FR-020**: On confirmed Terminate, System MUST set the **selected policy** to **Terminated**, record the description in the audit trail, and send a termination notification. System MUST set the **customer** to **Terminated** only when the customer has no remaining policies in Active, Pending Activation, or Suspended; otherwise System MUST recalculate customer status from remaining open policies. Starter-doc “blacklist” permanent block is achieved when the customer is Terminated (existing registration gate).
+- **FR-021**: System MUST NOT automatically Terminated/blacklist a holder solely because they defaulted >30 days after utilizing cover; that automation is out of scope until claims-processor integration.
+
+#### Automation & payments
+
+- **FR-022**: System MUST run a daily policy status evaluation covering Active/grace, Suspended → Inactive, expiry/renewal notifications, and related transitions.
+- **FR-023**: System MUST apply payment-driven transitions immediately on confirmed payment: first payment; arrears clearance; renewal within/after 30 days — per the decision table below.
+- **FR-024**: System MUST avoid duplicate sends of the same scheduled notification for the same policy and schedule point.
+- **FR-025**: System MUST ignore payment-lifecycle auto-transitions for policies that are Deactivated or Terminated.
+
+#### Decision table (normative)
+
+| Condition | Current status | Action | New status |
+| :---- | :---- | :---- | :---- |
+| Customer/policy created without first payment | None / new | Await first payment | Pending Activation |
+| First payment received | Pending Activation | Activate policy | Active |
+| Payment overdue 1–14 days (vs next unpaid expected due date) | Active | Enter grace | Active (Grace) |
+| Payment overdue >14 days (vs next unpaid expected due date) | Active (Grace) | Suspend cover | Suspended |
+| Arrears + 2 weeks paid (before end date) | Suspended | Restore cover | Active |
+| Payment on/after end date (≤ outstanding debt) | Suspended / Inactive / Expired | Collect debt only | Status unchanged if debt remains (never Active) |
+| Payment on/after end date clears Suspended debt exactly | Suspended | Debt cleared | Expired |
+| Payment on/after end date (> outstanding debt) | Suspended / Inactive / Expired | Debt to old; surplus renews | Old: Expired if was Suspended/Inactive path debt cleared (Suspended→Expired); New: Active |
+| Non-payment path >30 days (before end date only) | Suspended | Stop policy | Inactive |
+| Non-payment path >30 days (on/after end date) | Suspended | No change | Suspended |
+| Policy end date passed (Active/Grace, no renewal) | Active (or Grace) | End term | Expired |
+| Policy end date passed | Suspended | No change | Suspended |
+| Policy end date passed | Inactive | End term | Expired |
+| Policy end date passed | Terminated | No change | Terminated |
+| Renewal within 30 days of expiry | Expired | Create new policy (new policy #; reuse pay acct + member #s; start = day after old end) + supersession | New: Active; Old: Expired |
+| Renewal after 30 days of expiry | Expired | Create new policy (new policy #; reuse pay acct + member #s; start = payment date) + supersession | New: Active; Old: Expired |
+| Reactivation within 30 days of Inactive (non-payment) | Inactive | Pay arrears + 2 weeks on same policy | Active (same policy, dates unchanged) |
+| Reactivation after 30 days of Inactive (non-payment) | Inactive | Pay 1 month premium on same policy | Active (same policy, dates unchanged) |
+| Admin terminates selected policy (menu + mandatory description) | Any (except already Terminated) | Close selected policy; maybe customer | Policy Terminated; customer Terminated only if no remaining Active/Pending Activation/Suspended policies |
+
+### Key Entities
+
+- **Policy**: Insurance cover instance with status, start/end dates, grace overlay, premium schedule/due state, and links to customer and product/scheme.
+- **Policy status transition**: Auditable change between lifecycle statuses (and grace enter/exit), with trigger (daily job, payment, admin) and reason.
+- **Premium due / arrears state**: Outstanding amount, next unpaid expected premium due date from the policy schedule, days overdue from that date, and amounts required to restore cover (arrears, 2 weeks, or one month).
+- **Renewal window**: Relationship of current date to policy end date; drives notifications and new-policy start-date rules on expiry renewal.
+- **Lifecycle notification**: Scheduled or event-driven member message (activation, grace, suspension, inactive, renewal, terminate) with defined timing and intent.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of first qualifying premiums move Pending Activation → Active with correct 12-month start/end dates in business acceptance tests.
+- **SC-002**: For Active policies with an unpaid expected premium past due, daily evaluation places 100% of 1–14 day overdue cases (measured from that due date) into Grace and >14 day cases into Suspended in test scenarios spanning multiple payment frequencies.
+- **SC-003**: 100% of Suspended → Inactive transitions occur when the >30 day non-payment rule is met in test scenarios; none occur before that threshold.
+- **SC-004**: Expiry / surplus renewal creates a new Active policy with new policy number and reused pay account + member numbers; old policy never returns to Active after end date; debt-only post–end-date payments leave status non-Active — verified in acceptance tests.
+- **SC-004a**: Admin Activate and payment-driven Suspended/Inactive → Active are rejected or no-ops when end date has passed — 100% of acceptance cases.
+- **SC-005**: At least 95% of scheduled lifecycle notifications for a policy are sent within 24 hours of their schedule point in controlled test runs (no duplicates for the same schedule point).
+- **SC-006**: Support can explain any status change using the audit trail for 100% of automated and admin transitions in sampled cases.
+- **SC-007**: Admin Terminate with mandatory description always Terminates the selected policy; customer becomes Terminated if and only if no Active/Pending Activation/Suspended policies remain — verified for single- and multi-policy customers; subsequent registration attempts for a Terminated identity are rejected in 100% of attempts.
+- **SC-008**: Operations can process a full daily evaluation for the expected production-scale policy book within the overnight batch window (target: complete before start of next business day).
+
+## Out of Scope
+
+- Admin **Modify Product**, manual Deactivate/Activate, and Reset Start Date flows already specified in `002-modify-product-policy` (this feature consumes those statuses but does not re-specify those UIs; Terminate is added alongside that menu).
+- Waiting periods, benefit eligibility, service-access checks, scheme-transfer / group-of-15 waivers, and waiting-period notification content (deferred; e.g., with claims integration).
+- Changing premium pricing, plan catalogs, or claims adjudication clinical rules.
+- Building new payment collection rails (STK, IPN, etc.); this feature reacts to confirmed payments from existing payment processes.
+- Member-facing self-service UI redesign (beyond receiving notifications and experiencing correct status outcomes).
+- Regulatory filing or insurer reporting packs beyond status/audit data already implied here.
+- Automatic “blacklist” / terminate from default >30 days after service utilization (deferred until claims-processor integration).
+- A separate Blacklisted status or blacklist-override workflow.
+- Claims-based post–end-date payment routing (if no utilization, after one month all payments → new policy; before that → old pending premium) — deferred until claim data exists.
+
+## Assumptions
+
+- **Inactive vs Expired**: **Expired** = Active/Grace past end without renewal, or Inactive past end date. **Inactive** = mid-term stop after prolonged suspension/non-payment **before** end date only. **Suspended** at/after term end stays Suspended permanently (analytics). **Terminated** at term end stays Terminated. Member-facing copy may still say “inactive” for non-payment stops; term-end communications may say expired/renew as appropriate.
+- **Suspended after end date**: Stays **Suspended while debt remains** (no auto Inactive). When debt is **fully paid** → **EXPIRED**. Surplus above debt creates a new Active renewal policy. Dashboards can still distinguish “suspended with arrears past term” vs “expired after settling.”
+- **Expiry renewal always new policy**: After a finished cycle, both within-30-day and after-30-day renewals create a new policy (never reactivate the Expired row). New policy number; reused payment account number and member numbers. Within 30 days: new start = day after old end. After 30 days: new start = payment date. New-period payments attach to the new policy; supersession fields link the pair.
+- **Grace is not a separate member-facing status**: Members and partners see Active during grace; internally the system tracks grace for reminders and the 14-day clock.
+- **Product applicability**: Lifecycle rules apply to **both prepaid and postpaid** medical cover products; grace/suspend/inactive/expire/renew use the same due-date and payment logic. Scheme/product configuration may override durations later without changing the state machine.
+- **Policy end time-of-day**: End date keeps the activation start’s clock time (existing `policyEndDateFromStart`); not forced to 23:59:59.
+- **“2 weeks upfront” and “one month premium”**: Calculated from the policy’s premium rate using `ceil(days / paymentCadenceDays) × installmentAmount` (14 days and ~31 days respectively).
+- **Starter “blacklisted” = Terminated**: No Blacklisted status exists. Permanent restriction is admin Terminate of the selected policy (mandatory description), with customer Terminated only when no open (Active/Pending Activation/Suspended) policies remain. Existing Terminated registration gate blocks re-enrollment. Auto rules tied to claims utilization wait for claims integration.
+- **Waiting periods deferred**: Starter waiting-period durations/waivers are reference-only for a future feature; this lifecycle feature does not enforce or message them.
+- **Time basis**: All day-count and end-of-day overdue rules use UTC calendar days, consistent with platform timezone standards.
+- **Notifications**: Content and timing follow the starter SMS/WhatsApp templates for **status lifecycle** events (activation confirmation, premium/grace, suspension, inactive, renewal, terminate); waiting-period template content is out of scope. Day-0 pending welcome = existing `customer_created`. Delivery uses the existing customer messaging capability.
+- **Customer status coupling**: When a policy becomes Active, Suspended, Inactive, Expired, etc., customer-level status follows existing multi-policy rules (e.g., customer Active if any policy Active), without breaking 002’s Deactivated/Terminated behavior. Admin Terminate Terminates the selected policy and sets customer Terminated only when no Active/Pending Activation/Suspended policies remain.
+- **Daily job idempotency**: Re-running the daily evaluation the same UTC day does not re-send notifications already marked sent for that schedule point.
+- **Overdue clock**: Grace and suspension day counts start from the policy’s next unpaid expected premium due date on its schedule (respecting payment frequency/cadence). Clearing that installment advances the “next due” accordingly; multiple missed cycles accumulate into arrears.
+- **No Active after end date**: A policy cannot become Active on or after its end date (payment restore or admin). Post–end-date money still collects debt; surplus above debt funds a new renewal policy. **Suspended past end → Expired once debt is fully paid**; otherwise remains Suspended. Claims-aware routing of that money is future work.
+- **Pending day-0 messaging**: Uses existing `customer_created` template; lifecycle feature adds D3/D7 pending reminders only.
+- **Restore amount formula**: 2-week upfront = `ceil(14 / paymentCadenceDays) × installmentAmount`; one month ≈ `ceil(31 / paymentCadenceDays) × installmentAmount`.
+- **Partial payments**: Do not trigger upward status transitions until the full amount required for that transition is met (and never to Active after end date). Insufficient restore amount → `ValidationException` only (no dedicated SMS).

--- a/specs/003-policy-lifecycle/tasks.md
+++ b/specs/003-policy-lifecycle/tasks.md
@@ -1,0 +1,253 @@
+# Tasks: Policy Lifecycle & Status Rules
+
+**Input**: Design documents from `/specs/003-policy-lifecycle/`  
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: Not required by spec (no TDD mandate). Polish phase includes quickstart validation and selective unit coverage for due-date / restore math per plan Phase E.
+
+**Organization**: Tasks grouped by user story (US1–US6) for independent delivery.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no incomplete dependencies)
+- **[Story]**: US1–US6 maps to spec user stories
+- Paths are absolute from repo root under `apps/api` and `apps/agent-registration`
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Align branch workspace with design docs (no greenfield project)
+
+- [x] T001 Review `specs/003-policy-lifecycle/plan.md`, `data-model.md`, and `contracts/openapi.yaml` against current `apps/api/src/services/policy-lifecycle.service.ts`
+- [x] T002 [P] Confirm Nest `ScheduleModule` is registered in `apps/api/src/app.module.ts` (reuse existing pattern from messaging attachment cleanup)
+
+---
+
+## Phase 2: Foundational (Blocking)
+
+**Purpose**: Schema, due-date primitives, shared gates — MUST complete before user stories
+
+**⚠️ CRITICAL**: No user story work until this phase is done
+
+- [x] T003 Add `INACTIVE` to `PolicyStatus` and Policy grace/suspension/expiry clock fields (`inGracePeriod`, `graceEnteredAt`, `overdueAnchorDueDate`, `suspendedAt`, `inactivatedAt`, `expiredAt`) in `apps/api/prisma/schema.prisma`
+- [x] T004 Add `PolicyLifecycleNotification` model with `@@unique([policyId, scheduleKey])` in `apps/api/prisma/schema.prisma`
+- [x] T005 Create Prisma migration (never `db push`) via `cd apps/api && npx prisma migrate dev --name policy_payment_lifecycle` ensuring partial unique index still only `ACTIVE|PENDING_ACTIVATION|SUSPENDED`
+- [x] T006 [P] Confirm `policyEndDateFromStart` in `apps/api/src/utils/policy-dates.util.ts` keeps start time-of-day on end date (no 23:59:59 change); use as-is for activation/renewal
+- [x] T007 [P] Implement next unpaid expected due date + overdue days + restore amount helpers in `apps/api/src/utils/policy-due-date.util.ts` (reuse `premium-statement-math.ts` / installment slot logic). **Formula:** 2-week upfront = `ceil(14 / paymentCadenceDays) × installmentAmount`; one month = `ceil(31 / paymentCadenceDays) × installmentAmount`
+- [x] T008 Extend `syncCustomerStatusAfterPolicyChange` in `apps/api/src/services/policy-lifecycle.service.ts` so `INACTIVE` is non-open (like `EXPIRED`/`DEACTIVATED`)
+- [x] T009 Add shared `assertPolicyMayBecomeActive` (reject after `endDate`, Terminated/Deactivated/Expired) in `apps/api/src/services/policy-lifecycle.service.ts` and call from existing `activatePolicy`
+- [x] T009a Add empty `PolicyLifecycleJobService` stub (injectable, no-op or TODO `runDaily`) in `apps/api/src/services/policy-lifecycle-job.service.ts` and register in `apps/api/src/app.module.ts` so US1 can depend on the module without full cron logic
+- [x] T009b Document/enforce: every status change and grace enter/exit MUST write `EntityStatusChange` (correct trigger) — implement helper used by all lifecycle methods in `apps/api/src/services/policy-lifecycle.service.ts` / `entity-status-change.service.ts`
+
+**Checkpoint**: Schema applied; due-date util + Active gate + job stub + audit helper ready
+
+**Note (FR-007):** Creating policies as `PENDING_ACTIVATION` on registration already exists in onboarding — this feature does not re-implement create-customer policy insert.
+
+---
+
+## Phase 3: User Story 1 — Activate on first payment (P1) 🎯 MVP
+
+**Goal**: First qualifying premium activates policy with 12-month dates; pending-activation reminders D0/D3/D7 when still unpaid
+
+**Independent Test**: Create pending policy → first payment → Active + dates; without payment, D3/D7 reminders enqueue once
+
+### Implementation
+
+- [x] T010 [US1] Ensure first-payment activation continues to use `policyDatesFromPayment` / `policyEndDateFromStart` in `apps/api/src/services/policy.service.ts` / payment completion paths (`mpesa-ipn.service.ts`, `mpesa-stk-push.service.ts`)
+- [x] T011 [P] [US1] Add pending-activation reminder templates for **D3 and D7 only** in `apps/api/prisma/seed-messaging.sql` (do **not** add a new welcome template; day-0 uses existing `customer_created`)
+- [x] T012 [US1] Create `PolicyLifecycleMessagingService` in `apps/api/src/modules/messaging/policy-lifecycle-messaging.service.ts` with ledger insert into `policy_lifecycle_notifications` before enqueue
+- [x] T013 [US1] Wire pending-activation D3/D7 reminder scheduling via `PolicyLifecycleMessagingService` + daily eval helpers callable from the job stub (do **not** put full cron logic in US1) in `apps/api/src/services/policy-lifecycle.service.ts` / messaging service
+- [x] T014 [US1] Skip remaining pending reminders when first payment activates (mark schedule keys or cancel) from payment completion hook in `apps/api/src/services/policy-lifecycle.service.ts`
+
+**Checkpoint**: US1 independently testable per quickstart activation + reminder dedupe
+
+---
+
+## Phase 4: User Story 2 — Grace period (P1)
+
+**Goal**: Overdue 1–14 days vs next unpaid expected due date → Active + grace overlay + grace SMS schedule
+
+**Independent Test**: Set overdue 1–14 days → run daily → `inGracePeriod=true`, status Active; pay before day 15 → grace cleared
+
+### Implementation
+
+- [x] T015 [US2] Implement grace enter/update/clear logic (set `inGracePeriod`, `graceEnteredAt`, `overdueAnchorDueDate`) in `apps/api/src/services/policy-lifecycle.service.ts`
+- [x] T016 [P] [US2] Add grace reminder templates (`GRACE_DUE`, `GRACE_D7`, `GRACE_D10`, `GRACE_D13`) in `apps/api/prisma/seed-messaging.sql`
+- [x] T017 [US2] Enqueue grace schedule-point messages via `apps/api/src/modules/messaging/policy-lifecycle-messaging.service.ts` with unique `scheduleKey`s
+- [x] T018 [US2] Invoke grace evaluation from daily job for Active policies in `apps/api/src/services/policy-lifecycle-job.service.ts`
+
+**Checkpoint**: US2 works with daily run; member-facing status remains Active
+
+---
+
+## Phase 5: User Story 3 — Suspend & restore (P1)
+
+**Goal**: Overdue &gt;14 days → Suspended; before end date, arrears + 2 weeks → Active; never Active after end date
+
+**Independent Test**: Overdue &gt;14 → Suspended; pay arrears+2w before end → Active; Activate/pay restore after end → rejected / debt-only
+
+### Implementation
+
+- [x] T019 [US3] Implement Active/Grace → Suspended transition (clear grace, set `suspendedAt`, audit `PAYMENT_LIFECYCLE`/`SYSTEM`) in `apps/api/src/services/policy-lifecycle.service.ts`
+- [x] T020 [US3] Implement Suspended → Active restore when paid ≥ arrears + 2 weeks **and** `endDate` not passed in `apps/api/src/services/policy-lifecycle.service.ts`; if paid &lt; required, throw `ValidationException` (no silent partial restore)
+- [x] T021 [US3] Implement `applyPaymentToPolicyLifecycle` in `apps/api/src/services/policy-lifecycle.service.ts` and hook from completed-payment paths for **prepaid and postpaid**: `mpesa-ipn.service.ts`, `mpesa-stk-push.service.ts`, on-demand STK completion in `customer.service.ts`, and manual/admin payment completion paths that mark payments `COMPLETED` (including postpaid member payment completion where applicable)
+- [x] T022 [US3] On/after end date: apply payment to debt only (no Active); when Suspended debt reaches **zero** → set **EXPIRED**; surplus above debt → renew; reject admin Activate via `assertPolicyMayBecomeActive`; use `ValidationException` for insufficient restore amounts in `apps/api/src/services/policy-lifecycle.service.ts`
+- [x] T023 [P] [US3] Add suspension / reactivation SMS templates in `apps/api/prisma/seed-messaging.sql` and enqueue from transitions in `apps/api/src/modules/messaging/policy-lifecycle-messaging.service.ts`
+
+**Checkpoint**: US3 suspend/restore + post-end Activate block verified
+
+---
+
+## Phase 6: User Story 4 — Inactive / Expired / renewal (P1)
+
+**Goal**: Suspended ≥30d before end → Inactive; term-end rules; renewal new policy (new number, reuse pay acct + members); surplus after debt renews
+
+**Independent Test**: Suspended &gt;30d before end → Inactive; Active past end → Expired; Suspended past end stays Suspended; surplus payment creates new Active + supersession
+
+### Implementation
+
+- [x] T024 [US4] Implement Suspended → Inactive when `suspendedAt` age ≥30 days **and** before end date; set `inactivatedAt` in `apps/api/src/services/policy-lifecycle.service.ts`
+- [x] T025 [US4] Implement term-end transitions: Active/Grace → Expired; Inactive → Expired; Suspended/Terminated/Deactivated unchanged in `apps/api/src/services/policy-lifecycle.service.ts`
+- [x] T026 [US4] Implement Inactive restore before end (within 30d: arrears+2w; after 30d: one month) in `apps/api/src/services/policy-lifecycle.service.ts`
+- [x] T027 [US4] Implement `renewPolicyFromPrior` (new policy number, reuse `paymentAcNumber` + member numbers, supersession, start date within/after 30d rules; when renewing from Suspended-past-end after debt cleared, prior → **EXPIRED**) in `apps/api/src/services/policy-lifecycle.service.ts`
+- [x] T028 [US4] Split post–end-date overpayment: debt on old policyId, surplus triggers renew in `applyPaymentToPolicyLifecycle` in `apps/api/src/services/policy-lifecycle.service.ts`
+- [x] T029 [P] [US4] Add inactive / renewal SMS templates in `apps/api/prisma/seed-messaging.sql` and schedule keys for renewal windows in `apps/api/src/modules/messaging/policy-lifecycle-messaging.service.ts`
+- [x] T030 [US4] Extend policy display labels for `INACTIVE` in `apps/api/src/utils/policy-display.util.ts`
+
+**Checkpoint**: US4 expiry/renewal/surplus paths independently testable
+
+---
+
+## Phase 7: User Story 5 — Admin Terminate (P2)
+
+**Goal**: Terminate action beside Reset Start Date; mandatory reason; selected policy Terminated; customer Terminated only if no open policies
+
+**Independent Test**: Terminate one of two open policies → policy Terminated, customer not; terminate last open → customer Terminated; registration gate still blocks
+
+### Implementation
+
+- [x] T031 [US5] Add `TerminatePolicyRequestDto` / response fields in `apps/api/src/dto/policy-lifecycle/policy-lifecycle.dto.ts`
+- [x] T032 [US5] Implement `terminatePolicy` (audit `MANUAL_ADMIN`, notification, customer coupling Option C) in `apps/api/src/services/policy-lifecycle.service.ts`
+- [x] T033 [US5] Expose `POST .../policies/:policyId/terminate` in `apps/api/src/controllers/internal/policy-lifecycle.controller.ts` per `specs/003-policy-lifecycle/contracts/openapi.yaml`
+- [x] T034 [P] [US5] Add `terminateCustomerPolicy` client in `apps/agent-registration/src/lib/api.ts`
+- [x] T035 [US5] Add Terminate menu item + reason dialog on admin Products tab in `apps/agent-registration/src/app/(main)/customer/[customerId]/_components/products-tab.tsx` (reuse `policy-reason-dialog.tsx`)
+- [x] T036 [P] [US5] Add terminate SMS template in `apps/api/prisma/seed-messaging.sql` and send from `terminatePolicy`
+
+**Checkpoint**: US5 admin Terminate UX + API complete
+
+---
+
+## Phase 8: User Story 6 — Daily automated processing (P1)
+
+**Goal**: Once-daily UTC evaluation orchestrating grace/suspend/inactive/expire + renewal notification schedule; idempotent; manual run endpoint
+
+**Independent Test**: Seed boundary policies → `POST /internal/policies/lifecycle/run-daily` → expected transitions; second run same day does not duplicate SMS ledger rows
+
+### Implementation
+
+- [x] T037 [US6] Flesh out `PolicyLifecycleJobService` with `@Cron('0 1 * * *')` UTC calling evaluation methods in `apps/api/src/services/policy-lifecycle-job.service.ts` (stub from T009a)
+- [x] T038 [US6] Confirm job provider registration in `apps/api/src/app.module.ts` (may already be done in T009a)
+- [x] T039 [US6] Add `POST /internal/policies/lifecycle/run-daily` (admin-guarded) returning batch counters per `specs/003-policy-lifecycle/contracts/openapi.yaml` in `apps/api/src/controllers/internal/policy-lifecycle.controller.ts` (or dedicated controller)
+- [x] T040 [US6] Ensure job skips `DEACTIVATED`/`TERMINATED` for payment-lifecycle mutations and freezes Suspended after end per spec in `apps/api/src/services/policy-lifecycle-job.service.ts`
+- [x] T041 [US6] Queue renewal reminder schedule points (before/after expiry) with ledger dedupe in `apps/api/src/services/policy-lifecycle-job.service.ts` + messaging service
+- [x] T042 [US6] Add Sentry/error logging for job failures in `apps/api/src/services/policy-lifecycle-job.service.ts`
+- [x] T042a [US6] Log daily-run wall-clock duration (and counts) so ops can verify SC-008 overnight batch window in `apps/api/src/services/policy-lifecycle-job.service.ts`
+
+**Checkpoint**: Full daily automation matches quickstart flows 1–2 and 6
+
+---
+
+## Phase 9: Polish & Cross-Cutting
+
+**Purpose**: Verification, lint, docs consistency
+
+- [x] T043 [P] Add unit tests for due-date / restore amounts / renew start dates in `apps/api/src/utils/__tests__/policy-due-date.util.spec.ts`
+- [x] T044 [P] Add unit tests for Suspended-after-end debt→Expired and Terminate multi-policy coupling in `apps/api/src/services/__tests__/policy-lifecycle.service.spec.ts`
+- [ ] T045 Run manual scenarios from `specs/003-policy-lifecycle/quickstart.md` against local API
+- [x] T046 Run `pnpm lint` from repo root `~/Projects/microbima` and fix issues in touched TS/JS files
+- [x] T047 [P] Update Swagger decorators on new endpoints to match `specs/003-policy-lifecycle/contracts/openapi.yaml`
+- [x] T048 Confirm every lifecycle path calls the EntityStatusChange helper (T009b) — checklist pass in code review
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 Setup** → **Phase 2 Foundational** (blocks all stories)
+- **US1–US5** can proceed after Foundational; **US6** depends on US2–US4 evaluation methods existing (orchestrates them)
+- **US5 (Terminate)** independent of grace/suspend once Foundational + customer sync done
+- **Polish** after desired stories complete
+
+### User Story Dependencies
+
+```text
+Foundational
+    ├── US1 Activate + pending reminders
+    ├── US2 Grace          ──┐
+    ├── US3 Suspend/restore ─┼──► US6 Daily job (orchestration)
+    ├── US4 Inactive/Expire/Renew ──┘
+    └── US5 Terminate (can parallel with US2–US4)
+```
+
+### Parallel Opportunities
+
+- T006 || T007 after schema migration starts
+- T011 || T016 || T023 || T029 || T036 template seed edits (coordinate single file sequentially if conflicting)
+- T034 || T031 after service contract known
+- T043 || T044 in Polish
+
+### Parallel Example: After Foundational
+
+```bash
+# Dev A: US1 activation + messaging
+# Dev B: US5 Terminate API + UI
+# Dev C: US2/US3 grace+suspend (then US4, then US6)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First
+
+1. Phase 1–2 Foundational  
+2. **US1** (activation dates + pending reminders)  
+3. Stop and validate first-payment path  
+
+### Recommended incremental path
+
+1. US1 → US2 → US3 → US4 → US6 (automation spine)  
+2. US5 Terminate can ship anytime after Foundational  
+3. Polish + quickstart  
+
+### Suggested MVP scope
+
+**US1 only** proves term dates + activation messaging hooks; production value for lifecycle requires **US2+US3+US6** minimum for grace/suspend automation.
+
+---
+
+## Task count summary
+
+| Phase | Story | Tasks |
+|-------|-------|-------|
+| Setup | — | T001–T002 (2) |
+| Foundational | — | T003–T009, T009a–b |
+| US1 Activate | US1 | T010–T014 (5) |
+| US2 Grace | US2 | T015–T018 (4) |
+| US3 Suspend/restore | US3 | T019–T023 (5) |
+| US4 Inactive/Expire/Renew | US4 | T024–T030 (7) |
+| US5 Terminate | US5 | T031–T036 (6) |
+| US6 Daily job | US6 | T037–T042 (6) |
+| Polish | — | T043–T047 (5) |
+| **Total** | | **52** (T001–T009, T009a–b, T010–T042, T042a, T043–T048) |
+
+---
+
+## Notes
+
+- Do not implement waiting periods or claims-based payment routing (out of scope)
+- Prefer `message_templates` over new `system_settings` keys; if settings added, sync `MessagingSettingsSnapshot`
+- All status writes must use `EntityStatusChange` with correct trigger
+- Commit after each logical task group; run `pnpm lint` after TS/JS changes


### PR DESCRIPTION
## Summary
- Merge validated staging into `master` (production) for policy modify (002) and payment lifecycle (003).
- Adds grace / suspend / inactive / expire / terminate rules, daily 01:00 UTC lifecycle job, admin terminate API/UI, and lifecycle SMS templates.
- Includes CI fix mocking `PolicyLifecycleService` in the IPN unit tests.

## Test plan
- [x] Confirm staging deploy `29151379403` stayed healthy after the lifecycle cron (01:00 UTC)
- [ ] On merge: production migrate + messaging seed (`seed-messaging.sql`) as needed
- [ ] Optionally `POST /internal/policies/lifecycle/run-daily` once after prod deploy for catch-up
- [ ] Spot-check grace/suspend/renewal SMS and `entity_status_changes` on a sample policy
- [ ] Smoke-test terminate from admin Products ⋮ menu


Made with [Cursor](https://cursor.com)