### PR TITLE
feat(care-ops): missing-info queue and LCT export eligibility gates

### DIFF
--- a/apps/agent-registration/src/app/(main)/admin/layout.tsx
+++ b/apps/agent-registration/src/app/(main)/admin/layout.tsx
@@ -9,7 +9,7 @@ import { useBAStatusCheck } from '@/hooks/useBAStatusCheck';
 import { Button } from '@/components/ui/button';
 import { Sheet, SheetContent, SheetTrigger, SheetHeader, SheetTitle, SheetDescription } from '@/components/ui/sheet';
 import { useIsMobile } from '@/hooks/use-mobile';
-import { LogOut, User, LayoutDashboard, Search, Home, Users, UsersRound, Menu, Building2, Wallet, MessageSquare, FileCheck, FileSpreadsheet, Layers } from 'lucide-react';
+import { LogOut, User, LayoutDashboard, Search, Home, Users, UsersRound, Menu, Building2, Wallet, MessageSquare, FileCheck, FileSpreadsheet, Layers, ClipboardPen } from 'lucide-react';
 
 export default function AdminLayout({
   children,
@@ -156,6 +156,16 @@ export default function AdminLayout({
         >
           <FileSpreadsheet className="h-4 w-4 mr-2" />
           LCT Exports
+        </Link>
+        <Link
+          href="/dashboard/missing-information"
+          className={`flex items-center px-3 py-2 rounded-md hover:bg-white/10 transition-colors ${
+            pathname === '/dashboard/missing-information' ? 'bg-white/10' : ''
+          }`}
+          onClick={() => isMobile && setSidebarOpen(false)}
+        >
+          <ClipboardPen className="h-4 w-4 mr-2" />
+          Missing Information
         </Link>
         <Link
           href="/dashboard/search"

--- a/apps/agent-registration/src/app/(main)/admin/lct-exports/page.tsx
+++ b/apps/agent-registration/src/app/(main)/admin/lct-exports/page.tsx
@@ -28,7 +28,7 @@ import {
   type LctPendingGroup,
   type LctPendingRow,
 } from '@/lib/api'
-import { AlertTriangle, Download, Loader2, RefreshCw, UserPlus, ArrowRightLeft, UserCog } from 'lucide-react'
+import { AlertTriangle, Download, Loader2, RefreshCw, UserPlus, ArrowRightLeft, UserCog, CircleAlert } from 'lucide-react'
 import {
   Tooltip,
   TooltipContent,
@@ -71,6 +71,12 @@ const REASON_LEGEND = [
     label: 'Policy replaced',
     description: 'Product change with new member numbers',
     icon: <ArrowRightLeft className="h-3.5 w-3.5 text-purple-600" aria-hidden />,
+  },
+  {
+    key: 'MISSING_INFO',
+    label: 'Missing information',
+    description: 'Required spouse/child fields incomplete — not selectable until care-ops updates the record',
+    icon: <CircleAlert className="h-3.5 w-3.5 text-rose-600" aria-hidden />,
   },
 ] as const
 
@@ -163,6 +169,7 @@ export default function LctExportsAdminPage() {
     memberNumber: '',
     phone: '',
     product: '',
+    scheme: '',
   })
   const [batches, setBatches] = useState<LctOpenBatch[]>([])
   const [errors, setErrors] = useState<Array<Record<string, unknown>>>([])
@@ -186,6 +193,7 @@ export default function LctExportsAdminPage() {
         memberNumber: filters.memberNumber || undefined,
         phone: filters.phone || undefined,
         product: filters.product || undefined,
+        scheme: filters.scheme || undefined,
       })
       setGroups(res.data.groups)
       setOpenBatch(res.data.openBatch)
@@ -228,17 +236,19 @@ export default function LctExportsAdminPage() {
     if (tab === 'errors') void loadErrors()
   }, [tab, loadPending, loadHistory, loadErrors])
 
-  const allPendingIds = useMemo(() => {
+  const selectablePendingIds = useMemo(() => {
     const ids: string[] = []
     for (const g of groups) {
-      if (g.principal) ids.push(g.principal.id)
-      for (const d of g.dependants) ids.push(d.id)
+      if (g.principal && g.principal.exportEligible !== false) ids.push(g.principal.id)
+      for (const d of g.dependants) {
+        if (d.exportEligible !== false) ids.push(d.id)
+      }
     }
     return ids
   }, [groups])
 
   const toggleAll = (checked: boolean) => {
-    setSelected(checked ? new Set(allPendingIds) : new Set())
+    setSelected(checked ? new Set(selectablePendingIds) : new Set())
   }
 
   const toggleOne = (id: string, checked: boolean) => {
@@ -336,37 +346,45 @@ export default function LctExportsAdminPage() {
     }
   }
 
-  const renderRow = (row: LctPendingRow, indent = false) => (
-    <tr key={row.id} className="border-b text-sm">
-      <td className="p-2">
-        <input
-          type="checkbox"
-          checked={selected.has(rowCheckboxId(row))}
-          onChange={(e) => toggleOne(row.id, e.target.checked)}
-          disabled={!!openBatch}
-        />
-      </td>
-      <td className={`p-2 whitespace-nowrap ${indent ? 'pl-8' : 'font-medium'}`}>{row.personName}</td>
-      <td className="p-2 font-mono text-xs whitespace-nowrap">{row.memberNumber}</td>
-      <td className="p-2 whitespace-nowrap">{row.relationship}</td>
-      <td className="p-2 whitespace-nowrap">
-        <Badge variant="outline" className={actionBadgeClass(row.pendingAction)}>
-          {row.pendingAction}
-        </Badge>
-      </td>
-      <td className="p-2 whitespace-nowrap">{reasonIcons(row.pendingReasons)}</td>
-      <td className="p-2 text-muted-foreground">{row.schemeName || '—'}</td>
-      <td className="p-2 text-muted-foreground">{row.productName}</td>
-      <td className="p-2">
-        <Link
-          href={`/admin/customer/${row.customerId}`}
-          className="text-blue-600 hover:underline text-xs"
-        >
-          View
-        </Link>
-      </td>
-    </tr>
-  )
+  const renderRow = (row: LctPendingRow, indent = false) => {
+    const incomplete = row.exportEligible === false
+    const checkboxDisabled = !!openBatch || incomplete
+    return (
+      <tr
+        key={row.id}
+        className={`border-b text-sm ${incomplete ? 'bg-rose-50/60 text-muted-foreground' : ''}`}
+      >
+        <td className="p-2">
+          <input
+            type="checkbox"
+            checked={selected.has(rowCheckboxId(row))}
+            onChange={(e) => toggleOne(row.id, e.target.checked)}
+            disabled={checkboxDisabled}
+            title={incomplete ? 'Missing required information' : undefined}
+          />
+        </td>
+        <td className={`p-2 whitespace-nowrap ${indent ? 'pl-8' : 'font-medium'}`}>{row.personName}</td>
+        <td className="p-2 font-mono text-xs whitespace-nowrap">{row.memberNumber}</td>
+        <td className="p-2 whitespace-nowrap">{row.relationship}</td>
+        <td className="p-2 whitespace-nowrap">
+          <Badge variant="outline" className={actionBadgeClass(row.pendingAction)}>
+            {row.pendingAction}
+          </Badge>
+        </td>
+        <td className="p-2 whitespace-nowrap">{reasonIcons(row.pendingReasons)}</td>
+        <td className="p-2 text-muted-foreground">{row.schemeName || '—'}</td>
+        <td className="p-2 text-muted-foreground">{row.productName}</td>
+        <td className="p-2">
+          <Link
+            href={`/admin/customer/${row.customerId}`}
+            className="text-blue-600 hover:underline text-xs"
+          >
+            View
+          </Link>
+        </td>
+      </tr>
+    )
+  }
 
   return (
     <div className="space-y-6 p-4 md:p-6">
@@ -434,13 +452,14 @@ export default function LctExportsAdminPage() {
             </div>
           )}
 
-          <div className="grid gap-2 md:grid-cols-5">
+          <div className="grid gap-2 md:grid-cols-3 lg:grid-cols-6">
             {(
               [
                 ['name', 'Name'],
                 ['idNumber', 'ID number'],
                 ['memberNumber', 'Member #'],
                 ['phone', 'Phone'],
+                ['scheme', 'Scheme'],
                 ['product', 'Product'],
               ] as const
             ).map(([key, label]) => (
@@ -462,11 +481,13 @@ export default function LctExportsAdminPage() {
             <label className="flex items-center gap-2 text-sm">
               <input
                 type="checkbox"
-                checked={allPendingIds.length > 0 && selected.size === allPendingIds.length}
+                checked={
+                  selectablePendingIds.length > 0 && selected.size === selectablePendingIds.length
+                }
                 onChange={(e) => toggleAll(e.target.checked)}
-                disabled={!!openBatch || !allPendingIds.length}
+                disabled={!!openBatch || !selectablePendingIds.length}
               />
-              Select all ({selected.size})
+              Select all eligible ({selected.size})
             </label>
             <Button
               onClick={() => void handleExport()}

--- a/apps/agent-registration/src/app/(main)/dashboard/layout.tsx
+++ b/apps/agent-registration/src/app/(main)/dashboard/layout.tsx
@@ -9,14 +9,14 @@ import { useBAStatusCheck } from '@/hooks/useBAStatusCheck';
 import { Button } from '@/components/ui/button';
 import { Sheet, SheetContent, SheetTrigger, SheetHeader, SheetTitle, SheetDescription } from '@/components/ui/sheet';
 import { useIsMobile } from '@/hooks/use-mobile';
-import { LogOut, User, Settings, Search, Home, UserPlus, ClipboardList, Menu, RefreshCw, Hospital } from 'lucide-react';
+import { LogOut, User, Settings, Search, Home, UserPlus, ClipboardList, Menu, RefreshCw, Hospital, ClipboardPen } from 'lucide-react';
 
 export default function DashboardLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const { user, userMetadata, isBrandAmbassador, isAdmin, signOut, loading } = useAuth();
+  const { user, userMetadata, isBrandAmbassador, isAdmin, isCustomerCare, isRegistrationAdmin, signOut, loading } = useAuth();
   const pathname = usePathname();
   const isMobile = useIsMobile();
   const [sidebarOpen, setSidebarOpen] = useState(false);
@@ -41,8 +41,9 @@ export default function DashboardLayout({
     return null;
   }
 
-  // If user is authenticated but not authorized for dashboard
-  if (!isBrandAmbassador) {
+  // Agents, customer care, and registration admins can use the dashboard
+  const canAccessDashboard = isBrandAmbassador || isCustomerCare || isRegistrationAdmin
+  if (!canAccessDashboard) {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <div className="text-center">
@@ -129,6 +130,19 @@ export default function DashboardLayout({
           <Hospital className="h-4 w-4 mr-2" />
           Providers
         </Link>
+
+        {(isCustomerCare || isRegistrationAdmin) && (
+          <Link
+            href="/dashboard/missing-information"
+            className={`flex items-center px-3 py-2 rounded-md hover:bg-white/10 transition-colors ${
+              pathname === '/dashboard/missing-information' ? 'bg-white/10' : ''
+            }`}
+            onClick={() => isMobile && setSidebarOpen(false)}
+          >
+            <ClipboardPen className="h-4 w-4 mr-2" />
+            Missing Information
+          </Link>
+        )}
 
         {/* Admin link - only visible if user has registration_admin role */}
         {isAdmin && (

--- a/apps/agent-registration/src/app/(main)/dashboard/missing-information/page.tsx
+++ b/apps/agent-registration/src/app/(main)/dashboard/missing-information/page.tsx
@@ -1,0 +1,419 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
+import { useAuth } from '@/hooks/useAuth'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Badge } from '@/components/ui/badge'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import {
+  getCareOpsMissingQueue,
+  updateDependant,
+  updateBeneficiary,
+  type CareOpsQueueItem,
+} from '@/lib/api'
+import { Download, Loader2, RefreshCw } from 'lucide-react'
+
+type EditForm = {
+  firstName: string
+  middleName: string
+  lastName: string
+  gender: string
+  idType: string
+  idNumber: string
+  dateOfBirth: string
+}
+
+function toCsv(items: CareOpsQueueItem[]): string {
+  const headers = [
+    'Customer',
+    'Customer phone',
+    'Entity kind',
+    'Entity name',
+    'Missing fields',
+    'First name',
+    'Last name',
+    'Gender',
+    'ID type',
+    'ID number',
+    'Date of birth',
+  ]
+  const escape = (v: string) => (/[",\n\r]/.test(v) ? `"${v.replace(/"/g, '""')}"` : v)
+  const rows = items.map((item) =>
+    [
+      item.customerName,
+      item.customerPhone ?? '',
+      item.entityKind,
+      item.entityName,
+      item.missingFieldLabels.join('; '),
+      item.firstName ?? '',
+      item.lastName ?? '',
+      item.gender ?? '',
+      item.idType ?? '',
+      item.idNumber ?? '',
+      item.dateOfBirth ?? '',
+    ]
+      .map((c) => escape(String(c)))
+      .join(',')
+  )
+  return [headers.join(','), ...rows].join('\n') + '\n'
+}
+
+export default function MissingInformationPage() {
+  const { isCustomerCare, isRegistrationAdmin, loading: authLoading } = useAuth()
+  const canAccess = isCustomerCare || isRegistrationAdmin
+
+  const [items, setItems] = useState<CareOpsQueueItem[]>([])
+  const [total, setTotal] = useState(0)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [editItem, setEditItem] = useState<CareOpsQueueItem | null>(null)
+  const [form, setForm] = useState<EditForm | null>(null)
+  const [saving, setSaving] = useState(false)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await getCareOpsMissingQueue({ limit: 100, offset: 0 })
+      setItems(res.items)
+      setTotal(res.total)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load queue')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!authLoading && canAccess) void load()
+  }, [authLoading, canAccess, load])
+
+  const openEdit = (item: CareOpsQueueItem) => {
+    setEditItem(item)
+    setForm({
+      firstName: item.firstName ?? '',
+      middleName: item.middleName ?? '',
+      lastName: item.lastName ?? '',
+      gender: (item.gender ?? '').toLowerCase() === 'female' ? 'female' : (item.gender ?? '').toLowerCase() === 'male' ? 'male' : '',
+      idType: item.idType ?? 'NATIONAL_ID',
+      idNumber: item.idNumber ?? '',
+      dateOfBirth: item.dateOfBirth ?? '',
+    })
+  }
+
+  const mapIdTypeToApi = (idType?: string): string | undefined => {
+    if (!idType) return undefined
+    const mapping: Record<string, string> = {
+      NATIONAL_ID: 'national',
+      PASSPORT: 'passport',
+      ALIEN: 'alien',
+      BIRTH_CERTIFICATE: 'birth_certificate',
+      MILITARY: 'military',
+    }
+    return mapping[idType] ?? idType.toLowerCase()
+  }
+
+  const handleSave = async () => {
+    if (!editItem?.entityId || !form) return
+    setSaving(true)
+    setError(null)
+    try {
+      if (editItem.entityKind === 'BENEFICIARY') {
+        await updateBeneficiary(editItem.customerId, editItem.entityId, {
+          firstName: form.firstName || undefined,
+          middleName: form.middleName || undefined,
+          lastName: form.lastName || undefined,
+          idType: mapIdTypeToApi(form.idType),
+          idNumber: form.idNumber || undefined,
+          gender: form.gender || undefined,
+          dateOfBirth: form.dateOfBirth || undefined,
+        })
+      } else {
+        await updateDependant(editItem.entityId, {
+          firstName: form.firstName || undefined,
+          middleName: form.middleName || undefined,
+          lastName: form.lastName || undefined,
+          gender: form.gender || undefined,
+          idType: mapIdTypeToApi(form.idType),
+          idNumber: form.idNumber || undefined,
+          dateOfBirth: form.dateOfBirth || undefined,
+        })
+      }
+      setEditItem(null)
+      setForm(null)
+      await load()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to save')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const downloadCsv = () => {
+    const blob = new Blob([toCsv(items)], { type: 'text/csv;charset=utf-8' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `missing-information-${new Date().toISOString().slice(0, 10)}.csv`
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  const requiredHint = useMemo(() => {
+    if (!editItem) return ''
+    return editItem.missingFieldLabels.join(', ')
+  }, [editItem])
+
+  if (authLoading) {
+    return (
+      <div className="flex min-h-[300px] items-center justify-center">
+        <Loader2 className="h-6 w-6 animate-spin" />
+      </div>
+    )
+  }
+
+  if (!canAccess) {
+    return (
+      <div className="p-6">
+        <h1 className="text-2xl font-bold">Access Denied</h1>
+        <p className="mt-2 text-muted-foreground">
+          Only Customer Care and Registration Admin can access missing information.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6 p-4 md:p-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-bold">Missing Information</h1>
+          <p className="text-sm text-muted-foreground">
+            Care-ops queue for deferred spouse, child, and beneficiary fields. Completing these
+            unlocks LCT export eligibility.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="outline" size="sm" onClick={() => void load()} disabled={loading}>
+            <RefreshCw className="mr-2 h-4 w-4" />
+            Refresh
+          </Button>
+          <Button variant="outline" size="sm" onClick={downloadCsv} disabled={!items.length}>
+            <Download className="mr-2 h-4 w-4" />
+            Export CSV
+          </Button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800">
+          {error}
+        </div>
+      )}
+
+      <div className="text-sm text-muted-foreground">
+        Showing {items.length} incomplete entit{items.length === 1 ? 'y' : 'ies'}
+        {total ? ` across ${total} customer(s)` : ''}
+      </div>
+
+      {loading ? (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" /> Loading…
+        </div>
+      ) : (
+        <div className="rounded-md border overflow-x-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Customer</TableHead>
+                <TableHead>Phone</TableHead>
+                <TableHead>Member</TableHead>
+                <TableHead>Type</TableHead>
+                <TableHead>Missing</TableHead>
+                <TableHead />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {items.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={6} className="text-center text-muted-foreground py-8">
+                    No missing information right now
+                  </TableCell>
+                </TableRow>
+              ) : (
+                items.map((item) => (
+                  <TableRow key={`${item.customerId}:${item.entityKind}:${item.entityId}`}>
+                    <TableCell>
+                      <Link
+                        href={`/dashboard/customer/${item.customerId}`}
+                        className="text-blue-600 hover:underline font-medium"
+                      >
+                        {item.customerName}
+                      </Link>
+                    </TableCell>
+                    <TableCell className="whitespace-nowrap">{item.customerPhone || '—'}</TableCell>
+                    <TableCell>{item.entityName}</TableCell>
+                    <TableCell>
+                      <Badge variant="outline">{item.entityKind}</Badge>
+                    </TableCell>
+                    <TableCell className="text-sm">{item.missingFieldLabels.join(', ')}</TableCell>
+                    <TableCell>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        disabled={!item.entityId}
+                        onClick={() => openEdit(item)}
+                      >
+                        Update
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+
+      <Dialog
+        open={!!editItem}
+        onOpenChange={(open) => {
+          if (!open) {
+            setEditItem(null)
+            setForm(null)
+          }
+        }}
+      >
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>
+              Update {editItem?.entityKind.toLowerCase()} — {editItem?.entityName}
+            </DialogTitle>
+          </DialogHeader>
+          {form && (
+            <div className="grid gap-3">
+              <p className="text-xs text-muted-foreground">Required: {requiredHint}</p>
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <Label className="text-xs">First name</Label>
+                  <Input
+                    value={form.firstName}
+                    onChange={(e) => setForm({ ...form, firstName: e.target.value })}
+                  />
+                </div>
+                <div>
+                  <Label className="text-xs">Last name</Label>
+                  <Input
+                    value={form.lastName}
+                    onChange={(e) => setForm({ ...form, lastName: e.target.value })}
+                  />
+                </div>
+              </div>
+              <div>
+                <Label className="text-xs">Middle name</Label>
+                <Input
+                  value={form.middleName}
+                  onChange={(e) => setForm({ ...form, middleName: e.target.value })}
+                />
+              </div>
+              {(editItem?.entityKind === 'SPOUSE' ||
+                editItem?.entityKind === 'CHILD' ||
+                editItem?.missingFields.includes('gender')) && (
+                <div>
+                  <Label className="text-xs">Gender</Label>
+                  <Select
+                    value={form.gender || undefined}
+                    onValueChange={(v) => setForm({ ...form, gender: v })}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select gender" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="male">Male</SelectItem>
+                      <SelectItem value="female">Female</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              )}
+              {(editItem?.entityKind === 'SPOUSE' ||
+                editItem?.entityKind === 'CHILD' ||
+                editItem?.missingFields.includes('dateOfBirth')) && (
+                <div>
+                  <Label className="text-xs">Date of birth</Label>
+                  <Input
+                    type="date"
+                    value={form.dateOfBirth}
+                    onChange={(e) => setForm({ ...form, dateOfBirth: e.target.value })}
+                  />
+                </div>
+              )}
+              {(editItem?.entityKind === 'SPOUSE' ||
+                editItem?.entityKind === 'BENEFICIARY' ||
+                editItem?.missingFields.includes('idNumber')) && (
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <Label className="text-xs">ID type</Label>
+                    <Select
+                      value={form.idType || 'NATIONAL_ID'}
+                      onValueChange={(v) => setForm({ ...form, idType: v })}
+                    >
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="NATIONAL_ID">National ID</SelectItem>
+                        <SelectItem value="PASSPORT">Passport</SelectItem>
+                        <SelectItem value="ALIEN">Alien</SelectItem>
+                        <SelectItem value="BIRTH_CERTIFICATE">Birth certificate</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div>
+                    <Label className="text-xs">ID number</Label>
+                    <Input
+                      value={form.idNumber}
+                      onChange={(e) => setForm({ ...form, idNumber: e.target.value })}
+                    />
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setEditItem(null)} disabled={saving}>
+              Cancel
+            </Button>
+            <Button onClick={() => void handleSave()} disabled={saving || !form}>
+              {saving ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : null}
+              Save
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/apps/agent-registration/src/app/(main)/dashboard/missing-information/page.tsx
+++ b/apps/agent-registration/src/app/(main)/dashboard/missing-information/page.tsx
@@ -275,7 +275,7 @@ export default function MissingInformationPage() {
                         {item.customerName}
                       </Link>
                     </TableCell>
-                    <TableCell className="whitespace-nowrap">{item.customerPhone || '—'}</TableCell>
+                    <TableCell className="whitespace-nowrap">{item.customerPhone ?? '—'}</TableCell>
                     <TableCell>{item.entityName}</TableCell>
                     <TableCell>
                       <Badge variant="outline">{item.entityKind}</Badge>

--- a/apps/agent-registration/src/lib/api.ts
+++ b/apps/agent-registration/src/lib/api.ts
@@ -2826,7 +2826,7 @@ export async function getCareOpsMissingQueue(params?: {
   )
   if (!response.ok) {
     const err = await response.json().catch(() => ({}))
-    throw new Error(err.message || `Failed to load care-ops queue (${response.status})`)
+    throw new Error(err.message ?? `Failed to load care-ops queue (${response.status})`)
   }
   return response.json()
 }

--- a/apps/agent-registration/src/lib/api.ts
+++ b/apps/agent-registration/src/lib/api.ts
@@ -2715,6 +2715,8 @@ export interface LctPendingRow {
   idNumber: string
   phone: string
   relationship: string
+  exportEligible?: boolean
+  missingFields?: string[]
 }
 
 export interface LctPendingGroup {
@@ -2765,6 +2767,7 @@ export async function getLctPending(filters?: {
   memberNumber?: string
   phone?: string
   product?: string
+  scheme?: string
 }): Promise<{
   status: number
   data: { groups: LctPendingGroup[]; openBatch: LctOpenBatch | null }
@@ -2775,8 +2778,57 @@ export async function getLctPending(filters?: {
   if (filters?.memberNumber) params.set('memberNumber', filters.memberNumber)
   if (filters?.phone) params.set('phone', filters.phone)
   if (filters?.product) params.set('product', filters.product)
+  if (filters?.scheme) params.set('scheme', filters.scheme)
   const q = params.toString()
   return lctFetch(`/internal/lct-exports/pending${q ? `?${q}` : ''}`)
+}
+
+export interface CareOpsQueueItem {
+  customerId: string
+  customerName: string
+  customerPhone?: string | null
+  registrationId?: string | null
+  partnerId?: number | null
+  entityKind: 'SPOUSE' | 'CHILD' | 'BENEFICIARY' | 'CUSTOMER'
+  entityId?: string | null
+  entityName: string
+  missingFields: string[]
+  missingFieldLabels: string[]
+  firstName?: string | null
+  middleName?: string | null
+  lastName?: string | null
+  gender?: string | null
+  idType?: string | null
+  idNumber?: string | null
+  dateOfBirth?: string | null
+}
+
+export async function getCareOpsMissingQueue(params?: {
+  limit?: number
+  offset?: number
+  partnerId?: number
+}): Promise<{ items: CareOpsQueueItem[]; total: number }> {
+  const search = new URLSearchParams()
+  if (params?.limit != null) search.set('limit', String(params.limit))
+  if (params?.offset != null) search.set('offset', String(params.offset))
+  if (params?.partnerId != null) search.set('partnerId', String(params.partnerId))
+  const q = search.toString()
+  const token = await getSupabaseToken()
+  const response = await fetch(
+    `${process.env.NEXT_PUBLIC_INTERNAL_API_BASE_URL}/internal/agent-registrations/missing-requirements/queue${q ? `?${q}` : ''}`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        'x-correlation-id': `care-ops-${Date.now()}`,
+      },
+    }
+  )
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}))
+    throw new Error(err.message || `Failed to load care-ops queue (${response.status})`)
+  }
+  return response.json()
 }
 
 export async function getLctErrors(): Promise<{ status: number; data: unknown[] }> {

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -38,6 +38,7 @@
     "backfill:customer-portal-announcement": "ts-node -r dotenv/config scripts/backfill-customer-portal-announcement.ts",
     "backfill:unmapped-mpesa-payments": "ts-node -r dotenv/config scripts/backfill-unmapped-mpesa-payments.ts",
     "backfill:lct-never-sent": "ts-node -r dotenv/config scripts/backfill-lct-never-sent.ts",
+    "backfill:missing-requirements": "ts-node -r dotenv/config scripts/backfill-missing-requirements.ts",
     "reprocess:siti-empty-msisdn-ipns": "ts-node -r dotenv/config scripts/reprocess-siti-empty-msisdn-ipns.ts",
     "audit:messaging-creator-phones": "ts-node -r dotenv/config scripts/audit-messaging-creator-phones.ts",
     "remediate:daily-premium-as-installment": "ts-node -r dotenv/config scripts/remediate-daily-premium-as-installment.ts"

--- a/apps/api/prisma/seed-agent-registration.ts
+++ b/apps/api/prisma/seed-agent-registration.ts
@@ -2,53 +2,69 @@ import { PrismaClient } from '@prisma/client'
 
 /**
  * Seed Agent Registration Data
- * 
- * This function seeds deferred requirement defaults for agent registration.
- * It can be called standalone or as part of the master seed process.
- * 
+ *
+ * Seeds deferred requirement defaults aligned with care-ops / LCT completeness:
+ * - Spouse: firstName, lastName, idNumber, gender, dateOfBirth
+ * - Child: firstName, lastName, dateOfBirth, gender
+ * - Beneficiary: firstName, lastName, idType, idNumber (care-ops only; never sent to LCT)
+ *
  * @param prisma - PrismaClient instance (optional, creates new if not provided)
  */
 export async function seedAgentRegistrationData(prismaInstance?: PrismaClient) {
   const prisma = prismaInstance || new PrismaClient()
-  const shouldDisconnect = !prismaInstance // Only disconnect if we created the instance
+  const shouldDisconnect = !prismaInstance
 
   try {
     console.log('🌱 Starting Agent Registration seed data...')
 
-    // Seed DeferredRequirementDefault data
     const deferredRequirements = [
-      // Spouse requirements
-      { entityKind: 'SPOUSE', fieldPath: 'gender', isRequired: true },
-      { entityKind: 'SPOUSE', fieldPath: 'idType', isRequired: true },
+      { entityKind: 'SPOUSE', fieldPath: 'firstName', isRequired: true },
+      { entityKind: 'SPOUSE', fieldPath: 'lastName', isRequired: true },
       { entityKind: 'SPOUSE', fieldPath: 'idNumber', isRequired: true },
-      
-      // Child requirements  
+      { entityKind: 'SPOUSE', fieldPath: 'gender', isRequired: true },
+      { entityKind: 'SPOUSE', fieldPath: 'dateOfBirth', isRequired: true },
+
+      { entityKind: 'CHILD', fieldPath: 'firstName', isRequired: true },
+      { entityKind: 'CHILD', fieldPath: 'lastName', isRequired: true },
+      { entityKind: 'CHILD', fieldPath: 'dateOfBirth', isRequired: true },
       { entityKind: 'CHILD', fieldPath: 'gender', isRequired: true },
-      { entityKind: 'CHILD', fieldPath: 'idType', isRequired: true },
-      { entityKind: 'CHILD', fieldPath: 'idNumber', isRequired: true },
-      
-      // Beneficiary requirements
+
       { entityKind: 'BENEFICIARY', fieldPath: 'firstName', isRequired: true },
       { entityKind: 'BENEFICIARY', fieldPath: 'lastName', isRequired: true },
       { entityKind: 'BENEFICIARY', fieldPath: 'idType', isRequired: true },
       { entityKind: 'BENEFICIARY', fieldPath: 'idNumber', isRequired: true },
     ]
 
-    // Upsert each requirement
+    // Retire legacy spouse/child idType-only deferrals that are no longer required
+    const retired = [
+      { entityKind: 'SPOUSE', fieldPath: 'idType' },
+      { entityKind: 'CHILD', fieldPath: 'idType' },
+      { entityKind: 'CHILD', fieldPath: 'idNumber' },
+    ] as const
+
+    for (const req of retired) {
+      await prisma.deferredRequirementDefault.deleteMany({
+        where: {
+          entityKind: req.entityKind as never,
+          fieldPath: req.fieldPath,
+        },
+      })
+    }
+
     for (const req of deferredRequirements) {
       await prisma.deferredRequirementDefault.upsert({
         where: {
           entityKind_fieldPath: {
-            entityKind: req.entityKind as any,
-            fieldPath: req.fieldPath
-          }
+            entityKind: req.entityKind as never,
+            fieldPath: req.fieldPath,
+          },
         },
-        update: {},
+        update: { isRequired: req.isRequired },
         create: {
-          entityKind: req.entityKind as any,
+          entityKind: req.entityKind as never,
           fieldPath: req.fieldPath,
-          isRequired: req.isRequired
-        }
+          isRequired: req.isRequired,
+        },
       })
       console.log(`✅ Upserted requirement: ${req.entityKind}.${req.fieldPath}`)
     }
@@ -61,10 +77,6 @@ export async function seedAgentRegistrationData(prismaInstance?: PrismaClient) {
   }
 }
 
-/**
- * Standalone execution (for backward compatibility)
- * This allows the file to still be run directly: ts-node seed-agent-registration.ts
- */
 async function main() {
   try {
     await seedAgentRegistrationData()
@@ -74,7 +86,6 @@ async function main() {
   }
 }
 
-// Only run main if this file is executed directly (not imported)
 if (require.main === module) {
   main()
     .catch((e) => {

--- a/apps/api/scripts/backfill-missing-requirements.ts
+++ b/apps/api/scripts/backfill-missing-requirements.ts
@@ -1,0 +1,275 @@
+/**
+ * Backfill / reconcile MissingRequirement rows from live dependant & beneficiary data
+ * using aligned deferred field rules (spouse/child/beneficiary).
+ *
+ * Also clears legacy LCT errorCode MISSING_SPOUSE_ID (incomplete rows now stay on Pending).
+ *
+ * ── Recommended rollout ──
+ *
+ *   1. Preview customers:
+ *        LIST_ONLY=1 pnpm --filter @microbima/api backfill:missing-requirements
+ *
+ *   2. Dry-run:
+ *        DRY_RUN=1 LIMIT=20 pnpm --filter @microbima/api backfill:missing-requirements
+ *
+ *   3. Apply:
+ *        pnpm --filter @microbima/api backfill:missing-requirements
+ *
+ * ── On Fly ──
+ *
+ *   LIST_ONLY=1 node apps/api/dist/scripts/backfill-missing-requirements.js
+ *   node apps/api/dist/scripts/backfill-missing-requirements.js
+ *
+ * Required env: DATABASE_URL
+ * Optional: DRY_RUN=1, LIST_ONLY=1, LIMIT=n, OFFSET=n, CUSTOMER_IDS=a,b
+ */
+
+import { config } from 'dotenv';
+import { resolve } from 'path';
+import {
+  DependantRelationship,
+  PrismaClient,
+  RegistrationEntityKind,
+  RegistrationMissingStatus,
+} from '@prisma/client';
+
+const envPath = __dirname.includes('dist')
+  ? resolve(__dirname, '..', '..', '.env')
+  : resolve(__dirname, '..', '.env');
+config({ path: envPath });
+
+const prisma = new PrismaClient();
+const dryRun = process.env.DRY_RUN === '1';
+const listOnly = process.env.LIST_ONLY === '1';
+const limit = process.env.LIMIT ? Math.max(1, parseInt(process.env.LIMIT, 10)) : undefined;
+const offset = process.env.OFFSET ? Math.max(0, parseInt(process.env.OFFSET, 10)) : 0;
+const customerIdsFilter = process.env.CUSTOMER_IDS
+  ? process.env.CUSTOMER_IDS.split(',').map((s) => s.trim()).filter(Boolean)
+  : undefined;
+
+const REQUIRED: Record<string, string[]> = {
+  SPOUSE: ['firstName', 'lastName', 'idNumber', 'gender', 'dateOfBirth'],
+  CHILD: ['firstName', 'lastName', 'dateOfBirth', 'gender'],
+  BENEFICIARY: ['firstName', 'lastName', 'idType', 'idNumber'],
+};
+
+const RETIRED: Array<{ entityKind: RegistrationEntityKind; fieldPath: string }> = [
+  { entityKind: RegistrationEntityKind.SPOUSE, fieldPath: 'idType' },
+  { entityKind: RegistrationEntityKind.CHILD, fieldPath: 'idType' },
+  { entityKind: RegistrationEntityKind.CHILD, fieldPath: 'idNumber' },
+];
+
+function isBlank(value: unknown): boolean {
+  if (value === null || value === undefined) return true;
+  if (value instanceof Date) return Number.isNaN(value.getTime());
+  if (typeof value === 'string') return value.trim().length === 0;
+  return false;
+}
+
+function missingFields(
+  kind: 'SPOUSE' | 'CHILD' | 'BENEFICIARY',
+  person: Record<string, unknown>
+): string[] {
+  return (REQUIRED[kind] ?? []).filter((field) => isBlank(person[field]));
+}
+
+async function syncCustomer(customerId: string): Promise<{
+  created: number;
+  resolved: number;
+  pending: number;
+}> {
+  const registration = await prisma.agentRegistration.findFirst({
+    where: { customerId },
+    orderBy: { createdAt: 'desc' },
+  });
+  if (!registration) {
+    return { created: 0, resolved: 0, pending: 0 };
+  }
+
+  const [dependants, beneficiaries, existingPending] = await Promise.all([
+    prisma.dependant.findMany({
+      where: {
+        customerId,
+        deletedAt: null,
+        relationship: { in: [DependantRelationship.SPOUSE, DependantRelationship.CHILD] },
+      },
+    }),
+    prisma.beneficiary.findMany({ where: { customerId, deletedAt: null } }),
+    prisma.missingRequirement.findMany({
+      where: { customerId, status: RegistrationMissingStatus.PENDING },
+    }),
+  ]);
+
+  const desired = new Map<
+    string,
+    { entityKind: RegistrationEntityKind; entityId: string; fieldPath: string }
+  >();
+
+  for (const dep of dependants) {
+    const kind =
+      dep.relationship === DependantRelationship.SPOUSE
+        ? RegistrationEntityKind.SPOUSE
+        : RegistrationEntityKind.CHILD;
+    for (const fieldPath of missingFields(kind, dep as unknown as Record<string, unknown>)) {
+      desired.set(`${kind}:${dep.id}:${fieldPath}`, {
+        entityKind: kind,
+        entityId: dep.id,
+        fieldPath,
+      });
+    }
+  }
+  for (const ben of beneficiaries) {
+    for (const fieldPath of missingFields(
+      'BENEFICIARY',
+      ben as unknown as Record<string, unknown>
+    )) {
+      desired.set(`${RegistrationEntityKind.BENEFICIARY}:${ben.id}:${fieldPath}`, {
+        entityKind: RegistrationEntityKind.BENEFICIARY,
+        entityId: ben.id,
+        fieldPath,
+      });
+    }
+  }
+
+  let resolved = 0;
+  let created = 0;
+
+  if (!dryRun) {
+    for (const mr of existingPending) {
+      const isRetired = RETIRED.some(
+        (r) => r.entityKind === mr.entityKind && r.fieldPath === mr.fieldPath
+      );
+      const key = mr.entityId ? `${mr.entityKind}:${mr.entityId}:${mr.fieldPath}` : null;
+      const stillNeeded = key ? desired.has(key) : false;
+      let legacyStillNeeded = false;
+      if (!mr.entityId && !isRetired) {
+        legacyStillNeeded = Array.from(desired.values()).some(
+          (d) => d.entityKind === mr.entityKind && d.fieldPath === mr.fieldPath
+        );
+      }
+      if (isRetired || (mr.entityId && !stillNeeded) || (!mr.entityId && !legacyStillNeeded)) {
+        await prisma.missingRequirement.update({
+          where: { id: mr.id },
+          data: {
+            status: RegistrationMissingStatus.RESOLVED,
+            resolvedAt: new Date(),
+            resolvedBy: 'backfill-missing-requirements',
+          },
+        });
+        resolved += 1;
+      } else if (!mr.entityId && legacyStillNeeded) {
+        const match = Array.from(desired.values()).find(
+          (d) => d.entityKind === mr.entityKind && d.fieldPath === mr.fieldPath
+        );
+        if (match) {
+          await prisma.missingRequirement.update({
+            where: { id: mr.id },
+            data: { entityId: match.entityId },
+          });
+        }
+      }
+    }
+
+    const pendingAfter = await prisma.missingRequirement.findMany({
+      where: { customerId, status: RegistrationMissingStatus.PENDING },
+    });
+    const pendingKeys = new Set(
+      pendingAfter
+        .filter((mr) => mr.entityId)
+        .map((mr) => `${mr.entityKind}:${mr.entityId}:${mr.fieldPath}`)
+    );
+    const toCreate = Array.from(desired.entries())
+      .filter(([key]) => !pendingKeys.has(key))
+      .map(([, value]) => ({
+        registrationId: registration.id,
+        customerId,
+        partnerId: registration.partnerId,
+        entityKind: value.entityKind,
+        entityId: value.entityId,
+        fieldPath: value.fieldPath,
+        status: RegistrationMissingStatus.PENDING,
+      }));
+    if (toCreate.length) {
+      await prisma.missingRequirement.createMany({ data: toCreate });
+      created = toCreate.length;
+    }
+
+    const pending = await prisma.missingRequirement.count({
+      where: { customerId, status: RegistrationMissingStatus.PENDING },
+    });
+    await prisma.customer.update({
+      where: { id: customerId },
+      data: { hasMissingRequirements: pending > 0 },
+    });
+    return { created, resolved, pending };
+  }
+
+  return { created: desired.size, resolved: 0, pending: desired.size };
+}
+
+async function main() {
+  const customers = await prisma.customer.findMany({
+    where: {
+      isTestUser: false,
+      ...(customerIdsFilter ? { id: { in: customerIdsFilter } } : {}),
+      OR: [
+        { registrations: { some: {} } },
+        { hasMissingRequirements: true },
+        { missingRequirements: { some: {} } },
+        {
+          dependants: {
+            some: {
+              deletedAt: null,
+              relationship: { in: [DependantRelationship.SPOUSE, DependantRelationship.CHILD] },
+            },
+          },
+        },
+      ],
+    },
+    select: { id: true, firstName: true, lastName: true, hasMissingRequirements: true },
+    orderBy: { createdAt: 'asc' },
+    take: limit,
+    skip: offset,
+  });
+
+  console.log(
+    `Found ${customers.length} customer(s) dryRun=${dryRun} listOnly=${listOnly}`
+  );
+
+  if (listOnly) {
+    for (const c of customers) {
+      console.log(`${c.id} ${c.firstName} ${c.lastName} hasMissing=${c.hasMissingRequirements}`);
+    }
+    return;
+  }
+
+  let totalCreated = 0;
+  let totalResolved = 0;
+  for (const c of customers) {
+    const result = await syncCustomer(c.id);
+    totalCreated += result.created;
+    totalResolved += result.resolved;
+    console.log(
+      `${c.id} created=${result.created} resolved=${result.resolved} pending=${result.pending}`
+    );
+  }
+
+  if (!dryRun) {
+    const cleared = await prisma.lctMemberSyncTarget.updateMany({
+      where: { errorCode: 'MISSING_SPOUSE_ID' },
+      data: { errorCode: null },
+    });
+    console.log(`Cleared MISSING_SPOUSE_ID on ${cleared.count} LCT sync target(s)`);
+  }
+
+  console.log(`Done. created=${totalCreated} resolved=${totalResolved}`);
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/apps/api/src/controllers/internal/agent-registration.controller.ts
+++ b/apps/api/src/controllers/internal/agent-registration.controller.ts
@@ -30,10 +30,11 @@ import {
   CreateMissingRequirementDto,
   UpdateMissingRequirementDto,
   MissingRequirementResponseDto,
+  CareOpsQueueResponseDto,
 } from '../../dto/missing-requirement';
 import { CorrelationId } from '../../decorators/correlation-id.decorator';
 import { Request } from 'express';
-import { BAAuth, AdminOnly, AdminOrBA } from '../../decorators/ba-auth.decorator';
+import { BAAuth, AdminOnly, AdminOrBA, AdminOrCustomerCare } from '../../decorators/ba-auth.decorator';
 import { DataMaskingInterceptor } from '../../interceptors/data-masking.interceptor';
 import { EnableDataMasking } from '../../decorators/data-masking.decorator';
 
@@ -291,11 +292,73 @@ export class AgentRegistrationController {
   }
 
   /**
+   * Get pending missing requirements for care-ops / admin resolution
+   * (Static path must be registered before missing-requirements/:id)
+   */
+  @Get('missing-requirements/pending')
+  @HttpCode(HttpStatus.OK)
+  @AdminOrCustomerCare()
+  @ApiOperation({
+    summary: 'Get pending missing requirements',
+    description: 'Retrieve all pending missing requirements for care-ops resolution.',
+  })
+  @ApiQuery({ name: 'partnerId', required: false, example: 1 })
+  @ApiQuery({ name: 'limit', required: false, example: 50 })
+  @ApiQuery({ name: 'offset', required: false, example: 0 })
+  async getPendingMissingRequirements(
+    @Req() req: Request,
+    @CorrelationId() _correlationId: string,
+    @Query('partnerId') partnerId?: string,
+    @Query('limit') limit?: string,
+    @Query('offset') offset?: string,
+  ): Promise<{ missingRequirements: MissingRequirementResponseDto[]; total: number }> {
+    const userId = req.user?.id ?? 'system';
+    return this.missingRequirementService.getPendingMissingRequirements(
+      userId,
+      partnerId ? parseInt(partnerId, 10) : undefined,
+      limit ? parseInt(limit, 10) : 50,
+      offset ? parseInt(offset, 10) : 0,
+    );
+  }
+
+  /**
+   * Care-ops queue: grouped incomplete entities with live field values.
+   * (Static path must be registered before missing-requirements/:id)
+   */
+  @Get('missing-requirements/queue')
+  @HttpCode(HttpStatus.OK)
+  @AdminOrCustomerCare()
+  @ApiOperation({
+    summary: 'Care-ops missing information queue',
+    description:
+      'Returns incomplete spouse/child/beneficiary entities for customer care. Live fields are re-evaluated on each load.',
+  })
+  @ApiQuery({ name: 'partnerId', required: false })
+  @ApiQuery({ name: 'limit', required: false })
+  @ApiQuery({ name: 'offset', required: false })
+  @ApiResponse({ status: 200, type: CareOpsQueueResponseDto })
+  async getCareOpsQueue(
+    @Req() req: Request,
+    @CorrelationId() _correlationId: string,
+    @Query('partnerId') partnerId?: string,
+    @Query('limit') limit?: string,
+    @Query('offset') offset?: string,
+  ): Promise<CareOpsQueueResponseDto> {
+    const userId = req.user?.id ?? 'system';
+    return this.missingRequirementService.getCareOpsQueue({
+      userId,
+      partnerId: partnerId ? parseInt(partnerId, 10) : undefined,
+      limit: limit ? parseInt(limit, 10) : 50,
+      offset: offset ? parseInt(offset, 10) : 0,
+    });
+  }
+
+  /**
    * Get missing requirement by ID
    */
   @Get('missing-requirements/:id')
   @HttpCode(HttpStatus.OK)
-  @AdminOnly()
+  @AdminOrCustomerCare()
   @ApiOperation({
     summary: 'Get missing requirement by ID',
     description: 'Retrieve a specific missing requirement by its ID.',
@@ -337,7 +400,7 @@ export class AgentRegistrationController {
    */
   @Put('missing-requirements/:id')
   @HttpCode(HttpStatus.OK)
-  @AdminOnly()
+  @AdminOrCustomerCare()
   @ApiOperation({
     summary: 'Update missing requirement',
     description: 'Update an existing missing requirement.',
@@ -445,74 +508,4 @@ export class AgentRegistrationController {
     );
   }
 
-  /**
-   * Get pending missing requirements for admin resolution
-   */
-  @Get('missing-requirements/pending')
-  @HttpCode(HttpStatus.OK)
-  @AdminOnly()
-  @ApiOperation({
-    summary: 'Get pending missing requirements',
-    description: 'Retrieve all pending missing requirements for admin resolution.',
-  })
-  @ApiQuery({
-    name: 'partnerId',
-    description: 'Filter by partner ID',
-    required: false,
-    example: 1,
-  })
-  @ApiQuery({
-    name: 'limit',
-    description: 'Number of records to return',
-    required: false,
-    example: 50,
-  })
-  @ApiQuery({
-    name: 'offset',
-    description: 'Number of records to skip',
-    required: false,
-    example: 0,
-  })
-  @ApiResponse({
-    status: 200,
-    description: 'Pending missing requirements retrieved successfully',
-    schema: {
-      type: 'object',
-      properties: {
-        missingRequirements: {
-          type: 'array',
-          items: { $ref: '#/components/schemas/MissingRequirementResponseDto' },
-        },
-        total: { type: 'number' },
-      },
-    },
-  })
-  @ApiResponse({
-    status: 401,
-    description: 'Unauthorized - invalid authentication',
-  })
-  @ApiResponse({
-    status: 500,
-    description: 'Internal server error',
-  })
-  async getPendingMissingRequirements(
-    @CorrelationId() correlationId: string,
-    @Query('partnerId') partnerId?: string,
-    @Query('limit') limit?: string,
-    @Query('offset') offset?: string,
-  ): Promise<{ missingRequirements: MissingRequirementResponseDto[]; total: number }> {
-    // TODO: Extract user ID from JWT token
-    const userId = 'system'; // Placeholder until auth is implemented
-
-    const partnerIdNum = partnerId ? parseInt(partnerId, 10) : undefined;
-    const limitNum = limit ? parseInt(limit, 10) : 50;
-    const offsetNum = offset ? parseInt(offset, 10) : 0;
-
-    return this.missingRequirementService.getPendingMissingRequirements(
-      userId,
-      partnerIdNum,
-      limitNum,
-      offsetNum,
-    );
-  }
 }

--- a/apps/api/src/controllers/internal/lct-exports.controller.ts
+++ b/apps/api/src/controllers/internal/lct-exports.controller.ts
@@ -35,7 +35,8 @@ export class InternalLctExportsController {
     @Query('idNumber') idNumber?: string,
     @Query('memberNumber') memberNumber?: string,
     @Query('phone') phone?: string,
-    @Query('product') product?: string
+    @Query('product') product?: string,
+    @Query('scheme') scheme?: string
   ) {
     this.lctExportService.assertAdmin(user.roles ?? []);
     const data = await this.lctExportService.getPending({
@@ -44,6 +45,7 @@ export class InternalLctExportsController {
       memberNumber,
       phone,
       product,
+      scheme,
     });
     return {
       status: HttpStatus.OK,

--- a/apps/api/src/decorators/ba-auth.decorator.ts
+++ b/apps/api/src/decorators/ba-auth.decorator.ts
@@ -59,6 +59,12 @@ export const BAAuth = (options?: {
 export const AdminOnly = () => BAAuth({ roles: ['registration_admin', 'system_admin'] });
 
 /**
+ * Decorator for registration admin or customer care (care-ops queues).
+ */
+export const AdminOrCustomerCare = () =>
+  BAAuth({ roles: ['registration_admin', 'system_admin', 'customer_care'] });
+
+/**
  * Decorator for BA-only endpoints (with ownership requirement)
  */
 export const BAOnly = () => BAAuth({ allowBA: true, requireOwnership: true });

--- a/apps/api/src/dto/missing-requirement/care-ops-queue.dto.ts
+++ b/apps/api/src/dto/missing-requirement/care-ops-queue.dto.ts
@@ -1,0 +1,63 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { RegistrationEntityKind } from '@prisma/client';
+
+export class CareOpsQueueEntityDto {
+  @ApiProperty()
+  customerId: string;
+
+  @ApiProperty()
+  customerName: string;
+
+  @ApiPropertyOptional()
+  customerPhone?: string | null;
+
+  @ApiPropertyOptional()
+  registrationId?: string | null;
+
+  @ApiPropertyOptional()
+  partnerId?: number | null;
+
+  @ApiProperty({ enum: RegistrationEntityKind })
+  entityKind: RegistrationEntityKind;
+
+  @ApiPropertyOptional()
+  entityId?: string | null;
+
+  @ApiProperty()
+  entityName: string;
+
+  @ApiProperty({ type: [String] })
+  missingFields: string[];
+
+  @ApiProperty({ type: [String] })
+  missingFieldLabels: string[];
+
+  @ApiPropertyOptional()
+  firstName?: string | null;
+
+  @ApiPropertyOptional()
+  middleName?: string | null;
+
+  @ApiPropertyOptional()
+  lastName?: string | null;
+
+  @ApiPropertyOptional()
+  gender?: string | null;
+
+  @ApiPropertyOptional()
+  idType?: string | null;
+
+  @ApiPropertyOptional()
+  idNumber?: string | null;
+
+  @ApiPropertyOptional()
+  dateOfBirth?: string | null;
+}
+
+export class CareOpsQueueResponseDto {
+  @ApiProperty({ type: [CareOpsQueueEntityDto] })
+  items: CareOpsQueueEntityDto[];
+
+  @ApiProperty()
+  total: number;
+}

--- a/apps/api/src/dto/missing-requirement/index.ts
+++ b/apps/api/src/dto/missing-requirement/index.ts
@@ -1,3 +1,4 @@
 export * from './create-missing-requirement.dto';
 export * from './update-missing-requirement.dto';
 export * from './missing-requirement-response.dto';
+export * from './care-ops-queue.dto';

--- a/apps/api/src/modules/lct/__tests__/lct-action-csv.spec.ts
+++ b/apps/api/src/modules/lct/__tests__/lct-action-csv.spec.ts
@@ -12,6 +12,7 @@ import {
 } from '../lct.types';
 import { buildLctCsv, intentToCsvRow } from '../lct-csv.builder';
 import type { LctMemberSyncIntent } from '../lct.types';
+import { formatLctIdNumber, isLctDependantExportEligible } from '../../missing-requirements/completeness.util';
 
 describe('LCT action mapping', () => {
   it('maps policy statuses to CSV actions', () => {
@@ -113,6 +114,27 @@ describe('LCT CSV builder', () => {
     expect(formatLctPhone('+254722000000')).toBe('254722000000');
     expect(formatLctPhone('')).toBe('');
     expect(formatLctPhone('not-a-phone')).toBe('');
+  });
+
+  it('formats blank IDs as N/A and gates incomplete dependants', () => {
+    expect(formatLctIdNumber('')).toBe('N/A');
+    expect(formatLctIdNumber('12345678')).toBe('12345678');
+    expect(
+      isLctDependantExportEligible('SPOUSE', {
+        firstName: 'A',
+        lastName: 'B',
+        idNumber: '1',
+        gender: 'FEMALE',
+        dateOfBirth: new Date(),
+      })
+    ).toBe(true);
+    expect(
+      isLctDependantExportEligible('CHILD', {
+        firstName: 'A',
+        lastName: 'B',
+        dateOfBirth: new Date(),
+      })
+    ).toBe(false);
   });
 
   it('sorts export intents Principal → Spouse → Children by family', () => {

--- a/apps/api/src/modules/lct/lct-export.service.ts
+++ b/apps/api/src/modules/lct/lct-export.service.ts
@@ -24,6 +24,7 @@ import {
   formatLctDob,
   formatLctGender,
   formatLctPhone,
+  LCT_PENDING_REASONS,
   LCT_TEMPLATE_KEY,
   LctMemberSyncIntent,
   normalizeEmailList,
@@ -31,6 +32,12 @@ import {
   sortLctPendingDependants,
   toTitleCase,
 } from './lct.types';
+import {
+  formatLctIdNumber,
+  getMissingRequiredFields,
+  isLctDependantExportEligible,
+  relationshipToEntityKind,
+} from '../missing-requirements/completeness.util';
 
 const ADMIN_ROLE = 'registration_admin';
 
@@ -57,13 +64,14 @@ export class LctExportService {
     memberNumber?: string;
     phone?: string;
     product?: string;
+    scheme?: string;
   }) {
     const targets = await this.prisma.lctMemberSyncTarget.findMany({
       where: {
         pendingAction: { not: null },
         openBatchId: null,
-        errorCode: null,
         customer: { isTestUser: false },
+        OR: [{ errorCode: null }, { errorCode: 'MISSING_SPOUSE_ID' }],
       },
       include: {
         policy: {
@@ -119,6 +127,7 @@ export class LctExportService {
     const memberQ = filters.memberNumber?.trim().toLowerCase();
     const phoneQ = filters.phone?.trim();
     const productQ = filters.product?.trim().toLowerCase();
+    const schemeQ = filters.scheme?.trim().toLowerCase();
 
     const enriched = targets
       .map((t) => {
@@ -129,7 +138,8 @@ export class LctExportService {
           : customer
             ? [customer.firstName, customer.middleName, customer.lastName].filter(Boolean).join(' ')
             : '';
-        const idNumber = dependant?.idNumber ?? customer?.idNumber ?? '';
+        const rawId = dependant?.idNumber ?? customer?.idNumber ?? '';
+        const idNumber = formatLctIdNumber(rawId);
         const principalPhone = formatLctPhone(customer?.phoneNumber);
         const relationship =
           t.subjectType === LctSubjectType.PRINCIPAL
@@ -146,6 +156,19 @@ export class LctExportService {
           phone = principalPhone;
         }
 
+        let exportEligible = true;
+        let missingFields: string[] = [];
+        if (t.subjectType === LctSubjectType.DEPENDANT && dependant) {
+          const kind = relationshipToEntityKind(dependant.relationship);
+          missingFields = kind ? getMissingRequiredFields(kind, dependant) : [];
+          exportEligible = isLctDependantExportEligible(dependant.relationship, dependant);
+        }
+
+        const pendingReasons = [...(t.pendingReasons ?? [])];
+        if (!exportEligible && !pendingReasons.includes(LCT_PENDING_REASONS.MISSING_INFO)) {
+          pendingReasons.push(LCT_PENDING_REASONS.MISSING_INFO);
+        }
+
         return {
           id: t.id,
           policyId: t.policyId,
@@ -154,7 +177,7 @@ export class LctExportService {
           customerId: t.customerId,
           dependantId: t.dependantId,
           pendingAction: t.pendingAction,
-          pendingReasons: t.pendingReasons,
+          pendingReasons,
           pendingSince: t.pendingSince,
           productName: t.policy.productName,
           schemeName: schemeNameByPolicyId.get(t.policyId) ?? '',
@@ -163,6 +186,8 @@ export class LctExportService {
           idNumber,
           phone,
           relationship,
+          exportEligible,
+          missingFields,
         };
       })
       .filter((row) => {
@@ -170,13 +195,8 @@ export class LctExportService {
         if (idQ && !row.idNumber.toLowerCase().includes(idQ)) return false;
         if (memberQ && !row.memberNumber.toLowerCase().includes(memberQ)) return false;
         if (phoneQ && !row.phone.includes(phoneQ)) return false;
-        if (
-          productQ &&
-          !row.productName.toLowerCase().includes(productQ) &&
-          !row.schemeName.toLowerCase().includes(productQ)
-        ) {
-          return false;
-        }
+        if (productQ && !row.productName.toLowerCase().includes(productQ)) return false;
+        if (schemeQ && !row.schemeName.toLowerCase().includes(schemeQ)) return false;
         return true;
       });
 
@@ -222,7 +242,7 @@ export class LctExportService {
   async getErrors() {
     return this.prisma.lctMemberSyncTarget.findMany({
       where: {
-        errorCode: { not: null },
+        AND: [{ errorCode: { not: null } }, { NOT: { errorCode: 'MISSING_SPOUSE_ID' } }],
         customer: { isTestUser: false },
       },
       include: {
@@ -283,7 +303,7 @@ export class LctExportService {
         id: { in: syncTargetIds },
         pendingAction: { not: null },
         openBatchId: null,
-        errorCode: null,
+        OR: [{ errorCode: null }, { errorCode: 'MISSING_SPOUSE_ID' }],
       },
     });
 
@@ -295,6 +315,12 @@ export class LctExportService {
     }
 
     const intentsWithTargets = sortLctExportIntents(await this.buildIntents(targets));
+    const incomplete = intentsWithTargets.filter((x) => x.incomplete);
+    if (incomplete.length > 0) {
+      throw ValidationException.withMultipleErrors({
+        syncTargetIds: `${incomplete.length} selected member(s) have missing required information and cannot be exported`,
+      });
+    }
     const intents = intentsWithTargets.map((x) => x.intent);
     const { csv, rows, rowCount } = buildLctCsv(intents);
     const batchId = randomUUID();
@@ -560,8 +586,8 @@ export class LctExportService {
       pendingAction: LctPendingAction | null;
       pendingReasons: string[];
     }>
-  ): Promise<Array<{ targetId: string; intent: LctMemberSyncIntent }>> {
-    const intents: Array<{ targetId: string; intent: LctMemberSyncIntent }> = [];
+  ): Promise<Array<{ targetId: string; intent: LctMemberSyncIntent; incomplete: boolean }>> {
+    const intents: Array<{ targetId: string; intent: LctMemberSyncIntent; incomplete: boolean }> = [];
 
     const policyIds = [...new Set(targets.map((t) => t.policyId))];
     const policies = await this.prisma.policy.findMany({
@@ -612,6 +638,7 @@ export class LctExportService {
       if (target.subjectType === LctSubjectType.PRINCIPAL) {
         intents.push({
           targetId: target.id,
+          incomplete: false,
           intent: {
             memberNumber: target.memberNumber,
             action: target.pendingAction,
@@ -628,7 +655,7 @@ export class LctExportService {
             relationship: 'PRINCIPAL',
             email: customer.email ?? '',
             phoneNumber: principalPhone,
-            idNumber: customer.idNumber ?? '',
+            idNumber: formatLctIdNumber(customer.idNumber),
             principalMemberNumber: principalMemberNumber || target.memberNumber,
             schemeName,
             policyStartDate,
@@ -657,8 +684,11 @@ export class LctExportService {
           ? formatLctPhone(dependant.phoneNumber) || principalPhone
           : principalPhone;
 
+      const incomplete = !isLctDependantExportEligible(dependant.relationship, dependant);
+
       intents.push({
         targetId: target.id,
+        incomplete,
         intent: {
           memberNumber: target.memberNumber,
           action: target.pendingAction,
@@ -677,7 +707,7 @@ export class LctExportService {
           relationship,
           email: dependant.email ?? '',
           phoneNumber,
-          idNumber: dependant.idNumber ?? '',
+          idNumber: formatLctIdNumber(dependant.idNumber),
           principalMemberNumber,
           schemeName,
           policyStartDate,

--- a/apps/api/src/modules/lct/lct-sync.service.ts
+++ b/apps/api/src/modules/lct/lct-sync.service.ts
@@ -1,7 +1,6 @@
 import { createHash } from 'crypto';
 import { forwardRef, Inject, Injectable, Logger } from '@nestjs/common';
 import {
-  DependantRelationship,
   LctPendingAction,
   LctSubjectType,
   PolicyStatus,
@@ -584,21 +583,8 @@ export class LctSyncService {
       }
     }
 
-    if (target.subjectType === LctSubjectType.DEPENDANT && target.dependantId) {
-      const dep = await client.dependant.findUnique({
-        where: { id: target.dependantId },
-        select: { relationship: true, idNumber: true, deletedAt: true },
-      });
-      if (
-        dep &&
-        !dep.deletedAt &&
-        dep.relationship === DependantRelationship.SPOUSE &&
-        !(dep.idNumber ?? '').trim() &&
-        target.pendingAction
-      ) {
-        errorCode = LCT_ERROR_CODES.MISSING_SPOUSE_ID;
-      }
-    }
+    // Incomplete spouse/child data is Pending (disabled + MISSING_INFO), not Errors.
+    // Legacy MISSING_SPOUSE_ID is cleared when errorCode stays null here.
 
     if (target.errorCode !== errorCode) {
       await client.lctMemberSyncTarget.update({

--- a/apps/api/src/modules/lct/lct.types.ts
+++ b/apps/api/src/modules/lct/lct.types.ts
@@ -39,6 +39,8 @@ export const LCT_PENDING_REASONS = {
   PROFILE_CHANGE: 'PROFILE_CHANGE',
   DEPENDANT_REMOVED: 'DEPENDANT_REMOVED',
   POLICY_REPLACED: 'POLICY_REPLACED',
+  /** UI-only reason when spouse/child required fields are incomplete */
+  MISSING_INFO: 'MISSING_INFO',
 } as const;
 
 export const LCT_ERROR_CODES = {

--- a/apps/api/src/modules/missing-requirements/__tests__/completeness.util.spec.ts
+++ b/apps/api/src/modules/missing-requirements/__tests__/completeness.util.spec.ts
@@ -1,0 +1,96 @@
+import { DependantRelationship, RegistrationEntityKind } from '@prisma/client';
+import {
+  formatLctIdNumber,
+  getMissingRequiredFields,
+  isEntityComplete,
+  isLctDependantExportEligible,
+  relationshipToEntityKind,
+} from '../completeness.util';
+
+describe('completeness.util', () => {
+  const completeSpouse = {
+    firstName: 'Jane',
+    lastName: 'Doe',
+    idNumber: '12345678',
+    gender: 'FEMALE',
+    dateOfBirth: new Date(Date.UTC(1990, 0, 15)),
+  };
+
+  const completeChild = {
+    firstName: 'Sam',
+    lastName: 'Doe',
+    gender: 'MALE',
+    dateOfBirth: new Date(Date.UTC(2015, 5, 1)),
+  };
+
+  it('maps spouse/child relationships to entity kinds', () => {
+    expect(relationshipToEntityKind(DependantRelationship.SPOUSE)).toBe(
+      RegistrationEntityKind.SPOUSE
+    );
+    expect(relationshipToEntityKind(DependantRelationship.CHILD)).toBe(
+      RegistrationEntityKind.CHILD
+    );
+    expect(relationshipToEntityKind('OTHER')).toBeNull();
+  });
+
+  it('requires spouse first/last, id, gender, DOB', () => {
+    expect(getMissingRequiredFields(RegistrationEntityKind.SPOUSE, {})).toEqual([
+      'firstName',
+      'lastName',
+      'idNumber',
+      'gender',
+      'dateOfBirth',
+    ]);
+    expect(isEntityComplete(RegistrationEntityKind.SPOUSE, completeSpouse)).toBe(true);
+    expect(
+      getMissingRequiredFields(RegistrationEntityKind.SPOUSE, {
+        ...completeSpouse,
+        idNumber: '  ',
+        dateOfBirth: null,
+      })
+    ).toEqual(['idNumber', 'dateOfBirth']);
+  });
+
+  it('requires child first/last, DOB, gender (not ID)', () => {
+    expect(getMissingRequiredFields(RegistrationEntityKind.CHILD, {})).toEqual([
+      'firstName',
+      'lastName',
+      'dateOfBirth',
+      'gender',
+    ]);
+    expect(isEntityComplete(RegistrationEntityKind.CHILD, completeChild)).toBe(true);
+    expect(
+      isEntityComplete(RegistrationEntityKind.CHILD, {
+        ...completeChild,
+        idNumber: null,
+      })
+    ).toBe(true);
+  });
+
+  it('keeps beneficiary id fields for care-ops', () => {
+    expect(getMissingRequiredFields(RegistrationEntityKind.BENEFICIARY, {})).toEqual([
+      'firstName',
+      'lastName',
+      'idType',
+      'idNumber',
+    ]);
+  });
+
+  it('marks LCT export eligibility for spouse/child only when complete', () => {
+    expect(isLctDependantExportEligible('SPOUSE', completeSpouse)).toBe(true);
+    expect(
+      isLctDependantExportEligible('SPOUSE', { ...completeSpouse, gender: null })
+    ).toBe(false);
+    expect(isLctDependantExportEligible('CHILD', completeChild)).toBe(true);
+    expect(
+      isLctDependantExportEligible('CHILD', { ...completeChild, firstName: '' })
+    ).toBe(false);
+  });
+
+  it('formats blank IDs as N/A', () => {
+    expect(formatLctIdNumber('12345678')).toBe('12345678');
+    expect(formatLctIdNumber('')).toBe('N/A');
+    expect(formatLctIdNumber(null)).toBe('N/A');
+    expect(formatLctIdNumber('   ')).toBe('N/A');
+  });
+});

--- a/apps/api/src/modules/missing-requirements/completeness.util.ts
+++ b/apps/api/src/modules/missing-requirements/completeness.util.ts
@@ -1,0 +1,123 @@
+import { DependantRelationship, RegistrationEntityKind } from '@prisma/client';
+
+/** Field values used to evaluate deferred / LCT completeness. */
+export type CompletenessPerson = {
+  firstName?: string | null;
+  middleName?: string | null;
+  lastName?: string | null;
+  gender?: string | null;
+  idType?: string | null;
+  idNumber?: string | null;
+  dateOfBirth?: Date | string | null;
+};
+
+/** Aligned deferred + LCT rules (beneficiaries kept for care-ops only). */
+export const DEFERRED_REQUIRED_FIELDS: Record<RegistrationEntityKind, string[]> = {
+  [RegistrationEntityKind.CUSTOMER]: [],
+  [RegistrationEntityKind.SPOUSE]: [
+    'firstName',
+    'lastName',
+    'idNumber',
+    'gender',
+    'dateOfBirth',
+  ],
+  [RegistrationEntityKind.CHILD]: ['firstName', 'lastName', 'dateOfBirth', 'gender'],
+  [RegistrationEntityKind.BENEFICIARY]: ['firstName', 'lastName', 'idType', 'idNumber'],
+};
+
+export function relationshipToEntityKind(
+  relationship: DependantRelationship | string
+): RegistrationEntityKind | null {
+  if (relationship === DependantRelationship.SPOUSE || relationship === 'SPOUSE') {
+    return RegistrationEntityKind.SPOUSE;
+  }
+  if (relationship === DependantRelationship.CHILD || relationship === 'CHILD') {
+    return RegistrationEntityKind.CHILD;
+  }
+  return null;
+}
+
+function isBlank(value: unknown): boolean {
+  if (value === null || value === undefined) return true;
+  if (value instanceof Date) return Number.isNaN(value.getTime());
+  if (typeof value === 'string') return value.trim().length === 0;
+  return false;
+}
+
+export function isFieldPresent(person: CompletenessPerson, fieldPath: string): boolean {
+  switch (fieldPath) {
+    case 'firstName':
+      return !isBlank(person.firstName);
+    case 'lastName':
+      return !isBlank(person.lastName);
+    case 'middleName':
+      return !isBlank(person.middleName);
+    case 'gender':
+      return !isBlank(person.gender);
+    case 'idType':
+      return !isBlank(person.idType);
+    case 'idNumber':
+      return !isBlank(person.idNumber);
+    case 'dateOfBirth':
+      return !isBlank(person.dateOfBirth);
+    default:
+      return !isBlank((person as Record<string, unknown>)[fieldPath]);
+  }
+}
+
+/** Missing required field paths for an entity kind (empty = complete). */
+export function getMissingRequiredFields(
+  entityKind: RegistrationEntityKind,
+  person: CompletenessPerson | null | undefined
+): string[] {
+  const required = DEFERRED_REQUIRED_FIELDS[entityKind] ?? [];
+  if (!person) return [...required];
+  return required.filter((field) => !isFieldPresent(person, field));
+}
+
+export function isEntityComplete(
+  entityKind: RegistrationEntityKind,
+  person: CompletenessPerson | null | undefined
+): boolean {
+  return getMissingRequiredFields(entityKind, person).length === 0;
+}
+
+/**
+ * Whether a dependant row is eligible for LCT CSV export.
+ * Beneficiaries are never LCT-exportable.
+ */
+export function isLctDependantExportEligible(
+  relationship: DependantRelationship | string,
+  person: CompletenessPerson | null | undefined
+): boolean {
+  const kind = relationshipToEntityKind(relationship);
+  if (!kind) return false;
+  return isEntityComplete(kind, person);
+}
+
+/** Blank ID numbers become N/A for LCT CSV / display. */
+export function formatLctIdNumber(raw: string | null | undefined): string {
+  const trimmed = (raw ?? '').trim();
+  return trimmed.length > 0 ? trimmed : 'N/A';
+}
+
+export function humanizeFieldPath(fieldPath: string): string {
+  switch (fieldPath) {
+    case 'firstName':
+      return 'First name';
+    case 'lastName':
+      return 'Last name';
+    case 'middleName':
+      return 'Middle name';
+    case 'dateOfBirth':
+      return 'Date of birth';
+    case 'idNumber':
+      return 'ID number';
+    case 'idType':
+      return 'ID type';
+    case 'gender':
+      return 'Gender';
+    default:
+      return fieldPath;
+  }
+}

--- a/apps/api/src/services/agent-registration.service.ts
+++ b/apps/api/src/services/agent-registration.service.ts
@@ -3,10 +3,14 @@ import { PrismaService } from '../prisma/prisma.service';
 import { CreateAgentRegistrationDto, UpdateAgentRegistrationDto, AgentRegistrationResponseDto } from '../dto/agent-registration';
 import { RegistrationStatus, RegistrationMissingStatus, Prisma } from '@prisma/client';
 import * as Sentry from '@sentry/nestjs';
+import { MissingRequirementService } from './missing-requirement.service';
 
 @Injectable()
 export class AgentRegistrationService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly missingRequirementService: MissingRequirementService
+  ) {}
 
   /**
    * Create a new agent registration
@@ -96,8 +100,12 @@ export class AgentRegistrationService {
         },
       });
 
-      // Create missing requirements based on deferred requirements
-      await this.createMissingRequirements(registration.id, dto.customerId, partnerId);
+      // Seed missing requirements from live dependant/beneficiary fields
+      await this.missingRequirementService.seedFromRegistration(
+        registration.id,
+        dto.customerId,
+        partnerId
+      );
 
       return this.mapToResponseDto(registration);
     } catch (error) {
@@ -306,69 +314,6 @@ export class AgentRegistrationService {
           operation: 'getRegistrationsByBA',
           userId,
           baId,
-        },
-      });
-      throw error;
-    }
-  }
-
-  /**
-   * Create missing requirements for a registration
-   */
-  private async createMissingRequirements(
-    registrationId: string,
-    customerId: string,
-    partnerId: number
-  ): Promise<void> {
-    try {
-      // Get deferred requirements for the partner (or default if none exist)
-      const partnerRequirements = await this.prisma.deferredRequirementPartner.findMany({
-        where: { partnerId },
-      });
-
-      let requirements = partnerRequirements;
-
-      // If no partner-specific requirements, use defaults
-      if (requirements.length === 0) {
-        const defaultRequirements = await this.prisma.deferredRequirementDefault.findMany();
-        // Map default requirements to include partnerId
-        requirements = defaultRequirements.map(req => ({
-          ...req,
-          partnerId,
-        }));
-      }
-
-      // Create missing requirements for required fields
-      const missingRequirements = requirements
-        .filter(req => req.isRequired)
-        .map(req => ({
-          registrationId,
-          customerId,
-          partnerId,
-          entityKind: req.entityKind,
-          entityId: null, // Will be set when specific entities are created
-          fieldPath: req.fieldPath,
-          status: RegistrationMissingStatus.PENDING,
-        }));
-
-      if (missingRequirements.length > 0) {
-        await this.prisma.missingRequirement.createMany({
-          data: missingRequirements,
-        });
-      }
-
-      // Update customer's hasMissingRequirements flag
-      await this.prisma.customer.update({
-        where: { id: customerId },
-        data: { hasMissingRequirements: missingRequirements.length > 0 },
-      });
-    } catch (error) {
-      Sentry.captureException(error, {
-        tags: {
-          operation: 'createMissingRequirements',
-          registrationId,
-          customerId,
-          partnerId,
         },
       });
       throw error;

--- a/apps/api/src/services/customer.service.ts
+++ b/apps/api/src/services/customer.service.ts
@@ -71,6 +71,7 @@ import { ConfigurationService } from '../config/configuration.service';
 import { PolicyService } from './policy.service';
 import { UpdateCustomerDto } from '../dto/customers/update-customer.dto';
 import { LctSyncService } from '../modules/lct/lct-sync.service';
+import { MissingRequirementService } from './missing-requirement.service';
 import { UpdateDependantDto } from '../dto/dependants/update-dependant.dto';
 import { UpdateBeneficiaryDto } from '../dto/beneficiaries/update-beneficiary.dto';
 import {
@@ -132,6 +133,7 @@ export class CustomerService {
     private readonly policyService: PolicyService,
     @Inject(forwardRef(() => LctSyncService))
     private readonly lctSyncService: LctSyncService,
+    private readonly missingRequirementService: MissingRequirementService,
   ) {}
 
   /**
@@ -3568,6 +3570,11 @@ export class CustomerService {
         correlationId,
       });
 
+      await this.missingRequirementService.syncCustomerFromLiveData(
+        dependant.customerId,
+        userId
+      );
+
       return {
         id: updated.id,
         firstName: updated.firstName,
@@ -3578,6 +3585,7 @@ export class CustomerService {
         idType: updated.idType ?? undefined,
         idNumber: updated.idNumber ?? undefined,
         relationship: updated.relationship,
+        gender: updated.gender ?? undefined,
       };
     } catch (error) {
       this.logger.error(`[${correlationId}] Error updating dependant: ${error instanceof Error ? error.message : 'Unknown error'}`, error instanceof Error ? error.stack : undefined);
@@ -3654,6 +3662,8 @@ export class CustomerService {
         where: { id: beneficiaryId },
         data: updatePayload,
       });
+
+      await this.missingRequirementService.syncCustomerFromLiveData(customerId, userId);
 
       return {
         id: updated.id,

--- a/apps/api/src/services/missing-requirement.service.ts
+++ b/apps/api/src/services/missing-requirement.service.ts
@@ -1,32 +1,56 @@
-import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
+import { Injectable, NotFoundException, BadRequestException, Logger } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
-import { CreateMissingRequirementDto, UpdateMissingRequirementDto, MissingRequirementResponseDto } from '../dto/missing-requirement';
-import { RegistrationMissingStatus, RegistrationEntityKind, Prisma } from '@prisma/client';
+import {
+  CreateMissingRequirementDto,
+  UpdateMissingRequirementDto,
+  MissingRequirementResponseDto,
+} from '../dto/missing-requirement';
+import {
+  CareOpsQueueEntityDto,
+  CareOpsQueueResponseDto,
+} from '../dto/missing-requirement/care-ops-queue.dto';
+import {
+  RegistrationMissingStatus,
+  RegistrationEntityKind,
+  DependantRelationship,
+  Prisma,
+} from '@prisma/client';
 import * as Sentry from '@sentry/nestjs';
+import {
+  CompletenessPerson,
+  getMissingRequiredFields,
+  humanizeFieldPath,
+  relationshipToEntityKind,
+} from '../modules/missing-requirements/completeness.util';
+
+/** Legacy deferred fields no longer required — resolve on sync. */
+const RETIRED_FIELD_PATHS: Array<{ entityKind: RegistrationEntityKind; fieldPath: string }> = [
+  { entityKind: RegistrationEntityKind.SPOUSE, fieldPath: 'idType' },
+  { entityKind: RegistrationEntityKind.CHILD, fieldPath: 'idType' },
+  { entityKind: RegistrationEntityKind.CHILD, fieldPath: 'idNumber' },
+];
 
 @Injectable()
 export class MissingRequirementService {
+  private readonly logger = new Logger(MissingRequirementService.name);
+
   constructor(private readonly prisma: PrismaService) {}
 
-  /**
-   * Create a missing requirement
-   */
-  async createMissingRequirement(dto: CreateMissingRequirementDto, userId: string): Promise<MissingRequirementResponseDto> {
+  async createMissingRequirement(
+    dto: CreateMissingRequirementDto,
+    userId: string
+  ): Promise<MissingRequirementResponseDto> {
     try {
-      // Validate that registration exists
       const registration = await this.prisma.agentRegistration.findUnique({
         where: { id: dto.registrationId },
       });
-
       if (!registration) {
         throw new BadRequestException('Registration not found');
       }
 
-      // Validate that customer exists
       const customer = await this.prisma.customer.findUnique({
         where: { id: dto.customerId },
       });
-
       if (!customer) {
         throw new BadRequestException('Customer not found');
       }
@@ -35,7 +59,7 @@ export class MissingRequirementService {
         data: {
           registrationId: dto.registrationId,
           customerId: dto.customerId,
-          partnerId: parseInt(dto.partnerId),
+          partnerId: parseInt(dto.partnerId, 10),
           entityKind: dto.entityKind,
           entityId: dto.entityId,
           fieldPath: dto.fieldPath,
@@ -43,50 +67,34 @@ export class MissingRequirementService {
         },
       });
 
+      await this.checkAndUpdateCustomerMissingRequirements(missingRequirement.customerId);
       return this.mapToResponseDto(missingRequirement);
     } catch (error) {
       Sentry.captureException(error, {
-        tags: {
-          operation: 'createMissingRequirement',
-          userId,
-        },
-        extra: {
-          dto,
-        },
+        tags: { operation: 'createMissingRequirement', userId },
+        extra: { dto },
       });
       throw error;
     }
   }
 
-  /**
-   * Get missing requirement by ID
-   */
   async getMissingRequirementById(id: string, userId: string): Promise<MissingRequirementResponseDto> {
     try {
       const missingRequirement = await this.prisma.missingRequirement.findUnique({
         where: { id },
       });
-
       if (!missingRequirement) {
         throw new NotFoundException('Missing requirement not found');
       }
-
       return this.mapToResponseDto(missingRequirement);
     } catch (error) {
       Sentry.captureException(error, {
-        tags: {
-          operation: 'getMissingRequirementById',
-          userId,
-          missingRequirementId: id,
-        },
+        tags: { operation: 'getMissingRequirementById', userId, missingRequirementId: id },
       });
       throw error;
     }
   }
 
-  /**
-   * Update missing requirement
-   */
   async updateMissingRequirement(
     id: string,
     dto: UpdateMissingRequirementDto,
@@ -96,23 +104,15 @@ export class MissingRequirementService {
       const existingRequirement = await this.prisma.missingRequirement.findUnique({
         where: { id },
       });
-
       if (!existingRequirement) {
         throw new NotFoundException('Missing requirement not found');
       }
 
       const updateData: Prisma.MissingRequirementUpdateInput = {};
-      if (dto.status) {
-        updateData.status = dto.status;
-      }
-      if (dto.resolvedAt) {
-        updateData.resolvedAt = new Date(dto.resolvedAt);
-      }
-      if (dto.resolvedBy) {
-        updateData.resolvedBy = dto.resolvedBy;
-      }
+      if (dto.status) updateData.status = dto.status;
+      if (dto.resolvedAt) updateData.resolvedAt = new Date(dto.resolvedAt);
+      if (dto.resolvedBy) updateData.resolvedBy = dto.resolvedBy;
 
-      // If resolving, set resolved timestamp and user
       if (dto.status === RegistrationMissingStatus.RESOLVED) {
         updateData.resolvedAt = new Date();
         updateData.resolvedBy = userId;
@@ -123,28 +123,17 @@ export class MissingRequirementService {
         data: updateData,
       });
 
-      // Check if all missing requirements for this customer are resolved
       await this.checkAndUpdateCustomerMissingRequirements(missingRequirement.customerId);
-
       return this.mapToResponseDto(missingRequirement);
     } catch (error) {
       Sentry.captureException(error, {
-        tags: {
-          operation: 'updateMissingRequirement',
-          userId,
-          missingRequirementId: id,
-        },
-        extra: {
-          dto,
-        },
+        tags: { operation: 'updateMissingRequirement', userId, missingRequirementId: id },
+        extra: { dto },
       });
       throw error;
     }
   }
 
-  /**
-   * Get missing requirements by registration ID
-   */
   async getMissingRequirementsByRegistration(
     registrationId: string,
     userId: string,
@@ -159,30 +148,21 @@ export class MissingRequirementService {
           take: limit,
           skip: offset,
         }),
-        this.prisma.missingRequirement.count({
-          where: { registrationId },
-        }),
+        this.prisma.missingRequirement.count({ where: { registrationId } }),
       ]);
 
       return {
-        missingRequirements: missingRequirements.map(mr => this.mapToResponseDto(mr)),
+        missingRequirements: missingRequirements.map((mr) => this.mapToResponseDto(mr)),
         total,
       };
     } catch (error) {
       Sentry.captureException(error, {
-        tags: {
-          operation: 'getMissingRequirementsByRegistration',
-          userId,
-          registrationId,
-        },
+        tags: { operation: 'getMissingRequirementsByRegistration', userId, registrationId },
       });
       throw error;
     }
   }
 
-  /**
-   * Get missing requirements by customer ID
-   */
   async getMissingRequirementsByCustomer(
     customerId: string,
     userId: string,
@@ -197,30 +177,21 @@ export class MissingRequirementService {
           take: limit,
           skip: offset,
         }),
-        this.prisma.missingRequirement.count({
-          where: { customerId },
-        }),
+        this.prisma.missingRequirement.count({ where: { customerId } }),
       ]);
 
       return {
-        missingRequirements: missingRequirements.map(mr => this.mapToResponseDto(mr)),
+        missingRequirements: missingRequirements.map((mr) => this.mapToResponseDto(mr)),
         total,
       };
     } catch (error) {
       Sentry.captureException(error, {
-        tags: {
-          operation: 'getMissingRequirementsByCustomer',
-          userId,
-          customerId,
-        },
+        tags: { operation: 'getMissingRequirementsByCustomer', userId, customerId },
       });
       throw error;
     }
   }
 
-  /**
-   * Get pending missing requirements for admin resolution
-   */
   async getPendingMissingRequirements(
     userId: string,
     partnerId?: number,
@@ -231,88 +202,337 @@ export class MissingRequirementService {
       const whereClause: Prisma.MissingRequirementWhereInput = {
         status: RegistrationMissingStatus.PENDING,
       };
-
-      if (partnerId) {
-        whereClause.partnerId = partnerId;
-      }
+      if (partnerId) whereClause.partnerId = partnerId;
 
       const [missingRequirements, total] = await Promise.all([
         this.prisma.missingRequirement.findMany({
           where: whereClause,
-          include: {
-            registration: {
-              include: {
-                ba: {
-                  select: {
-                    id: true,
-                    displayName: true,
-                  },
-                },
-                customer: {
-                  select: {
-                    id: true,
-                    firstName: true,
-                    lastName: true,
-                  },
-                },
-              },
-            },
-          },
           orderBy: { createdAt: 'asc' },
           take: limit,
           skip: offset,
         }),
-        this.prisma.missingRequirement.count({
-          where: whereClause,
-        }),
+        this.prisma.missingRequirement.count({ where: whereClause }),
       ]);
 
       return {
-        missingRequirements: missingRequirements.map(mr => this.mapToResponseDto(mr)),
+        missingRequirements: missingRequirements.map((mr) => this.mapToResponseDto(mr)),
         total,
       };
     } catch (error) {
       Sentry.captureException(error, {
-        tags: {
-          operation: 'getPendingMissingRequirements',
-          userId,
-          partnerId,
-        },
+        tags: { operation: 'getPendingMissingRequirements', userId, partnerId },
       });
       throw error;
     }
   }
 
   /**
-   * Check and update customer's hasMissingRequirements flag
+   * Care-ops queue: re-sync live fields for page of customers, then return
+   * grouped incomplete spouse/child/beneficiary entities.
    */
-  private async checkAndUpdateCustomerMissingRequirements(customerId: string): Promise<void> {
-    try {
-      const pendingCount = await this.prisma.missingRequirement.count({
+  async getCareOpsQueue(params: {
+    userId: string;
+    limit?: number;
+    offset?: number;
+    partnerId?: number;
+  }): Promise<CareOpsQueueResponseDto> {
+    const limit = params.limit ?? 50;
+    const offset = params.offset ?? 0;
+
+    const customerWhere: Prisma.CustomerWhereInput = {
+      isTestUser: false,
+      missingRequirements: {
+        some: {
+          status: RegistrationMissingStatus.PENDING,
+          ...(params.partnerId ? { partnerId: params.partnerId } : {}),
+        },
+      },
+    };
+
+    const [customerIdsPage, total] = await Promise.all([
+      this.prisma.customer.findMany({
+        where: customerWhere,
+        select: { id: true },
+        orderBy: { updatedAt: 'desc' },
+        take: limit,
+        skip: offset,
+      }),
+      this.prisma.customer.count({ where: customerWhere }),
+    ]);
+
+    for (const { id } of customerIdsPage) {
+      await this.syncCustomerFromLiveData(id, params.userId);
+    }
+
+    const items: CareOpsQueueEntityDto[] = [];
+    for (const { id: customerId } of customerIdsPage) {
+      items.push(...(await this.buildQueueItemsForCustomer(customerId)));
+    }
+
+    return { items, total };
+  }
+
+  /**
+   * Reconcile PENDING MRs with live dependant/beneficiary fields for a customer.
+   * Creates MRs only for fields that are actually blank; resolves filled ones.
+   */
+  async syncCustomerFromLiveData(
+    customerId: string,
+    resolvedBy: string = 'system',
+    opts?: { registrationId?: string; partnerId?: number }
+  ): Promise<{ pendingCount: number }> {
+    const registration =
+      opts?.registrationId
+        ? await this.prisma.agentRegistration.findUnique({ where: { id: opts.registrationId } })
+        : await this.prisma.agentRegistration.findFirst({
+            where: { customerId },
+            orderBy: { createdAt: 'desc' },
+          });
+
+    if (!registration && !opts?.registrationId) {
+      // No registration — still clear flag if no pending MRs can be owned
+      await this.checkAndUpdateCustomerMissingRequirements(customerId);
+      return { pendingCount: 0 };
+    }
+
+    const registrationId = registration!.id;
+    const partnerId = opts?.partnerId ?? registration!.partnerId;
+
+    const [dependants, beneficiaries, existingPending] = await Promise.all([
+      this.prisma.dependant.findMany({
         where: {
           customerId,
-          status: RegistrationMissingStatus.PENDING,
+          deletedAt: null,
+          relationship: { in: [DependantRelationship.SPOUSE, DependantRelationship.CHILD] },
         },
-      });
+      }),
+      this.prisma.beneficiary.findMany({
+        where: { customerId, deletedAt: null },
+      }),
+      this.prisma.missingRequirement.findMany({
+        where: { customerId, status: RegistrationMissingStatus.PENDING },
+      }),
+    ]);
 
-      await this.prisma.customer.update({
-        where: { id: customerId },
-        data: { hasMissingRequirements: pendingCount > 0 },
-      });
-    } catch (error) {
-      Sentry.captureException(error, {
-        tags: {
-          operation: 'checkAndUpdateCustomerMissingRequirements',
-          customerId,
-        },
-      });
-      throw error;
+    const desired = new Map<string, { entityKind: RegistrationEntityKind; entityId: string; fieldPath: string }>();
+
+    for (const dep of dependants) {
+      const kind = relationshipToEntityKind(dep.relationship);
+      if (!kind) continue;
+      const missing = getMissingRequiredFields(kind, dep);
+      for (const fieldPath of missing) {
+        desired.set(`${kind}:${dep.id}:${fieldPath}`, {
+          entityKind: kind,
+          entityId: dep.id,
+          fieldPath,
+        });
+      }
     }
+
+    for (const ben of beneficiaries) {
+      const missing = getMissingRequiredFields(RegistrationEntityKind.BENEFICIARY, ben);
+      for (const fieldPath of missing) {
+        desired.set(`${RegistrationEntityKind.BENEFICIARY}:${ben.id}:${fieldPath}`, {
+          entityKind: RegistrationEntityKind.BENEFICIARY,
+          entityId: ben.id,
+          fieldPath,
+        });
+      }
+    }
+
+    // Resolve retired field paths and anything no longer missing
+    for (const mr of existingPending) {
+      const isRetired = RETIRED_FIELD_PATHS.some(
+        (r) => r.entityKind === mr.entityKind && r.fieldPath === mr.fieldPath
+      );
+      const key = mr.entityId
+        ? `${mr.entityKind}:${mr.entityId}:${mr.fieldPath}`
+        : null;
+      const stillNeeded = key ? desired.has(key) : false;
+
+      // Legacy rows without entityId: resolve if any live entity of that kind has the field
+      let legacyStillNeeded = false;
+      if (!mr.entityId && !isRetired) {
+        legacyStillNeeded = Array.from(desired.values()).some(
+          (d) => d.entityKind === mr.entityKind && d.fieldPath === mr.fieldPath
+        );
+      }
+
+      if (isRetired || (mr.entityId && !stillNeeded) || (!mr.entityId && !legacyStillNeeded)) {
+        await this.prisma.missingRequirement.update({
+          where: { id: mr.id },
+          data: {
+            status: RegistrationMissingStatus.RESOLVED,
+            resolvedAt: new Date(),
+            resolvedBy,
+          },
+        });
+      } else if (!mr.entityId && legacyStillNeeded) {
+        // Attach to first matching live entity and keep pending
+        const match = Array.from(desired.values()).find(
+          (d) => d.entityKind === mr.entityKind && d.fieldPath === mr.fieldPath
+        );
+        if (match) {
+          await this.prisma.missingRequirement.update({
+            where: { id: mr.id },
+            data: { entityId: match.entityId },
+          });
+        }
+      }
+    }
+
+    const pendingAfterResolve = await this.prisma.missingRequirement.findMany({
+      where: { customerId, status: RegistrationMissingStatus.PENDING },
+    });
+    const pendingKeys = new Set(
+      pendingAfterResolve
+        .filter((mr) => mr.entityId)
+        .map((mr) => `${mr.entityKind}:${mr.entityId}:${mr.fieldPath}`)
+    );
+
+    const toCreate = Array.from(desired.entries())
+      .filter(([key]) => !pendingKeys.has(key))
+      .map(([, value]) => ({
+        registrationId,
+        customerId,
+        partnerId,
+        entityKind: value.entityKind,
+        entityId: value.entityId,
+        fieldPath: value.fieldPath,
+        status: RegistrationMissingStatus.PENDING,
+      }));
+
+    if (toCreate.length > 0) {
+      await this.prisma.missingRequirement.createMany({ data: toCreate });
+    }
+
+    const pendingCount = await this.checkAndUpdateCustomerMissingRequirements(customerId);
+    return { pendingCount };
   }
 
   /**
-   * Map Prisma result to response DTO
+   * Seed MRs for a new registration from live dependant/beneficiary data only.
    */
+  async seedFromRegistration(
+    registrationId: string,
+    customerId: string,
+    partnerId: number
+  ): Promise<void> {
+    await this.syncCustomerFromLiveData(customerId, 'system', { registrationId, partnerId });
+  }
+
+  private async buildQueueItemsForCustomer(customerId: string): Promise<CareOpsQueueEntityDto[]> {
+    const customer = await this.prisma.customer.findUnique({
+      where: { id: customerId },
+      select: {
+        id: true,
+        firstName: true,
+        middleName: true,
+        lastName: true,
+        phoneNumber: true,
+      },
+    });
+    if (!customer) return [];
+
+    const registration = await this.prisma.agentRegistration.findFirst({
+      where: { customerId },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    const pending = await this.prisma.missingRequirement.findMany({
+      where: { customerId, status: RegistrationMissingStatus.PENDING },
+    });
+    if (!pending.length) return [];
+
+    const byEntity = new Map<string, typeof pending>();
+    for (const mr of pending) {
+      const key = `${mr.entityKind}:${mr.entityId ?? 'none'}`;
+      const list = byEntity.get(key) ?? [];
+      list.push(mr);
+      byEntity.set(key, list);
+    }
+
+    const customerName = [customer.firstName, customer.middleName, customer.lastName]
+      .filter(Boolean)
+      .join(' ');
+
+    const items: CareOpsQueueEntityDto[] = [];
+
+    for (const [key, mrs] of byEntity) {
+      const [entityKindStr, entityIdRaw] = key.split(':');
+      const entityKind = entityKindStr as RegistrationEntityKind;
+      const entityId = entityIdRaw === 'none' ? null : entityIdRaw;
+
+      let person: CompletenessPerson | null = null;
+      if (
+        entityId &&
+        (entityKind === RegistrationEntityKind.SPOUSE || entityKind === RegistrationEntityKind.CHILD)
+      ) {
+        person = await this.prisma.dependant.findUnique({ where: { id: entityId } });
+      } else if (entityId && entityKind === RegistrationEntityKind.BENEFICIARY) {
+        person = await this.prisma.beneficiary.findUnique({ where: { id: entityId } });
+      }
+
+      const missingFields = person
+        ? getMissingRequiredFields(entityKind, person)
+        : [...new Set(mrs.map((m) => m.fieldPath))];
+
+      if (!missingFields.length) continue;
+
+      const entityName = person
+        ? [person.firstName, person.middleName, person.lastName].filter(Boolean).join(' ') ||
+          entityKind
+        : entityKind;
+
+      items.push({
+        customerId,
+        customerName,
+        customerPhone: customer.phoneNumber,
+        registrationId: registration?.id ?? mrs[0]?.registrationId,
+        partnerId: registration?.partnerId ?? mrs[0]?.partnerId,
+        entityKind,
+        entityId,
+        entityName,
+        missingFields,
+        missingFieldLabels: missingFields.map(humanizeFieldPath),
+        firstName: person?.firstName ?? null,
+        middleName: person?.middleName ?? null,
+        lastName: person?.lastName ?? null,
+        gender: person?.gender ?? null,
+        idType: person?.idType ?? null,
+        idNumber: person?.idNumber ?? null,
+        dateOfBirth: person?.dateOfBirth
+          ? person.dateOfBirth instanceof Date
+            ? person.dateOfBirth.toISOString().slice(0, 10)
+            : String(person.dateOfBirth).slice(0, 10)
+          : null,
+      });
+    }
+
+    return items;
+  }
+
+  private async checkAndUpdateCustomerMissingRequirements(customerId: string): Promise<number> {
+    const pendingCount = await this.prisma.missingRequirement.count({
+      where: {
+        customerId,
+        status: RegistrationMissingStatus.PENDING,
+      },
+    });
+
+    await this.prisma.customer.update({
+      where: { id: customerId },
+      data: { hasMissingRequirements: pendingCount > 0 },
+    });
+
+    return pendingCount;
+  }
+
+  /** Exposed for tests / callers that only need the flag refresh. */
+  async refreshCustomerMissingFlag(customerId: string): Promise<number> {
+    return this.checkAndUpdateCustomerMissingRequirements(customerId);
+  }
+
   private mapToResponseDto(missingRequirement: unknown): MissingRequirementResponseDto {
     if (!missingRequirement || typeof missingRequirement !== 'object') {
       throw new Error('Invalid missing requirement data');

--- a/apps/api/tsconfig.scripts.json
+++ b/apps/api/tsconfig.scripts.json
@@ -10,6 +10,7 @@
     "scripts/backfill-customer-portal-announcement.ts",
     "scripts/backfill-unmapped-mpesa-payments.ts",
     "scripts/backfill-lct-never-sent.ts",
+    "scripts/backfill-missing-requirements.ts",
     "scripts/reprocess-siti-empty-msisdn-ipns.ts",
     "scripts/remediate-daily-premium-as-installment.ts"
   ],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Care-ops missing-information workflow + LCT Pending eligibility, aligned to deferred/MR completeness rules.

### LCT Pending
- Scheme and Product filters (separate; no Plan filter)
- Incomplete spouses/children remain visible but **disabled** with a **MISSING_INFO** reason icon
- Blank ID → `N/A` in CSV/UI
- Legacy `MISSING_SPOUSE_ID` errors no longer park rows on Errors

### Completeness rules
- **Spouse:** first + last, ID, gender, DOB
- **Child:** first + last, DOB, gender
- **Beneficiary:** kept for care-ops (not sent to LCT)

### Care-ops
- New `/dashboard/missing-information` queue (CSV export + inline update)
- Access: `customer_care` + `registration_admin`
- Live MR sync on dependant/beneficiary update and on queue load
- `GET /internal/agent-registrations/missing-requirements/queue`

### Data
- Seed deferred defaults aligned to rules
- Backfill: `pnpm --filter @microbima/api backfill:missing-requirements`

### Tests
- Completeness util + LCT CSV coverage for N/A / eligibility
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-40fad95d-98bf-4faa-bc26-b7f1384ed902?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40fad95d-98bf-4faa-bc26-b7f1384ed902&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

