### PR TITLE
fix(lct): CSV PRODUCT/PLAN, phone format, principal number, family sort

### DIFF
--- a/apps/api/src/modules/lct/__tests__/lct-action-csv.spec.ts
+++ b/apps/api/src/modules/lct/__tests__/lct-action-csv.spec.ts
@@ -3,9 +3,12 @@ import {
   buildLctExportSubject,
   formatLctDob,
   formatLctGender,
+  formatLctPhone,
   mapPolicyStatusToLctAction,
   normalizeEmailList,
   shouldEnqueueStatusChange,
+  sortLctExportIntents,
+  toTitleCase,
 } from '../lct.types';
 import { buildLctCsv, intentToCsvRow } from '../lct-csv.builder';
 import type { LctMemberSyncIntent } from '../lct.types';
@@ -52,12 +55,14 @@ describe('LCT CSV builder', () => {
     dateOfBirth: '15-01-1990',
     relationship: 'PRINCIPAL',
     email: 'jane@example.com',
-    phoneNumber: '+254700000000',
+    phoneNumber: '254700000000',
     idNumber: '12345678',
-    principalMemberNumber: '',
+    principalMemberNumber: 'MP00100',
     schemeName: 'Maisha Poa General',
     policyStartDate: '01-01-2026',
     policyEndDate: '31-12-2026',
+    productName: 'Maisha Poa',
+    planName: 'Gold',
     ...overrides,
   });
 
@@ -81,20 +86,70 @@ describe('LCT CSV builder', () => {
       }),
     ]);
 
+    const header = csv.split('\n')[0];
     expect(rowCount).toBe(3);
-    expect(csv.split('\n')[0]).toContain('REQUIRED ACTION');
-    expect(csv.split('\n')[0]).toContain('SCHEME NAME');
-    expect(csv.split('\n')[0]).toContain('START DATE');
-    expect(csv.split('\n')[0]).toContain('END DATE');
+    expect(header).toContain('REQUIRED ACTION');
+    expect(header).toContain('SCHEME NAME');
+    expect(header).toContain('START DATE');
+    expect(header).toContain('END DATE');
+    expect(header.endsWith('PRODUCT,PLAN')).toBe(true);
     expect(csv).toContain('ACTIVATE');
     expect(csv).toContain('SUSPENDED');
     expect(csv).toContain('DEACTIVATE');
-    expect(rows[0]['PRINCIPAL MEMBER NUMBER']).toBe('');
+    expect(rows[0]['PRINCIPAL MEMBER NUMBER']).toBe('MP00100');
     expect(rows[1]['PRINCIPAL MEMBER NUMBER']).toBe('MP00100');
     expect(intentToCsvRow(sampleIntent())['STAFF NUMBER']).toBe('S-1');
     expect(rows[0]['SCHEME NAME']).toBe('Maisha Poa General');
     expect(rows[0]['START DATE']).toBe('01-01-2026');
     expect(rows[0]['END DATE']).toBe('31-12-2026');
+    expect(rows[0].PRODUCT).toBe('Maisha Poa');
+    expect(rows[0].PLAN).toBe('Gold');
+  });
+
+  it('title-cases PLAN and normalizes phone without +', () => {
+    expect(toTitleCase('gold')).toBe('Gold');
+    expect(toTitleCase('SILVER PLAN')).toBe('Silver Plan');
+    expect(formatLctPhone('0722000000')).toBe('254722000000');
+    expect(formatLctPhone('+254722000000')).toBe('254722000000');
+    expect(formatLctPhone('')).toBe('');
+    expect(formatLctPhone('not-a-phone')).toBe('');
+  });
+
+  it('sorts export intents Principal → Spouse → Children by family', () => {
+    const mixed = [
+      { intent: sampleIntent({ policyId: 'p2', memberNumber: 'B-00', relationship: 'PRINCIPAL' }) },
+      {
+        intent: sampleIntent({
+          policyId: 'p1',
+          memberNumber: 'A-02',
+          subjectType: 'DEPENDANT',
+          relationship: 'CHILD',
+          principalMemberNumber: 'A-00',
+        }),
+      },
+      {
+        intent: sampleIntent({
+          policyId: 'p1',
+          memberNumber: 'A-01',
+          subjectType: 'DEPENDANT',
+          relationship: 'SPOUSE',
+          principalMemberNumber: 'A-00',
+        }),
+      },
+      { intent: sampleIntent({ policyId: 'p1', memberNumber: 'A-00', relationship: 'PRINCIPAL' }) },
+      {
+        intent: sampleIntent({
+          policyId: 'p1',
+          memberNumber: 'A-03',
+          subjectType: 'DEPENDANT',
+          relationship: 'CHILD',
+          principalMemberNumber: 'A-00',
+        }),
+      },
+    ];
+
+    const sorted = sortLctExportIntents(mixed).map((x) => x.intent.memberNumber);
+    expect(sorted).toEqual(['A-00', 'A-01', 'A-02', 'A-03', 'B-00']);
   });
 
   it('formats gender and DOB helpers', () => {

--- a/apps/api/src/modules/lct/__tests__/lct-safety-critical.spec.ts
+++ b/apps/api/src/modules/lct/__tests__/lct-safety-critical.spec.ts
@@ -159,12 +159,14 @@ describe('LCT safety — CSV action fidelity', () => {
     dateOfBirth: '01-01-1980',
     relationship: 'PRINCIPAL',
     email: '',
-    phoneNumber: '+254711000000',
+    phoneNumber: '254711000000',
     idNumber: '11111111',
-    principalMemberNumber: '',
+    principalMemberNumber: 'MFG100-00',
     schemeName: 'Test Scheme',
     policyStartDate: '01-06-2026',
     policyEndDate: '31-05-2027',
+    productName: 'Maisha Poa',
+    planName: 'Gold',
     ...overrides,
   });
 

--- a/apps/api/src/modules/lct/__tests__/lct-safety-critical.spec.ts
+++ b/apps/api/src/modules/lct/__tests__/lct-safety-critical.spec.ts
@@ -196,11 +196,15 @@ describe('LCT safety — CSV action fidelity', () => {
         memberName: 'Spouse',
       }),
     ];
-    const { csv, rowCount } = buildLctCsv(intents);
+    const { csv, rowCount, rows } = buildLctCsv(intents);
     const dataLines = csv.trimEnd().split('\n').slice(1);
     expect(rowCount).toBe(2);
     expect(dataLines).toHaveLength(2);
     expect(dataLines[1]).toContain('SUSPENDED');
+    expect(csv.split('\n')[0].endsWith('PRODUCT,PLAN')).toBe(true);
+    expect(rows[0]['PRINCIPAL MEMBER NUMBER']).toBe('MFG100-00');
+    expect(rows[0].PRODUCT).toBe('Maisha Poa');
+    expect(rows[0].PLAN).toBe('Gold');
   });
 
   it('rejects unknown REQUIRED ACTION values', () => {

--- a/apps/api/src/modules/lct/lct-csv.builder.ts
+++ b/apps/api/src/modules/lct/lct-csv.builder.ts
@@ -17,6 +17,8 @@ export const LCT_CSV_HEADERS = [
   'SCHEME NAME',
   'START DATE',
   'END DATE',
+  'PRODUCT',
+  'PLAN',
 ] as const;
 
 export type LctCsvRow = Record<(typeof LCT_CSV_HEADERS)[number], string>;
@@ -38,6 +40,8 @@ export function intentToCsvRow(intent: LctMemberSyncIntent): LctCsvRow {
     'SCHEME NAME': intent.schemeName,
     'START DATE': intent.policyStartDate,
     'END DATE': intent.policyEndDate,
+    PRODUCT: intent.productName,
+    PLAN: intent.planName,
   };
 }
 

--- a/apps/api/src/modules/lct/lct-export.service.ts
+++ b/apps/api/src/modules/lct/lct-export.service.ts
@@ -23,9 +23,13 @@ import {
   buildLctExportSubject,
   formatLctDob,
   formatLctGender,
+  formatLctPhone,
   LCT_TEMPLATE_KEY,
   LctMemberSyncIntent,
   normalizeEmailList,
+  sortLctExportIntents,
+  sortLctPendingDependants,
+  toTitleCase,
 } from './lct.types';
 
 const ADMIN_ROLE = 'registration_admin';
@@ -126,7 +130,21 @@ export class LctExportService {
             ? [customer.firstName, customer.middleName, customer.lastName].filter(Boolean).join(' ')
             : '';
         const idNumber = dependant?.idNumber ?? customer?.idNumber ?? '';
-        const phone = dependant?.phoneNumber ?? customer?.phoneNumber ?? '';
+        const principalPhone = formatLctPhone(customer?.phoneNumber);
+        const relationship =
+          t.subjectType === LctSubjectType.PRINCIPAL
+            ? 'PRINCIPAL'
+            : dependant?.relationship === DependantRelationship.SPOUSE
+              ? 'SPOUSE'
+              : dependant?.relationship === DependantRelationship.CHILD
+                ? 'CHILD'
+                : (dependant?.relationship ?? 'DEPENDANT');
+        let phone = principalPhone;
+        if (relationship === 'SPOUSE') {
+          phone = formatLctPhone(dependant?.phoneNumber) || principalPhone;
+        } else if (relationship === 'CHILD') {
+          phone = principalPhone;
+        }
 
         return {
           id: t.id,
@@ -144,10 +162,7 @@ export class LctExportService {
           personName,
           idNumber,
           phone,
-          relationship:
-            t.subjectType === LctSubjectType.PRINCIPAL
-              ? 'PRINCIPAL'
-              : (dependant?.relationship ?? 'DEPENDANT'),
+          relationship,
         };
       })
       .filter((row) => {
@@ -187,6 +202,10 @@ export class LctExportService {
       } else {
         g.dependants.push(row);
       }
+    }
+
+    for (const g of groups.values()) {
+      g.dependants = sortLctPendingDependants(g.dependants);
     }
 
     const openBatch = await this.prisma.lctExportBatch.findFirst({
@@ -275,7 +294,7 @@ export class LctExportService {
       );
     }
 
-    const intentsWithTargets = await this.buildIntents(targets);
+    const intentsWithTargets = sortLctExportIntents(await this.buildIntents(targets));
     const intents = intentsWithTargets.map((x) => x.intent);
     const { csv, rows, rowCount } = buildLctCsv(intents);
     const batchId = randomUUID();
@@ -554,6 +573,8 @@ export class LctExportService {
         packageId: true,
         startDate: true,
         endDate: true,
+        package: { select: { name: true } },
+        packagePlan: { select: { name: true } },
       },
     });
     const policyMap = new Map(policies.map((p) => [p.id, p]));
@@ -584,6 +605,9 @@ export class LctExportService {
       const schemeName = schemeNameByPolicyId.get(target.policyId) ?? '';
       const policyStartDate = formatLctDob(policy.startDate);
       const policyEndDate = formatLctDob(policy.endDate);
+      const productName = policy.package?.name ?? '';
+      const planName = toTitleCase(policy.packagePlan?.name);
+      const principalPhone = formatLctPhone(customer.phoneNumber);
 
       if (target.subjectType === LctSubjectType.PRINCIPAL) {
         intents.push({
@@ -603,12 +627,14 @@ export class LctExportService {
             dateOfBirth: formatLctDob(customer.dateOfBirth),
             relationship: 'PRINCIPAL',
             email: customer.email ?? '',
-            phoneNumber: customer.phoneNumber ?? '',
+            phoneNumber: principalPhone,
             idNumber: customer.idNumber ?? '',
-            principalMemberNumber: '',
+            principalMemberNumber: principalMemberNumber || target.memberNumber,
             schemeName,
             policyStartDate,
             policyEndDate,
+            productName,
+            planName,
           },
         });
         continue;
@@ -625,6 +651,11 @@ export class LctExportService {
           : dependant.relationship === DependantRelationship.CHILD
             ? 'CHILD'
             : dependant.relationship;
+
+      const phoneNumber =
+        relationship === 'SPOUSE'
+          ? formatLctPhone(dependant.phoneNumber) || principalPhone
+          : principalPhone;
 
       intents.push({
         targetId: target.id,
@@ -645,12 +676,14 @@ export class LctExportService {
           dateOfBirth: formatLctDob(dependant.dateOfBirth),
           relationship,
           email: dependant.email ?? '',
-          phoneNumber: dependant.phoneNumber ?? '',
+          phoneNumber,
           idNumber: dependant.idNumber ?? '',
           principalMemberNumber,
           schemeName,
           policyStartDate,
           policyEndDate,
+          productName,
+          planName,
         },
       });
     }

--- a/apps/api/src/modules/lct/lct.types.ts
+++ b/apps/api/src/modules/lct/lct.types.ts
@@ -1,4 +1,5 @@
 import { LctPendingAction, PolicyStatus } from '@prisma/client';
+import { normalizePhoneNumber } from '../../utils/phone-number.util';
 
 /** Shared domain intent for CSV (and future LCT HTTP) adapters */
 export interface LctMemberSyncIntent {
@@ -24,6 +25,10 @@ export interface LctMemberSyncIntent {
   /** Policy coverage dates — CSV only (DD-MM-YYYY) */
   policyStartDate: string;
   policyEndDate: string;
+  /** Package name only — CSV PRODUCT column */
+  productName: string;
+  /** Package plan name (title case) — CSV PLAN column */
+  planName: string;
 }
 
 export const LCT_TEMPLATE_KEY = 'lct_customer_export';
@@ -128,6 +133,92 @@ export function formatLctGender(gender: string | null | undefined): string {
   if (gender === 'MALE') return 'Male';
   if (gender === 'FEMALE') return 'Female';
   return '';
+}
+
+/** Title-case words for LCT PLAN column (e.g. gold → Gold). */
+export function toTitleCase(value: string | null | undefined): string {
+  if (!value?.trim()) return '';
+  return value
+    .trim()
+    .split(/\s+/)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(' ');
+}
+
+/**
+ * Normalize phone for LCT CSV: 254XXXXXXXXX without "+".
+ * Invalid / blank → '' so callers can apply spouse/child fallback.
+ */
+export function formatLctPhone(raw: string | null | undefined): string {
+  if (!raw?.trim()) return '';
+  try {
+    return normalizePhoneNumber(raw.trim());
+  } catch {
+    return '';
+  }
+}
+
+const RELATIONSHIP_SORT_ORDER: Record<string, number> = {
+  PRINCIPAL: 0,
+  SPOUSE: 1,
+  CHILD: 2,
+};
+
+function relationshipSortRank(relationship: string): number {
+  return RELATIONSHIP_SORT_ORDER[relationship] ?? 99;
+}
+
+/**
+ * Sort export rows: families by principal memberNumber, within family
+ * Principal → Spouse → Children → other, then memberNumber ascending.
+ */
+export function sortLctExportIntents<T extends { intent: LctMemberSyncIntent }>(
+  items: T[]
+): T[] {
+  const byPolicy = new Map<string, T[]>();
+  for (const item of items) {
+    const key = item.intent.policyId;
+    const list = byPolicy.get(key);
+    if (list) list.push(item);
+    else byPolicy.set(key, [item]);
+  }
+
+  const familyKeys = Array.from(byPolicy.keys()).sort((a, b) => {
+    const aPrincipal =
+      byPolicy.get(a)?.find((x) => x.intent.relationship === 'PRINCIPAL')?.intent
+        .memberNumber ??
+      byPolicy.get(a)?.[0]?.intent.memberNumber ??
+      '';
+    const bPrincipal =
+      byPolicy.get(b)?.find((x) => x.intent.relationship === 'PRINCIPAL')?.intent
+        .memberNumber ??
+      byPolicy.get(b)?.[0]?.intent.memberNumber ??
+      '';
+    return aPrincipal.localeCompare(bPrincipal);
+  });
+
+  const sorted: T[] = [];
+  for (const key of familyKeys) {
+    const family = byPolicy.get(key)!;
+    family.sort((a, b) => {
+      const rel = relationshipSortRank(a.intent.relationship) - relationshipSortRank(b.intent.relationship);
+      if (rel !== 0) return rel;
+      return a.intent.memberNumber.localeCompare(b.intent.memberNumber);
+    });
+    sorted.push(...family);
+  }
+  return sorted;
+}
+
+/** Sort pending UI dependants: Spouse → Children → other, then memberNumber. */
+export function sortLctPendingDependants<
+  T extends { relationship: string; memberNumber: string },
+>(dependants: T[]): T[] {
+  return [...dependants].sort((a, b) => {
+    const rel = relationshipSortRank(a.relationship) - relationshipSortRank(b.relationship);
+    if (rel !== 0) return rel;
+    return a.memberNumber.localeCompare(b.memberNumber);
+  });
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves LCT customer export CSV fields and row ordering without changing Pending UI product/plan columns.

### Changes
- **PRODUCT / PLAN columns** (CSV only): last two headers after `END DATE`, from `package.name` and title-cased `packagePlan.name`
- **Phone**: normalize to `254XXXXXXXXX` (no `+`); spouse uses own phone or principal; child always principal
- **PRINCIPAL MEMBER NUMBER**: filled on principal rows (same as `MEMBER NUMBER`)
- **Ordering**: export intents sorted Principal → Spouse → Children per family (families by principal member number); pending UI dependants sorted the same way

### Tests
- Updated `lct-action-csv.spec.ts` and `lct-safety-critical.spec.ts`
- `pnpm --filter @microbima/api exec jest --testPathPattern=modules/lct` — pass
- `pnpm lint` — pass (pre-existing warnings only)

### Out of scope
- UI Product/Plan column changes
- Re-export of historical batches
- LCT email template changes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-40fad95d-98bf-4faa-bc26-b7f1384ed902?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40fad95d-98bf-4faa-bc26-b7f1384ed902&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

