### PR TITLE
fix(lifecycle): prepaid money-target cap, premiumCompleted, inactive at 15d

### DIFF
--- a/apps/agent-registration/src/app/(main)/admin/underwriters/packages/[packageId]/_components/package-pricing-grid.tsx
+++ b/apps/agent-registration/src/app/(main)/admin/underwriters/packages/[packageId]/_components/package-pricing-grid.tsx
@@ -30,6 +30,7 @@ import {
   type PackagePricingCategory,
   type PackagePricingData,
   createPackagePricingCategory,
+  convertPackagePricingCategoryToMemberOnly,
   getPackagePricing,
   putPackagePricing,
 } from '@/lib/api';
@@ -183,10 +184,13 @@ export default function PackagePricingGrid({
   const [addingPlan, setAddingPlan] = useState(false);
 
   const [addCategoryOpen, setAddCategoryOpen] = useState(false);
-  const [addCategoryKind, setAddCategoryKind] = useState<'UP_TO_N' | 'ADDITIONAL_SPOUSE'>('UP_TO_N');
+  const [addCategoryKind, setAddCategoryKind] = useState<
+    'MEMBER_ONLY' | 'UP_TO_N' | 'ADDITIONAL_SPOUSE'
+  >('UP_TO_N');
   const [categoryDisplay, setCategoryDisplay] = useState('');
   const [maxMembers, setMaxMembers] = useState('5');
   const [addingCategory, setAddingCategory] = useState(false);
+  const [convertingCategoryId, setConvertingCategoryId] = useState<number | null>(null);
 
   useEffect(() => {
     setLocal({
@@ -230,6 +234,7 @@ export default function PackagePricingGrid({
   );
 
   const hasSpouse = local.categories.some((c) => c.kind === 'ADDITIONAL_SPOUSE');
+  const hasMemberOnly = local.categories.some((c) => c.kind === 'MEMBER_ONLY');
   const maximumFamilySize = pricing.maximumFamilySize ?? 8;
 
   const usedUpToNSizes = useMemo(
@@ -514,9 +519,11 @@ export default function PackagePricingGrid({
 
       const display =
         categoryDisplay.trim() ||
-        (addCategoryKind === 'ADDITIONAL_SPOUSE'
-          ? 'Additional spouse'
-          : `Up to ${maxMembers}`);
+        (addCategoryKind === 'MEMBER_ONLY'
+          ? 'M'
+          : addCategoryKind === 'ADDITIONAL_SPOUSE'
+            ? 'Additional spouse'
+            : `Up to ${maxMembers}`);
 
       const body =
         addCategoryKind === 'UP_TO_N'
@@ -525,10 +532,15 @@ export default function PackagePricingGrid({
               display,
               maxMembers: parseInt(maxMembers, 10),
             }
-          : {
-              kind: 'ADDITIONAL_SPOUSE' as const,
-              display,
-            };
+          : addCategoryKind === 'MEMBER_ONLY'
+            ? {
+                kind: 'MEMBER_ONLY' as const,
+                display,
+              }
+            : {
+                kind: 'ADDITIONAL_SPOUSE' as const,
+                display,
+              };
 
       const result = await createPackagePricingCategory(packageId, body);
       setLocal((prev) => ({
@@ -543,6 +555,40 @@ export default function PackagePricingGrid({
       setError(err instanceof Error ? err.message : 'Failed to add category');
     } finally {
       setAddingCategory(false);
+    }
+  };
+
+  const handleConvertToMemberOnly = async (category: PackagePricingCategory) => {
+    if (category.id == null) {
+      setError('This category cannot be converted until it has been saved');
+      return;
+    }
+    if (dirty) {
+      setError('Save or discard unsaved pricing changes before converting a category');
+      return;
+    }
+    const maxLabel = category.maxMembers ?? 'N';
+    const confirmed = window.confirm(
+      `Convert “${category.display}” (Up to ${maxLabel}) into the required Member only band? Existing rates are kept. Households of 2 or more will then use the next Up to N band.`
+    );
+    if (!confirmed) return;
+
+    setConvertingCategoryId(category.id);
+    setError(null);
+    try {
+      const saved = await convertPackagePricingCategoryToMemberOnly(packageId, category.id);
+      setLocal({
+        categories: saved.categories,
+        plans: clonePlans(saved.plans),
+      });
+      setBaselinePlans(clonePlans(saved.plans));
+      setDirty(false);
+      onSaved(saved);
+      onWarning?.(saved.warning ?? null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to convert category');
+    } finally {
+      setConvertingCategoryId(null);
     }
   };
 
@@ -587,6 +633,16 @@ export default function PackagePricingGrid({
           <AlertDescription>{error}</AlertDescription>
         </Alert>
       )}
+      {!readOnly && !hasMemberOnly && (
+        <Alert>
+          <AlertTriangle className="h-4 w-4" />
+          <AlertDescription>
+            Member only is required to complete pricing. Convert an existing Up to
+            N band (if it was meant to be principal-only) or add a Member only
+            category.
+          </AlertDescription>
+        </Alert>
+      )}
 
       <div className="flex flex-wrap gap-2 items-center justify-between">
         <div className="flex flex-wrap gap-2">
@@ -596,6 +652,20 @@ export default function PackagePricingGrid({
                 <Plus className="h-4 w-4 mr-1" />
                 Add plan column
               </Button>
+              {!hasMemberOnly && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    setAddCategoryKind('MEMBER_ONLY');
+                    setCategoryDisplay('M');
+                    setAddCategoryOpen(true);
+                  }}
+                >
+                  <Plus className="h-4 w-4 mr-1" />
+                  Add Member only
+                </Button>
+              )}
               <Button
                 variant="outline"
                 size="sm"
@@ -656,6 +726,24 @@ export default function PackagePricingGrid({
                 {category.kind === 'ADDITIONAL_SPOUSE' && 'Additional spouse'}
               </p>
             </div>
+            {!readOnly && !hasMemberOnly && category.kind === 'UP_TO_N' && category.id != null && (
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={convertingCategoryId != null || dirty}
+                title={
+                  dirty
+                    ? 'Save pricing changes before converting this category'
+                    : undefined
+                }
+                onClick={() => handleConvertToMemberOnly(category)}
+              >
+                {convertingCategoryId === category.id && (
+                  <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+                )}
+                Convert to Member only
+              </Button>
+            )}
           </div>
 
           <div className="rounded-md border overflow-x-auto">
@@ -823,10 +911,16 @@ export default function PackagePricingGrid({
         <DialogContent>
           <DialogHeader>
             <DialogTitle>
-              {addCategoryKind === 'UP_TO_N' ? 'Add Up to N category' : 'Add spouse category'}
+              {addCategoryKind === 'MEMBER_ONLY'
+                ? 'Add Member only category'
+                : addCategoryKind === 'UP_TO_N'
+                  ? 'Add Up to N category'
+                  : 'Add spouse category'}
             </DialogTitle>
             <DialogDescription>
-              Optional pricing band for family sizes or additional spouse.
+              {addCategoryKind === 'MEMBER_ONLY'
+                ? 'Required principal-only pricing band. Every package needs exactly one.'
+                : 'Optional pricing band for family sizes or additional spouse.'}
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-4">
@@ -853,9 +947,11 @@ export default function PackagePricingGrid({
                 value={categoryDisplay}
                 onChange={(e) => setCategoryDisplay(e.target.value)}
                 placeholder={
-                  addCategoryKind === 'ADDITIONAL_SPOUSE'
-                    ? 'Additional spouse'
-                    : `Up to ${maxMembers}`
+                  addCategoryKind === 'MEMBER_ONLY'
+                    ? 'M'
+                    : addCategoryKind === 'ADDITIONAL_SPOUSE'
+                      ? 'Additional spouse'
+                      : `Up to ${maxMembers}`
                 }
               />
             </div>

--- a/apps/agent-registration/src/lib/api.ts
+++ b/apps/agent-registration/src/lib/api.ts
@@ -2351,6 +2351,16 @@ export async function createPackagePricingCategory(
   })
 }
 
+export async function convertPackagePricingCategoryToMemberOnly(
+  packageId: number,
+  categoryId: number
+): Promise<PackagePricingData> {
+  return packagePricingFetch(
+    `/packages/${packageId}/pricing/categories/${categoryId}/convert-to-member-only`,
+    { method: 'POST' }
+  )
+}
+
 // Policy Creation API
 
 export interface CreatePolicyRequest {

--- a/apps/api/prisma/migrations/20260823150000_policy_premium_completed/migration.sql
+++ b/apps/api/prisma/migrations/20260823150000_policy_premium_completed/migration.sql
@@ -1,0 +1,3 @@
+-- Flag: prepaid policy money target fully paid (skip suspend/inactive accrual pressure)
+ALTER TABLE "policies" ADD COLUMN IF NOT EXISTS "premiumCompleted" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "policies" ADD COLUMN IF NOT EXISTS "premiumCompletedAt" TIMESTAMP(3);

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -339,6 +339,9 @@ model Policy {
   expectedInstallmentCount Int?
   /// Nominal last installment date (set at activation); capped by endDate
   nominalPaymentPeriodEndDate DateTime?
+  /// True when confirmed paid >= expectedInstallmentCount × premium (prepaid money target)
+  premiumCompleted   Boolean   @default(false)
+  premiumCompletedAt DateTime?
 
   /// Denormalized; source of truth is EntityStatusChange
   deactivatedAt DateTime?
@@ -348,7 +351,7 @@ model Policy {
   graceEnteredAt       DateTime?
   /// Anchor: next unpaid expected due date that opened this overdue episode
   overdueAnchorDueDate DateTime?
-  /// When status became SUSPENDED (for >30 day → INACTIVE clock before end)
+  /// When status became SUSPENDED (for ≥15 day → INACTIVE clock before end)
   suspendedAt          DateTime?
   /// When status became INACTIVE
   inactivatedAt        DateTime?

--- a/apps/api/scripts/enqueue-postpaid-false-suspend-apology-sms.sql
+++ b/apps/api/scripts/enqueue-postpaid-false-suspend-apology-sms.sql
@@ -1,0 +1,283 @@
+-- =============================================================================
+-- Enqueue apology SMS for false postpaid suspensions (exclude Sharon)
+-- =============================================================================
+--
+-- Message (Draft B):
+--   Dear {first_name}, we apologise for the mistaken suspension message.
+--   Your benefits were available then and remain available now.
+--   For help call {general_support_number}.
+--
+-- Audience: ACTIVE live policies on schemes 2 / 8 / 9, excluding Sharon
+--   (idNumber 36783633). Expected ~30 rows.
+--
+-- How it works:
+--   1) Ensures messaging template + SMS route exist
+--   2) Inserts messaging_deliveries status=PENDING (empty renderedBody)
+--   3) Worker renders {first_name} from customer + support number from
+--      enqueuePlaceholderContext, then sends
+--
+-- HOW TO RUN:
+--   1. Run STEP 0 (template/route) once — safe to re-run
+--   2. Run STEP 1 preview — confirm 30 people, phones look right
+--   3. Uncomment STEP 2 and run once
+--   4. Run STEP 3 verification (PENDING / SENT counts)
+--
+--   psql $DATABASE_URL -f apps/api/scripts/enqueue-postpaid-false-suspend-apology-sms.sql
+-- =============================================================================
+
+-- Template key for this one-off / reusable ops message
+-- (do not reuse policy_reactivated — that thanks them for a payment)
+
+
+-- ── STEP 0: Ensure template + route ─────────────────────────────────────────
+
+INSERT INTO messaging_routes ("templateKey", "smsEnabled", "emailEnabled", "isActive", "createdAt", "updatedAt")
+VALUES ('postpaid_false_suspend_apology', true, false, true, NOW(), NOW())
+ON CONFLICT ("templateKey") DO UPDATE
+SET
+  "smsEnabled" = true,
+  "emailEnabled" = false,
+  "isActive" = true,
+  "updatedAt" = NOW();
+
+INSERT INTO messaging_templates (
+  id, "templateKey", channel, language, subject, body, "textBody",
+  placeholders, "isActive", "createdAt", "updatedAt"
+)
+VALUES (
+  gen_random_uuid(),
+  'postpaid_false_suspend_apology',
+  'SMS',
+  'en',
+  NULL,
+  'Dear {first_name}, we apologise for the mistaken suspension message. Your benefits were available then and remain available now. For help call {general_support_number}.',
+  NULL,
+  ARRAY['first_name', 'general_support_number'],
+  true,
+  NOW(),
+  NOW()
+)
+ON CONFLICT ("templateKey", channel, language) DO UPDATE
+SET
+  body = EXCLUDED.body,
+  placeholders = EXCLUDED.placeholders,
+  "isActive" = true,
+  "updatedAt" = NOW();
+
+
+-- ── STEP 1: Preview audience ────────────────────────────────────────────────
+
+WITH config AS (
+  SELECT
+    ARRAY[2, 8, 9]::int[] AS scheme_ids,
+    '36783633'::text AS exclude_id_number, -- Sharon Ng'etich
+    COALESCE(
+      (
+        SELECT NULLIF(TRIM(BOTH '"' FROM value::text), '')
+        FROM system_settings
+        WHERE key = 'general_support_number'
+      ),
+      '0746907934'
+    ) AS support_number
+),
+audience AS (
+  SELECT
+    s.id AS scheme_id,
+    s."schemeName",
+    c.id AS customer_id,
+    TRIM(c."firstName") AS first_name,
+    c."lastName",
+    c."idNumber",
+    c."phoneNumber",
+    p.id AS policy_id,
+    p."policyNumber",
+    p.status AS policy_status,
+    cfg.support_number,
+    'Dear ' || TRIM(c."firstName") ||
+      ', we apologise for the mistaken suspension message. Your benefits were available then and remain available now. For help call ' ||
+      cfg.support_number || '.' AS sample_rendered_body
+  FROM config cfg
+  INNER JOIN schemes s ON s.id = ANY (cfg.scheme_ids)
+  INNER JOIN package_schemes ps ON ps."schemeId" = s.id
+  INNER JOIN package_scheme_customers psc ON psc."packageSchemeId" = ps.id
+  INNER JOIN customers c ON c.id = psc."customerId"
+  INNER JOIN policies p ON p."customerId" = c.id
+    AND p."packageId" = ps."packageId"
+    AND p.status = 'ACTIVE'
+    AND p."supersededByPolicyId" IS NULL
+  WHERE c."idNumber" <> cfg.exclude_id_number
+)
+SELECT
+  scheme_id,
+  "schemeName",
+  first_name,
+  "lastName",
+  "idNumber",
+  "phoneNumber",
+  policy_id,
+  "policyNumber",
+  CASE
+    WHEN "phoneNumber" IS NULL OR TRIM("phoneNumber") = '' THEN 'MISSING_PHONE'
+    ELSE 'OK'
+  END AS phone_status,
+  sample_rendered_body,
+  LENGTH(sample_rendered_body) AS sms_char_count
+FROM audience
+ORDER BY scheme_id, "lastName", first_name;
+
+-- Summary
+WITH config AS (
+  SELECT
+    ARRAY[2, 8, 9]::int[] AS scheme_ids,
+    '36783633'::text AS exclude_id_number
+)
+SELECT
+  COUNT(*) AS audience_count,
+  COUNT(*) FILTER (
+    WHERE c."phoneNumber" IS NULL OR TRIM(c."phoneNumber") = ''
+  ) AS missing_phone_count
+FROM config cfg
+INNER JOIN schemes s ON s.id = ANY (cfg.scheme_ids)
+INNER JOIN package_schemes ps ON ps."schemeId" = s.id
+INNER JOIN package_scheme_customers psc ON psc."packageSchemeId" = ps.id
+INNER JOIN customers c ON c.id = psc."customerId"
+INNER JOIN policies p ON p."customerId" = c.id
+  AND p."packageId" = ps."packageId"
+  AND p.status = 'ACTIVE'
+  AND p."supersededByPolicyId" IS NULL
+WHERE c."idNumber" <> cfg.exclude_id_number;
+
+
+-- ── STEP 2: Enqueue PENDING deliveries (uncomment after preview) ────────────
+-- Idempotent for this correlationId: skips if already inserted.
+
+/*
+BEGIN;
+
+WITH config AS (
+  SELECT
+    ARRAY[2, 8, 9]::int[] AS scheme_ids,
+    '36783633'::text AS exclude_id_number,
+    'ops-postpaid-false-suspend-apology-2026-08-18'::varchar(100) AS correlation_id,
+    COALESCE(
+      (
+        SELECT NULLIF(TRIM(BOTH '"' FROM value::text), '')
+        FROM system_settings
+        WHERE key = 'general_support_number'
+      ),
+      '0746907934'
+    ) AS support_number,
+    COALESCE(
+      (
+        SELECT NULLIF(TRIM(BOTH '"' FROM value::text), '')::int
+        FROM system_settings
+        WHERE key = 'smsMaxAttempts'
+      ),
+      2
+    ) AS max_attempts
+),
+audience AS (
+  SELECT
+    c.id AS customer_id,
+    p.id AS policy_id,
+    NULLIF(TRIM(c."phoneNumber"), '') AS phone,
+    cfg.support_number,
+    cfg.correlation_id,
+    cfg.max_attempts
+  FROM config cfg
+  INNER JOIN schemes s ON s.id = ANY (cfg.scheme_ids)
+  INNER JOIN package_schemes ps ON ps."schemeId" = s.id
+  INNER JOIN package_scheme_customers psc ON psc."packageSchemeId" = ps.id
+  INNER JOIN customers c ON c.id = psc."customerId"
+  INNER JOIN policies p ON p."customerId" = c.id
+    AND p."packageId" = ps."packageId"
+    AND p.status = 'ACTIVE'
+    AND p."supersededByPolicyId" IS NULL
+  WHERE c."idNumber" <> cfg.exclude_id_number
+),
+inserted AS (
+  INSERT INTO messaging_deliveries (
+    id,
+    "templateKey",
+    channel,
+    "customerId",
+    "policyId",
+    "recipientPhone",
+    "recipientEmail",
+    "requestedLanguage",
+    "renderedBody",
+    status,
+    "attemptCount",
+    "maxAttempts",
+    "correlationId",
+    "enqueuePlaceholderContext",
+    "createdAt",
+    "updatedAt",
+    "createdBy"
+  )
+  SELECT
+    gen_random_uuid(),
+    'postpaid_false_suspend_apology',
+    'SMS',
+    a.customer_id,
+    a.policy_id,
+    a.phone,
+    NULL,
+    'en',
+    '', -- worker renders from template + customer first_name + context
+    CASE
+      WHEN a.phone IS NULL THEN 'FAILED'::"MessagingDeliveryStatus"
+      ELSE 'PENDING'::"MessagingDeliveryStatus"
+    END,
+    0,
+    a.max_attempts,
+    a.correlation_id,
+    jsonb_build_object('general_support_number', a.support_number),
+    NOW(),
+    NOW(),
+    'ops-sql-false-suspend-apology'
+  FROM audience a
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM messaging_deliveries d
+    WHERE d."correlationId" = a.correlation_id
+      AND d."customerId" = a.customer_id
+      AND d."policyId" = a.policy_id
+      AND d."templateKey" = 'postpaid_false_suspend_apology'
+  )
+  RETURNING id, status, "customerId", "recipientPhone"
+)
+SELECT
+  COUNT(*) AS rows_inserted,
+  COUNT(*) FILTER (WHERE status = 'PENDING') AS pending_to_send,
+  COUNT(*) FILTER (WHERE status = 'FAILED') AS failed_missing_phone
+FROM inserted;
+
+COMMIT;
+*/
+
+
+-- ── STEP 3: Verification ────────────────────────────────────────────────────
+
+SELECT
+  status,
+  COUNT(*) AS n
+FROM messaging_deliveries
+WHERE "correlationId" = 'ops-postpaid-false-suspend-apology-2026-08-18'
+  AND "templateKey" = 'postpaid_false_suspend_apology'
+GROUP BY status
+ORDER BY status;
+
+SELECT
+  d.status,
+  c."firstName",
+  c."lastName",
+  c."idNumber",
+  d."recipientPhone",
+  d."renderedBody",
+  d."lastError",
+  d."createdAt"
+FROM messaging_deliveries d
+LEFT JOIN customers c ON c.id = d."customerId"
+WHERE d."correlationId" = 'ops-postpaid-false-suspend-apology-2026-08-18'
+ORDER BY d.status, c."lastName", c."firstName";

--- a/apps/api/scripts/revert-postpaid-premium-reactivate.sql
+++ b/apps/api/scripts/revert-postpaid-premium-reactivate.sql
@@ -1,0 +1,268 @@
+-- =============================================================================
+-- Revert postpaid premium accrual + reactivate false SYSTEM suspends
+-- =============================================================================
+--
+-- Context (Aug 2026): after populating policies.premium / annualPremium for
+-- Titanic (2), Waiyaki (8), ALTO (9), lifecycle started accruing like prepaid
+-- and mass-suspended members. Pre-patch, premium = 0 skipped the job.
+--
+-- This script restores that safe model for live policies on those schemes:
+--   1) Set premium = 0 and annualPremium = 0
+--   2) Move SUSPENDED → ACTIVE (clear suspend/grace flags)
+--   3) Set customer status SUSPENDED → ACTIVE when they now have an ACTIVE policy
+--
+-- Does NOT change: packagePlanId, productName, frequency, paymentCadence,
+-- expectedInstallmentCount, scheme frequency/cadence, startDate / endDate.
+--
+-- Does NOT touch: DEACTIVATED / superseded policies, PENDING_ACTIVATION,
+-- INACTIVE (those need a separate decision).
+--
+-- LCT / SMS / entity_status_changes:
+--   Raw SQL does NOT call EntityStatusChangeService or LctSyncService, so this
+--   will NOT push a reactivation to LCT and will NOT enqueue policy_reactivated
+--   SMS. That is intentional for this ops undo (members were not LCT-pushed
+--   for the false suspend either in the intended sense for this fix).
+--
+-- HOW TO RUN:
+--   1. Run STEP 1 preview — confirm counts / sample rows.
+--   2. Uncomment STEP 2, run once inside the transaction.
+--   3. Run STEP 3 verification.
+--
+--   psql $DATABASE_URL -f apps/api/scripts/revert-postpaid-premium-reactivate.sql
+-- =============================================================================
+
+
+-- ── CONFIGURATION ───────────────────────────────────────────────────────────
+
+-- scheme_ids: Titanic=2, OOD Waiyaki=8, ALTO=9
+
+
+-- ── STEP 1: Preview ─────────────────────────────────────────────────────────
+
+WITH config AS (
+  SELECT ARRAY[2, 8, 9]::int[] AS scheme_ids
+),
+targets AS (
+  SELECT
+    s.id AS scheme_id,
+    s."schemeName",
+    c.id AS customer_id,
+    c."firstName",
+    c."lastName",
+    c."idNumber",
+    c.status AS customer_status,
+    p.id AS policy_id,
+    p."policyNumber",
+    p.status AS policy_status,
+    p.premium AS current_premium,
+    p."annualPremium" AS current_annual_premium,
+    p."suspendedAt",
+    p."packagePlanId",
+    p.frequency,
+    p."paymentCadence"
+  FROM config cfg
+  INNER JOIN schemes s ON s.id = ANY (cfg.scheme_ids)
+  INNER JOIN package_schemes ps ON ps."schemeId" = s.id
+  INNER JOIN package_scheme_customers psc ON psc."packageSchemeId" = ps.id
+  INNER JOIN customers c ON c.id = psc."customerId"
+  INNER JOIN policies p ON p."customerId" = c.id
+    AND p."packageId" = ps."packageId"
+    AND p.status <> 'DEACTIVATED'
+    AND p."supersededByPolicyId" IS NULL
+)
+SELECT
+  scheme_id,
+  "schemeName",
+  policy_status,
+  COUNT(*) AS policies,
+  COUNT(*) FILTER (WHERE current_premium > 0 OR current_annual_premium > 0)
+    AS with_nonzero_premium_or_annual,
+  COUNT(*) FILTER (WHERE policy_status = 'SUSPENDED') AS suspended_to_reactivate,
+  COUNT(*) FILTER (WHERE policy_status = 'ACTIVE') AS already_active,
+  COUNT(*) FILTER (WHERE policy_status = 'PENDING_ACTIVATION') AS pending_left_alone,
+  COUNT(*) FILTER (WHERE policy_status = 'INACTIVE') AS inactive_left_alone
+FROM targets
+GROUP BY scheme_id, "schemeName", policy_status
+ORDER BY scheme_id, policy_status;
+
+-- Sample rows that will get premium zeroed (and reactivated if SUSPENDED)
+WITH config AS (
+  SELECT ARRAY[2, 8, 9]::int[] AS scheme_ids
+),
+targets AS (
+  SELECT
+    s.id AS scheme_id,
+    s."schemeName",
+    c."firstName",
+    c."lastName",
+    c."idNumber",
+    c.status AS customer_status,
+    p.id AS policy_id,
+    p."policyNumber",
+    p.status AS policy_status,
+    p.premium AS current_premium,
+    p."annualPremium" AS current_annual_premium
+  FROM config cfg
+  INNER JOIN schemes s ON s.id = ANY (cfg.scheme_ids)
+  INNER JOIN package_schemes ps ON ps."schemeId" = s.id
+  INNER JOIN package_scheme_customers psc ON psc."packageSchemeId" = ps.id
+  INNER JOIN customers c ON c.id = psc."customerId"
+  INNER JOIN policies p ON p."customerId" = c.id
+    AND p."packageId" = ps."packageId"
+    AND p.status <> 'DEACTIVATED'
+    AND p."supersededByPolicyId" IS NULL
+  WHERE p.status IN ('ACTIVE', 'SUSPENDED')
+)
+SELECT *
+FROM targets
+ORDER BY scheme_id, policy_status, "lastName", "firstName";
+
+
+-- ── STEP 2: Apply (uncomment after preview) ─────────────────────────────────
+-- NOTE: Must be ONE update on policies (Postgres cannot update the same row
+-- twice in one statement — that was why a first run zeroed premiums but left
+-- policies_reactivated = 0).
+
+/*
+BEGIN;
+
+WITH config AS (
+  SELECT ARRAY[2, 8, 9]::int[] AS scheme_ids
+),
+live_policies AS (
+  SELECT p.id AS policy_id, p."customerId", p.status AS prior_status
+  FROM config cfg
+  INNER JOIN schemes s ON s.id = ANY (cfg.scheme_ids)
+  INNER JOIN package_schemes ps ON ps."schemeId" = s.id
+  INNER JOIN package_scheme_customers psc ON psc."packageSchemeId" = ps.id
+  INNER JOIN policies p ON p."customerId" = psc."customerId"
+    AND p."packageId" = ps."packageId"
+    AND p.status <> 'DEACTIVATED'
+    AND p."supersededByPolicyId" IS NULL
+    AND p.status IN ('ACTIVE', 'SUSPENDED')
+),
+policies_updated AS (
+  UPDATE policies pol
+  SET
+    premium = 0,
+    "annualPremium" = 0,
+    status = CASE WHEN t.prior_status = 'SUSPENDED' THEN 'ACTIVE'::"PolicyStatus" ELSE pol.status END,
+    "suspendedAt" = CASE WHEN t.prior_status = 'SUSPENDED' THEN NULL ELSE pol."suspendedAt" END,
+    "inactivatedAt" = CASE WHEN t.prior_status = 'SUSPENDED' THEN NULL ELSE pol."inactivatedAt" END,
+    "inGracePeriod" = CASE WHEN t.prior_status = 'SUSPENDED' THEN false ELSE pol."inGracePeriod" END,
+    "graceEnteredAt" = CASE WHEN t.prior_status = 'SUSPENDED' THEN NULL ELSE pol."graceEnteredAt" END,
+    "overdueAnchorDueDate" = CASE
+      WHEN t.prior_status = 'SUSPENDED' THEN NULL
+      ELSE pol."overdueAnchorDueDate"
+    END,
+    "deactivatedAt" = CASE WHEN t.prior_status = 'SUSPENDED' THEN NULL ELSE pol."deactivatedAt" END,
+    "updatedAt" = NOW()
+  FROM live_policies t
+  WHERE pol.id = t.policy_id
+  RETURNING
+    pol.id,
+    pol."customerId",
+    t.prior_status,
+    pol.status AS new_status
+),
+customers_updated AS (
+  UPDATE customers c
+  SET
+    status = 'ACTIVE',
+    "deactivatedAt" = NULL,
+    "updatedAt" = NOW()
+  WHERE c.status = 'SUSPENDED'
+    AND c.id IN (
+      SELECT DISTINCT pu."customerId"
+      FROM policies_updated pu
+      WHERE pu.prior_status = 'SUSPENDED'
+        AND pu.new_status = 'ACTIVE'
+    )
+  RETURNING c.id
+)
+SELECT
+  (SELECT COUNT(*) FROM policies_updated) AS policies_touched,
+  (SELECT COUNT(*) FROM policies_updated WHERE prior_status = 'SUSPENDED')
+    AS policies_reactivated,
+  (SELECT COUNT(*) FROM customers_updated) AS customers_set_active;
+
+COMMIT;
+*/
+
+
+-- ── STEP 2b: Finish reactivation if STEP 2 already zeroed premiums only ─────
+-- Run this when verification still shows SUSPENDED with premium = 0.
+
+/*
+BEGIN;
+
+WITH config AS (
+  SELECT ARRAY[2, 8, 9]::int[] AS scheme_ids
+),
+suspended_live AS (
+  SELECT p.id AS policy_id, p."customerId"
+  FROM config cfg
+  INNER JOIN schemes s ON s.id = ANY (cfg.scheme_ids)
+  INNER JOIN package_schemes ps ON ps."schemeId" = s.id
+  INNER JOIN package_scheme_customers psc ON psc."packageSchemeId" = ps.id
+  INNER JOIN policies p ON p."customerId" = psc."customerId"
+    AND p."packageId" = ps."packageId"
+    AND p.status = 'SUSPENDED'
+    AND p."supersededByPolicyId" IS NULL
+),
+reactivated AS (
+  UPDATE policies pol
+  SET
+    status = 'ACTIVE',
+    "suspendedAt" = NULL,
+    "inactivatedAt" = NULL,
+    "inGracePeriod" = false,
+    "graceEnteredAt" = NULL,
+    "overdueAnchorDueDate" = NULL,
+    "deactivatedAt" = NULL,
+    "updatedAt" = NOW()
+  FROM suspended_live t
+  WHERE pol.id = t.policy_id
+  RETURNING pol.id, pol."customerId"
+),
+customers_updated AS (
+  UPDATE customers c
+  SET
+    status = 'ACTIVE',
+    "deactivatedAt" = NULL,
+    "updatedAt" = NOW()
+  WHERE c.status = 'SUSPENDED'
+    AND c.id IN (SELECT DISTINCT r."customerId" FROM reactivated r)
+  RETURNING c.id
+)
+SELECT
+  (SELECT COUNT(*) FROM reactivated) AS policies_reactivated,
+  (SELECT COUNT(*) FROM customers_updated) AS customers_set_active;
+
+COMMIT;
+*/
+
+
+-- ── STEP 3: Verification ────────────────────────────────────────────────────
+
+WITH config AS (
+  SELECT ARRAY[2, 8, 9]::int[] AS scheme_ids
+)
+SELECT
+  s.id AS scheme_id,
+  s."schemeName",
+  p.status AS policy_status,
+  COUNT(*) AS policies,
+  COUNT(*) FILTER (WHERE p.premium <> 0 OR p."annualPremium" <> 0)
+    AS still_nonzero_premium_or_annual,
+  ROUND(AVG(p.premium)::numeric, 2) AS avg_premium
+FROM config cfg
+INNER JOIN schemes s ON s.id = ANY (cfg.scheme_ids)
+INNER JOIN package_schemes ps ON ps."schemeId" = s.id
+INNER JOIN package_scheme_customers psc ON psc."packageSchemeId" = ps.id
+INNER JOIN policies p ON p."customerId" = psc."customerId"
+  AND p."packageId" = ps."packageId"
+  AND p.status <> 'DEACTIVATED'
+  AND p."supersededByPolicyId" IS NULL
+GROUP BY s.id, s."schemeName", p.status
+ORDER BY s.id, p.status;

--- a/apps/api/src/constants/policy-lifecycle.constants.ts
+++ b/apps/api/src/constants/policy-lifecycle.constants.ts
@@ -1,0 +1,12 @@
+/**
+ * Policy payment lifecycle thresholds (UTC calendar days).
+ *
+ * Timeline from first overdue day:
+ *   1–14  → grace (still ACTIVE)
+ *   >14   → SUSPENDED
+ *   ≥15 days suspended → INACTIVE (~30 days from first overdue total)
+ */
+export const GRACE_OVERDUE_MAX_DAYS = 14;
+export const SUSPEND_OVERDUE_AFTER_DAYS = 14;
+/** Days in SUSPENDED before auto-transition to INACTIVE (was 30). */
+export const INACTIVE_AFTER_SUSPENDED_DAYS = 15;

--- a/apps/api/src/controllers/internal/product-management.controller.ts
+++ b/apps/api/src/controllers/internal/product-management.controller.ts
@@ -656,6 +656,37 @@ export class ProductManagementController {
   }
 
   /**
+   * Convert an Up to N pricing category into Member only (in place).
+   */
+  @Post('packages/:packageId/pricing/categories/:categoryId/convert-to-member-only')
+  @SetupAdminOnly()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Convert an Up to N category to Member only (requires setup_admin)',
+  })
+  async convertPackagePricingCategoryToMemberOnly(
+    @Param('packageId', ParseIntPipe) packageId: number,
+    @Param('categoryId', ParseIntPipe) categoryId: number,
+    @UserId() userId: string,
+    @CorrelationId() correlationId?: string,
+  ) {
+    if (!userId) {
+      throw new Error('User ID not found in request');
+    }
+    const data = await this.packagePricingService.convertCategoryToMemberOnly(
+      packageId,
+      categoryId,
+      userId
+    );
+    return {
+      status: HttpStatus.OK,
+      correlationId: correlationId ?? 'unknown',
+      message: 'Pricing category converted to Member only',
+      data,
+    };
+  }
+
+  /**
    * Suggest fill for empty pricing cells
    */
   @Post('packages/:packageId/pricing/suggest-fill')

--- a/apps/api/src/services/__tests__/package-pricing-category.spec.ts
+++ b/apps/api/src/services/__tests__/package-pricing-category.spec.ts
@@ -1,4 +1,5 @@
 /// <reference types="jest" />
+import { NotFoundException } from '@nestjs/common';
 import { PackagePricingCategoryKind } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { PackagePricingService } from '../package-pricing/package-pricing.service';
@@ -13,6 +14,7 @@ describe('PackagePricingService - createCategory uniqueness', () => {
     packagePricingCategory: {
       findMany: jest.fn(),
       create: jest.fn(),
+      update: jest.fn(),
     },
   };
 
@@ -171,5 +173,164 @@ describe('PackagePricingService - createCategory uniqueness', () => {
       })
     );
     expect(result.category.key).toBe('up_to_5');
+  });
+
+  it('creates MEMBER_ONLY when none exists', async () => {
+    prismaMock.packagePricingCategory.findMany.mockResolvedValue([]);
+    prismaMock.packagePricingCategory.create.mockResolvedValue({
+      id: 43,
+      key: 'member_only',
+      displayName: 'M',
+      kind: PackagePricingCategoryKind.MEMBER_ONLY,
+      maxMembers: null,
+      sortOrder: 0,
+    });
+    loadedPackage.packagePricingCategories = [
+      {
+        id: 43,
+        key: 'member_only',
+        displayName: 'M',
+        kind: PackagePricingCategoryKind.MEMBER_ONLY,
+        maxMembers: null,
+        sortOrder: 0,
+      },
+    ];
+
+    const result = await service.createCategory(
+      10,
+      { kind: PackagePricingCategoryKindDto.MEMBER_ONLY, display: 'M' },
+      'user-1'
+    );
+
+    expect(prismaMock.packagePricingCategory.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          key: 'member_only',
+          kind: PackagePricingCategoryKind.MEMBER_ONLY,
+          maxMembers: null,
+        }),
+      })
+    );
+    expect(result.category.key).toBe('member_only');
+  });
+});
+
+describe('PackagePricingService.convertCategoryToMemberOnly', () => {
+  const prismaMock = {
+    package: {
+      findUnique: jest.fn(),
+    },
+    packagePricingCategory: {
+      findMany: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+    },
+  };
+
+  const service = new PackagePricingService(prismaMock as unknown as PrismaService);
+
+  const upToTwo = {
+    id: 43,
+    key: 'up_to_2',
+    displayName: 'M',
+    kind: PackagePricingCategoryKind.UP_TO_N,
+    maxMembers: 2,
+    sortOrder: 0,
+  };
+
+  let loadedPackage: {
+    id: number;
+    slug: string;
+    isActive: boolean;
+    maximumFamilySize: number;
+    packagePaymentFrequencies: unknown[];
+    packagePricingCategories: unknown[];
+    packagePlans: unknown[];
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    loadedPackage = {
+      id: 5,
+      slug: 'mfanisi-tuktuk',
+      isActive: false,
+      maximumFamilySize: 8,
+      packagePaymentFrequencies: [],
+      packagePricingCategories: [upToTwo],
+      packagePlans: [],
+    };
+    prismaMock.package.findUnique.mockImplementation(() => Promise.resolve(loadedPackage));
+    prismaMock.packagePricingCategory.update.mockImplementation(
+      async (args: { data: Record<string, unknown> }) => {
+        const converted = {
+          ...upToTwo,
+          ...args.data,
+        };
+        loadedPackage.packagePricingCategories = [converted];
+        return converted;
+      }
+    );
+  });
+
+  it('flips kind, key, and maxMembers in place', async () => {
+    const result = await service.convertCategoryToMemberOnly(5, 43, 'user-1');
+
+    expect(prismaMock.packagePricingCategory.update).toHaveBeenCalledWith({
+      where: { id: 43 },
+      data: {
+        kind: PackagePricingCategoryKind.MEMBER_ONLY,
+        key: 'member_only',
+        maxMembers: null,
+        displayName: 'M',
+        updatedBy: 'user-1',
+      },
+    });
+    expect(result.categories.some((c) => c.kind === 'MEMBER_ONLY' && c.key === 'member_only')).toBe(
+      true
+    );
+    expect(result.isPricingComplete).toBe(false);
+  });
+
+  it('rejects converting Additional spouse', async () => {
+    loadedPackage.packagePricingCategories = [
+      {
+        id: 46,
+        key: 'additional_spouse',
+        displayName: 'Additional spouse',
+        kind: PackagePricingCategoryKind.ADDITIONAL_SPOUSE,
+        maxMembers: null,
+        sortOrder: 1,
+      },
+    ];
+
+    await expect(service.convertCategoryToMemberOnly(5, 46, 'user-1')).rejects.toBeInstanceOf(
+      ValidationException
+    );
+    expect(prismaMock.packagePricingCategory.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects when Member only already exists', async () => {
+    loadedPackage.packagePricingCategories = [
+      {
+        id: 1,
+        key: 'member_only',
+        displayName: 'M',
+        kind: PackagePricingCategoryKind.MEMBER_ONLY,
+        maxMembers: null,
+        sortOrder: 0,
+      },
+      upToTwo,
+    ];
+
+    await expect(service.convertCategoryToMemberOnly(5, 43, 'user-1')).rejects.toBeInstanceOf(
+      ValidationException
+    );
+    expect(prismaMock.packagePricingCategory.update).not.toHaveBeenCalled();
+  });
+
+  it('throws when category is not on the package', async () => {
+    await expect(service.convertCategoryToMemberOnly(5, 999, 'user-1')).rejects.toBeInstanceOf(
+      NotFoundException
+    );
   });
 });

--- a/apps/api/src/services/customer.service.ts
+++ b/apps/api/src/services/customer.service.ts
@@ -2839,6 +2839,7 @@ export class CustomerService {
         paymentCadenceDays: p.paymentCadence,
         installmentAmount: premiumNum,
         paidExact: paid.exact,
+        expectedInstallmentCount: p.expectedInstallmentCount,
       });
 
       list.push({
@@ -2959,6 +2960,7 @@ export class CustomerService {
       paymentCadenceDays: policy.paymentCadence,
       installmentAmount: premiumNum,
       paidExact: paid.exact,
+      expectedInstallmentCount: policy.expectedInstallmentCount,
     });
 
     const missedPaymentsAmount = this.buildMissedPaymentsAmount(
@@ -3107,6 +3109,7 @@ export class CustomerService {
       startDate: Date | null;
       premium: Prisma.Decimal;
       paymentCadence: number;
+      expectedInstallmentCount?: number | null;
       policyPayments: Array<{
         expectedPaymentDate: Date;
         amount: Prisma.Decimal;
@@ -3142,6 +3145,7 @@ export class CustomerService {
       installmentAmount: premiumNum,
       payments,
       confirmedStatuses,
+      expectedInstallmentCount: policy.expectedInstallmentCount,
     });
     const allTime = formatMissedPaymentsAmountSide(allTimeResult);
 
@@ -3156,6 +3160,7 @@ export class CustomerService {
           installmentAmount: premiumNum,
           payments,
           confirmedStatuses,
+          expectedInstallmentCount: policy.expectedInstallmentCount,
         });
         filtered = formatMissedPaymentsAmountSide(filteredResult);
       }

--- a/apps/api/src/services/package-pricing/package-pricing.service.ts
+++ b/apps/api/src/services/package-pricing/package-pricing.service.ts
@@ -367,6 +367,78 @@ export class PackagePricingService {
     };
   }
 
+  /**
+   * Convert an Up to N band into the required Member only band in place.
+   * Rates stay on the same category row (FK by id); only kind/key/maxMembers change.
+   */
+  async convertCategoryToMemberOnly(
+    packageId: number,
+    categoryId: number,
+    userId: string
+  ): Promise<PackagePricingData> {
+    const pkg = await this.prisma.package.findUnique({
+      where: { id: packageId },
+      include: { packagePricingCategories: true },
+    });
+    if (!pkg) {
+      throw new NotFoundException(`Package with ID ${packageId} not found`);
+    }
+
+    const target = pkg.packagePricingCategories.find((c) => c.id === categoryId);
+    if (!target) {
+      throw new NotFoundException(
+        `Pricing category ${categoryId} not found on package ${packageId}`
+      );
+    }
+
+    if (target.kind === PackagePricingCategoryKind.MEMBER_ONLY) {
+      return this.getPricing(packageId);
+    }
+
+    if (target.kind !== PackagePricingCategoryKind.UP_TO_N) {
+      throw ValidationException.forField(
+        'kind',
+        'Only an Up to N category can be converted to Member only',
+        ErrorCodes.VALIDATION_ERROR
+      );
+    }
+
+    const existingMemberOnly = pkg.packagePricingCategories.find(
+      (c) => c.kind === PackagePricingCategoryKind.MEMBER_ONLY
+    );
+    if (existingMemberOnly) {
+      throw ValidationException.forField(
+        'kind',
+        'A Member only category already exists on this package',
+        ErrorCodes.VALIDATION_ERROR
+      );
+    }
+
+    const keyTaken = pkg.packagePricingCategories.find(
+      (c) => c.key === 'member_only' && c.id !== categoryId
+    );
+    if (keyTaken) {
+      throw ValidationException.forField(
+        'key',
+        'Category key "member_only" is already in use',
+        ErrorCodes.VALIDATION_ERROR
+      );
+    }
+
+    await this.prisma.packagePricingCategory.update({
+      where: { id: categoryId },
+      data: {
+        kind: PackagePricingCategoryKind.MEMBER_ONLY,
+        key: 'member_only',
+        maxMembers: null,
+        displayName: target.displayName.trim() || 'M',
+        updatedBy: userId,
+      },
+    });
+
+    return this.getPricing(packageId);
+  }
+
   async suggestFill(
     packageId: number,
     body: SuggestFillRequestDto

--- a/apps/api/src/services/policy-lifecycle.service.ts
+++ b/apps/api/src/services/policy-lifecycle.service.ts
@@ -1367,6 +1367,7 @@ export class PolicyLifecycleService {
         productName: true,
         premium: true,
         paymentCadence: true,
+        expectedInstallmentCount: true,
         startDate: true,
         endDate: true,
         status: true,
@@ -1508,6 +1509,7 @@ export class PolicyLifecycleService {
     policy: {
       startDate: Date | null;
       paymentCadence: number;
+      expectedInstallmentCount?: number | null;
       policyPayments: Array<{
         amount: unknown;
         paymentStatus: string;

--- a/apps/api/src/services/policy-lifecycle.service.ts
+++ b/apps/api/src/services/policy-lifecycle.service.ts
@@ -66,12 +66,16 @@ import {
   SUSPEND_TEMPLATE,
 } from '../modules/messaging/policy-lifecycle-messaging.service';
 import { LctSyncService } from '../modules/lct/lct-sync.service';
-import { utcDayStart, utcDayEnd, sumConfirmedPaidThroughAsOf, computeExpectedPremiumThroughAsOf } from '../utils/premium-statement-math';
+import { utcDayStart, utcDayEnd, sumConfirmedPaidThroughAsOf, computeExpectedPremiumThroughAsOf, isPremiumMoneyComplete } from '../utils/premium-statement-math';
 import {
   CONFIRMED_PAYMENT_STATUSES,
   confirmedActivePaymentWhere,
   notDetachedPaymentWhere,
 } from '../utils/policy-payment-filters';
+import {
+  INACTIVE_AFTER_SUSPENDED_DAYS,
+  SUSPEND_OVERDUE_AFTER_DAYS,
+} from '../constants/policy-lifecycle.constants';
 
 /** Well-known actor UUID for SYSTEM / payment-lifecycle automated transitions. */
 export const LIFECYCLE_SYSTEM_ACTOR_ID = '00000000-0000-0000-0000-000000000001';
@@ -89,6 +93,39 @@ export class PolicyLifecycleService {
     private readonly lifecycleMessaging: PolicyLifecycleMessagingService,
     private readonly lctSyncService: LctSyncService
   ) {}
+
+  /**
+   * Persist premiumCompleted when prepaid money target is met.
+   * Returns true when the policy should be treated as premium-complete (skip suspend/inactive).
+   */
+  private async syncPremiumCompletedFlag(params: {
+    policyId: string;
+    premiumCompleted: boolean;
+    paidTotal: number;
+    expectedInstallmentCount: number | null | undefined;
+    installmentAmount: number;
+    asOfUtc: Date;
+  }): Promise<boolean> {
+    if (params.premiumCompleted) {
+      return true;
+    }
+    const complete = isPremiumMoneyComplete({
+      paidTotal: params.paidTotal,
+      expectedInstallmentCount: params.expectedInstallmentCount,
+      installmentAmount: params.installmentAmount,
+    });
+    if (!complete) {
+      return false;
+    }
+    await this.prisma.policy.update({
+      where: { id: params.policyId },
+      data: {
+        premiumCompleted: true,
+        premiumCompletedAt: params.asOfUtc,
+      },
+    });
+    return true;
+  }
 
   assertAdmin(userRoles: string[]): void {
     if (userRoles.includes(ADMIN_ROLE)) return;
@@ -274,6 +311,8 @@ export class PolicyLifecycleService {
         productName: true,
         premium: true,
         paymentCadence: true,
+        expectedInstallmentCount: true,
+        premiumCompleted: true,
         startDate: true,
         endDate: true,
         inGracePeriod: true,
@@ -318,12 +357,30 @@ export class PolicyLifecycleService {
         CONFIRMED_PAYMENT_STATUSES
       );
 
+      if (
+        await this.syncPremiumCompletedFlag({
+          policyId: policy.id,
+          premiumCompleted: policy.premiumCompleted,
+          paidTotal: paidThroughAsOf,
+          expectedInstallmentCount: policy.expectedInstallmentCount,
+          installmentAmount,
+          asOfUtc,
+        })
+      ) {
+        if (policy.inGracePeriod) {
+          await this.clearGraceOverlay(policy, correlationId);
+          graceCleared += 1;
+        }
+        continue;
+      }
+
       const nextDue = nextUnpaidExpectedDueDate({
         policyStart: policy.startDate,
         paymentCadenceDays: policy.paymentCadence,
         installmentAmount,
         paidThroughAsOf,
         asOfUtc,
+        expectedInstallmentCount: policy.expectedInstallmentCount,
       });
       const overdue = daysOverdue({ nextUnpaidDueDate: nextDue, asOfUtc });
       const arrears = outstandingArrears({
@@ -332,6 +389,7 @@ export class PolicyLifecycleService {
         installmentAmount,
         paidThroughAsOf,
         asOfUtc,
+        expectedInstallmentCount: policy.expectedInstallmentCount,
       });
 
       // Fully current or not yet overdue → clear grace if set
@@ -344,7 +402,7 @@ export class PolicyLifecycleService {
       }
 
       // Overdue >14 → leave for suspend evaluation (US3)
-      if (overdue > 14) {
+      if (overdue > SUSPEND_OVERDUE_AFTER_DAYS) {
         continue;
       }
 
@@ -505,6 +563,8 @@ export class PolicyLifecycleService {
         productName: true,
         premium: true,
         paymentCadence: true,
+        expectedInstallmentCount: true,
+        premiumCompleted: true,
         startDate: true,
         endDate: true,
         inGracePeriod: true,
@@ -535,12 +595,27 @@ export class PolicyLifecycleService {
         policy.policyPayments,
         asOfUtc
       );
+
+      if (
+        await this.syncPremiumCompletedFlag({
+          policyId: policy.id,
+          premiumCompleted: policy.premiumCompleted,
+          paidTotal: paidThroughAsOf,
+          expectedInstallmentCount: policy.expectedInstallmentCount,
+          installmentAmount,
+          asOfUtc,
+        })
+      ) {
+        continue;
+      }
+
       const arrears = outstandingArrears({
         policyStart: policy.startDate,
         paymentCadenceDays: policy.paymentCadence,
         installmentAmount,
         paidThroughAsOf,
         asOfUtc,
+        expectedInstallmentCount: policy.expectedInstallmentCount,
       });
       // Never suspend (or SMS) when premium accrued-to-date is fully paid.
       if (arrears <= 0) continue;
@@ -551,9 +626,10 @@ export class PolicyLifecycleService {
         installmentAmount,
         paidThroughAsOf,
         asOfUtc,
+        expectedInstallmentCount: policy.expectedInstallmentCount,
       });
       const overdue = daysOverdue({ nextUnpaidDueDate: nextDue, asOfUtc });
-      if (overdue <= 14) continue;
+      if (overdue <= SUSPEND_OVERDUE_AFTER_DAYS) continue;
 
       await this.prisma.$transaction(async (tx) => {
         if (policy.inGracePeriod) {
@@ -626,7 +702,7 @@ export class PolicyLifecycleService {
   }
 
   /**
-   * Suspended ≥30 days before end → Inactive.
+   * Suspended ≥15 days before end → Inactive (~30 days from first overdue total).
    */
   async evaluateInactiveForSuspendedPolicies(
     asOfUtc: Date = new Date(),
@@ -643,7 +719,20 @@ export class PolicyLifecycleService {
         productName: true,
         endDate: true,
         suspendedAt: true,
+        premium: true,
+        paymentCadence: true,
+        expectedInstallmentCount: true,
+        premiumCompleted: true,
+        startDate: true,
         customer: { select: { firstName: true } },
+        policyPayments: {
+          where: notDetachedPaymentWhere(),
+          select: {
+            amount: true,
+            paymentStatus: true,
+            expectedPaymentDate: true,
+          },
+        },
       },
     });
 
@@ -654,8 +743,31 @@ export class PolicyLifecycleService {
       if (!policy.suspendedAt) continue;
       if (isPolicyEndDatePassed(policy.endDate, asOfUtc)) continue;
 
+      const installmentAmount = Number(policy.premium);
+      if (policy.startDate && policy.paymentCadence > 0 && installmentAmount > 0) {
+        const paidThroughAsOf = this.paidThroughAsOf(
+          policy.startDate,
+          policy.policyPayments,
+          asOfUtc
+        );
+        if (
+          await this.syncPremiumCompletedFlag({
+            policyId: policy.id,
+            premiumCompleted: policy.premiumCompleted,
+            paidTotal: paidThroughAsOf,
+            expectedInstallmentCount: policy.expectedInstallmentCount,
+            installmentAmount,
+            asOfUtc,
+          })
+        ) {
+          continue;
+        }
+      } else if (policy.premiumCompleted) {
+        continue;
+      }
+
       const daysSuspended = utcCalendarDaysBetween(policy.suspendedAt, asOfUtc);
-      if (daysSuspended < 30) continue;
+      if (daysSuspended < INACTIVE_AFTER_SUSPENDED_DAYS) continue;
 
       await this.prisma.$transaction(async (tx) => {
         await this.statusChangeService.recordPolicyChange({
@@ -1069,12 +1181,21 @@ export class PolicyLifecycleService {
       policy.policyPayments,
       asOfUtc
     );
+    await this.syncPremiumCompletedFlag({
+      policyId: policy.id,
+      premiumCompleted: policy.premiumCompleted,
+      paidTotal: paidThroughAsOf,
+      expectedInstallmentCount: policy.expectedInstallmentCount,
+      installmentAmount,
+      asOfUtc,
+    });
     const arrears = outstandingArrears({
       policyStart: policy.startDate,
       paymentCadenceDays: policy.paymentCadence,
       installmentAmount,
       paidThroughAsOf,
       asOfUtc,
+      expectedInstallmentCount: policy.expectedInstallmentCount,
     });
     const endPassed = isPolicyEndDatePassed(policy.endDate, asOfUtc);
 
@@ -1127,6 +1248,7 @@ export class PolicyLifecycleService {
         statementGenerationUtc: asOfUtc,
         paymentCadenceDays: policy.paymentCadence,
         installmentAmount,
+        expectedInstallmentCount: policy.expectedInstallmentCount,
       });
       const coverageNeeded = expectedPremium + twoWeek;
       const canRestore = paidThroughAsOf >= coverageNeeded;
@@ -1183,6 +1305,7 @@ export class PolicyLifecycleService {
         statementGenerationUtc: asOfUtc,
         paymentCadenceDays: policy.paymentCadence,
         installmentAmount,
+        expectedInstallmentCount: policy.expectedInstallmentCount,
       });
       const oneMonth = amountRequiredToRestoreInactive({
         paymentCadenceDays: policy.paymentCadence,
@@ -1287,6 +1410,7 @@ export class PolicyLifecycleService {
       installmentAmount,
       paidThroughAsOf,
       asOfUtc,
+      expectedInstallmentCount: policy.expectedInstallmentCount,
     });
     const nextDue = nextUnpaidExpectedDueDate({
       policyStart: policy.startDate,
@@ -1294,6 +1418,7 @@ export class PolicyLifecycleService {
       installmentAmount,
       paidThroughAsOf,
       asOfUtc,
+      expectedInstallmentCount: policy.expectedInstallmentCount,
     });
     const overdue = daysOverdue({ nextUnpaidDueDate: nextDue, asOfUtc });
 
@@ -1406,6 +1531,7 @@ export class PolicyLifecycleService {
       installmentAmount,
       paidThroughAsOf: paidWithoutLast,
       asOfUtc,
+      expectedInstallmentCount: policy.expectedInstallmentCount,
     });
     return Math.max(0, lastAmt - arrearsWithoutLast);
   }
@@ -1880,6 +2006,7 @@ export class PolicyLifecycleService {
       installmentAmount,
       paidThroughAsOf,
       asOfUtc,
+      expectedInstallmentCount: source.expectedInstallmentCount,
     });
     const twoWeek = amountRequiredToRestoreSuspended({
       paymentCadenceDays: source.paymentCadence,
@@ -1891,6 +2018,7 @@ export class PolicyLifecycleService {
       statementGenerationUtc: asOfUtc,
       paymentCadenceDays: source.paymentCadence,
       installmentAmount,
+      expectedInstallmentCount: source.expectedInstallmentCount,
     });
     if (paidThroughAsOf < expectedPremium + twoWeek) {
       const required = amountRequiredToRestoreSuspended({

--- a/apps/api/src/services/premium-statement.service.ts
+++ b/apps/api/src/services/premium-statement.service.ts
@@ -199,6 +199,7 @@ export class PremiumStatementService {
       statementGenerationUtc: generatedAt,
       paymentCadenceDays: cadence,
       installmentAmount: premiumNum,
+      expectedInstallmentCount: policy.expectedInstallmentCount,
     });
 
     const ps = policy.startDate;

--- a/apps/api/src/utils/__tests__/policy-due-date.util.spec.ts
+++ b/apps/api/src/utils/__tests__/policy-due-date.util.spec.ts
@@ -6,9 +6,11 @@ import {
   isPolicyEndDatePassed,
   nextUnpaidExpectedDueDate,
   oneMonthPremiumAmount,
+  outstandingArrears,
   twoWeekUpfrontAmount,
   utcCalendarDaysBetween,
 } from '../policy-due-date.util';
+import { INACTIVE_AFTER_SUSPENDED_DAYS } from '../../constants/policy-lifecycle.constants';
 
 describe('policy-due-date.util', () => {
   describe('ceilCadencePeriods / restore amounts', () => {
@@ -75,6 +77,57 @@ describe('policy-due-date.util', () => {
       expect(isPolicyEndDatePassed(end, new Date(Date.UTC(2026, 5, 1, 10, 15, 0)))).toBe(true);
       expect(isPolicyEndDatePassed(end, new Date(Date.UTC(2026, 4, 31)))).toBe(false);
       expect(utcCalendarDaysBetween(new Date(Date.UTC(2026, 0, 1)), new Date(Date.UTC(2026, 0, 31)))).toBe(30);
+    });
+  });
+
+  describe('outstandingArrears with expectedInstallmentCount', () => {
+    it('caps arrears at money target (no phantom missed after schedule complete)', () => {
+      const start = new Date(Date.UTC(2025, 10, 1));
+      const asOf = new Date(Date.UTC(2026, 7, 23));
+      const phantom = outstandingArrears({
+        policyStart: start,
+        paymentCadenceDays: 1,
+        installmentAmount: 152,
+        paidThroughAsOf: 41952,
+        asOfUtc: asOf,
+      });
+      expect(phantom).toBeGreaterThan(0);
+
+      const capped = outstandingArrears({
+        policyStart: start,
+        paymentCadenceDays: 1,
+        installmentAmount: 152,
+        paidThroughAsOf: 41952,
+        asOfUtc: asOf,
+        expectedInstallmentCount: 276,
+      });
+      expect(capped).toBe(0);
+    });
+
+    it('still reports remaining arrears when under money target past schedule', () => {
+      const start = new Date(Date.UTC(2025, 10, 1));
+      const asOf = new Date(Date.UTC(2026, 7, 23));
+      const arrears = outstandingArrears({
+        policyStart: start,
+        paymentCadenceDays: 1,
+        installmentAmount: 152,
+        paidThroughAsOf: 40000,
+        asOfUtc: asOf,
+        expectedInstallmentCount: 276,
+      });
+      expect(arrears).toBe(1952);
+    });
+  });
+
+  describe('inactive after suspended threshold', () => {
+    it('uses 15 days suspended before auto-inactive (~30 from first overdue)', () => {
+      expect(INACTIVE_AFTER_SUSPENDED_DAYS).toBe(15);
+      const suspendedAt = new Date(Date.UTC(2026, 6, 1));
+      expect(utcCalendarDaysBetween(suspendedAt, new Date(Date.UTC(2026, 6, 15)))).toBe(14);
+      expect(utcCalendarDaysBetween(suspendedAt, new Date(Date.UTC(2026, 6, 16)))).toBe(15);
+      expect(utcCalendarDaysBetween(suspendedAt, new Date(Date.UTC(2026, 6, 16)))).toBeGreaterThanOrEqual(
+        INACTIVE_AFTER_SUSPENDED_DAYS
+      );
     });
   });
 });

--- a/apps/api/src/utils/__tests__/premium-statement-math.spec.ts
+++ b/apps/api/src/utils/__tests__/premium-statement-math.spec.ts
@@ -4,7 +4,9 @@ import {
   computeExpectedPremiumThroughAsOf,
   computeMissedOrExcess,
   computePremiumDueAndExcess,
+  computePremiumMoneyTarget,
   formatMissedPaymentsAmountSide,
+  isPremiumMoneyComplete,
   isUtcCalendarDayBefore,
   parseYmdToUtcEnd,
   parseYmdToUtcStart,
@@ -86,6 +88,73 @@ describe('premium-statement-math', () => {
       });
       expect(periods).toBe(2);
       expect(expectedPremium).toBe(400);
+    });
+
+    it('caps periods at expectedInstallmentCount so calendar days past schedule do not invent debt', () => {
+      // Nathaniel-style: daily 152, eic 276 → money target 41952; far past nominal end
+      const policyStart = new Date(Date.UTC(2025, 10, 1, 0, 0, 0)); // 2025-11-01
+      const asOfFarPast = new Date(Date.UTC(2026, 7, 23, 12, 0, 0)); // ~295 days later
+      const uncapped = computeExpectedPremiumThroughAsOf({
+        policyStart,
+        statementGenerationUtc: asOfFarPast,
+        paymentCadenceDays: 1,
+        installmentAmount: 152,
+      });
+      expect(uncapped.periods).toBeGreaterThan(276);
+      expect(uncapped.expectedPremium).toBeGreaterThan(41952);
+
+      const capped = computeExpectedPremiumThroughAsOf({
+        policyStart,
+        statementGenerationUtc: asOfFarPast,
+        paymentCadenceDays: 1,
+        installmentAmount: 152,
+        expectedInstallmentCount: 276,
+      });
+      expect(capped.periods).toBe(276);
+      expect(capped.expectedPremium).toBe(41952);
+    });
+
+    it('does not raise periods when calendar periods are below eic', () => {
+      const policyStart = new Date(Date.UTC(2025, 0, 1, 0, 0, 0));
+      const asOf = new Date(Date.UTC(2025, 0, 10, 12, 0, 0));
+      const { periods, expectedPremium } = computeExpectedPremiumThroughAsOf({
+        policyStart,
+        statementGenerationUtc: asOf,
+        paymentCadenceDays: 1,
+        installmentAmount: 100,
+        expectedInstallmentCount: 276,
+      });
+      expect(periods).toBe(10);
+      expect(expectedPremium).toBe(1000);
+    });
+  });
+
+  describe('computePremiumMoneyTarget / isPremiumMoneyComplete', () => {
+    it('returns eic × premium for prepaid targets', () => {
+      expect(computePremiumMoneyTarget(276, 152)).toBe(41952);
+    });
+
+    it('returns null when eic or premium cannot form a target', () => {
+      expect(computePremiumMoneyTarget(null, 152)).toBeNull();
+      expect(computePremiumMoneyTarget(276, 0)).toBeNull();
+      expect(computePremiumMoneyTarget(0, 152)).toBeNull();
+    });
+
+    it('is complete when paid covers money target (Nathaniel paid in full)', () => {
+      expect(
+        isPremiumMoneyComplete({
+          paidTotal: 41952,
+          expectedInstallmentCount: 276,
+          installmentAmount: 152,
+        })
+      ).toBe(true);
+      expect(
+        isPremiumMoneyComplete({
+          paidTotal: 41951,
+          expectedInstallmentCount: 276,
+          installmentAmount: 152,
+        })
+      ).toBe(false);
     });
   });
 
@@ -180,6 +249,38 @@ describe('premium-statement-math', () => {
           confirmedStatuses: CONFIRMED,
         })
       ).toBeNull();
+    });
+
+    it('shows zero missed when paid equals money target even far past schedule', () => {
+      const start = new Date(Date.UTC(2025, 10, 1, 0, 0, 0));
+      const asOf = new Date(Date.UTC(2026, 7, 23, 12, 0, 0));
+      const payments = [
+        {
+          amount: 41952,
+          paymentStatus: PaymentStatus.COMPLETED,
+          expectedPaymentDate: utcDayStart(2025, 10, 1),
+        },
+      ];
+      const withoutCap = computeMissedOrExcess({
+        policyStart: start,
+        asOfUtc: asOf,
+        paymentCadenceDays: 1,
+        installmentAmount: 152,
+        payments,
+        confirmedStatuses: CONFIRMED,
+      });
+      expect(withoutCap!.premiumDue).toBeGreaterThan(0);
+
+      const withCap = computeMissedOrExcess({
+        policyStart: start,
+        asOfUtc: asOf,
+        paymentCadenceDays: 1,
+        installmentAmount: 152,
+        payments,
+        confirmedStatuses: CONFIRMED,
+        expectedInstallmentCount: 276,
+      });
+      expect(withCap).toEqual({ premiumDue: 0, excessAmount: 0 });
     });
   });
 

--- a/apps/api/src/utils/installment-count.util.ts
+++ b/apps/api/src/utils/installment-count.util.ts
@@ -58,8 +58,16 @@ export function computeMissedInstallments(params: {
   paymentCadenceDays: number;
   installmentAmount: number;
   paidExact: number;
+  expectedInstallmentCount?: number | null;
 }): InstallmentCountDisplay {
-  const { policyStart, asOfUtc, paymentCadenceDays, installmentAmount, paidExact } = params;
+  const {
+    policyStart,
+    asOfUtc,
+    paymentCadenceDays,
+    installmentAmount,
+    paidExact,
+    expectedInstallmentCount,
+  } = params;
   if (
     policyStart == null ||
     paymentCadenceDays <= 0 ||
@@ -72,6 +80,7 @@ export function computeMissedInstallments(params: {
     statementGenerationUtc: asOfUtc,
     paymentCadenceDays,
     installmentAmount,
+    expectedInstallmentCount,
   });
   const missedExact = Math.max(0, periods - paidExact);
   return formatInstallmentCount(missedExact);

--- a/apps/api/src/utils/policy-due-date.util.ts
+++ b/apps/api/src/utils/policy-due-date.util.ts
@@ -54,6 +54,7 @@ export function nextUnpaidExpectedDueDate(params: {
   installmentAmount: number;
   paidThroughAsOf: number;
   asOfUtc?: Date;
+  expectedInstallmentCount?: number | null;
 }): Date {
   const asOf = params.asOfUtc ?? new Date();
   const start = utcDayStart(
@@ -66,6 +67,7 @@ export function nextUnpaidExpectedDueDate(params: {
     statementGenerationUtc: asOf,
     paymentCadenceDays: params.paymentCadenceDays,
     installmentAmount: params.installmentAmount,
+    expectedInstallmentCount: params.expectedInstallmentCount,
   });
 
   const { premiumDue } = computePremiumDueAndExcess(expectedPremium, params.paidThroughAsOf);
@@ -99,6 +101,7 @@ export function outstandingArrears(params: {
   installmentAmount: number;
   paidThroughAsOf: number;
   asOfUtc?: Date;
+  expectedInstallmentCount?: number | null;
 }): number {
   const asOf = params.asOfUtc ?? new Date();
   const { expectedPremium } = computeExpectedPremiumThroughAsOf({
@@ -106,6 +109,7 @@ export function outstandingArrears(params: {
     statementGenerationUtc: asOf,
     paymentCadenceDays: params.paymentCadenceDays,
     installmentAmount: params.installmentAmount,
+    expectedInstallmentCount: params.expectedInstallmentCount,
   });
   return computePremiumDueAndExcess(expectedPremium, params.paidThroughAsOf).premiumDue;
 }

--- a/apps/api/src/utils/premium-statement-math.ts
+++ b/apps/api/src/utils/premium-statement-math.ts
@@ -29,14 +29,51 @@ export function parseYmdToUtcEnd(yyyyMmDd: string): Date {
 }
 
 /**
- * Expected premium through statement as-of (generation calendar day end UTC), per research:
+ * Prepaid term money target = expectedInstallmentCount × installment.
+ * Returns null when eic/premium cannot form a target (e.g. postpaid premium 0).
+ */
+export function computePremiumMoneyTarget(
+  expectedInstallmentCount: number | null | undefined,
+  installmentAmount: number
+): number | null {
+  if (
+    expectedInstallmentCount == null ||
+    expectedInstallmentCount <= 0 ||
+    !Number.isFinite(installmentAmount) ||
+    installmentAmount <= 0
+  ) {
+    return null;
+  }
+  return expectedInstallmentCount * installmentAmount;
+}
+
+/** True when confirmed paid covers the prepaid money target. */
+export function isPremiumMoneyComplete(params: {
+  paidTotal: number;
+  expectedInstallmentCount: number | null | undefined;
+  installmentAmount: number;
+}): boolean {
+  const target = computePremiumMoneyTarget(
+    params.expectedInstallmentCount,
+    params.installmentAmount
+  );
+  if (target == null) return false;
+  return params.paidTotal + 1e-9 >= target;
+}
+
+/**
+ * Expected premium through statement as-of (generation calendar day end UTC):
  * periods = floor(inclusiveDays / paymentCadenceDays), expected = periods × installmentAmount.
+ * When expectedInstallmentCount is set, periods (and thus expected) are capped so calendar
+ * days past the schedule cannot invent debt beyond the prepaid money target.
+ * Payments may still arrive before or after nominalPaymentPeriodEndDate.
  */
 export function computeExpectedPremiumThroughAsOf(params: {
   policyStart: Date;
   statementGenerationUtc: Date;
   paymentCadenceDays: number;
   installmentAmount: number;
+  expectedInstallmentCount?: number | null;
 }): { inclusiveDays: number; periods: number; expectedPremium: number } {
   const policyStartStart = utcDayStart(
     params.policyStart.getUTCFullYear(),
@@ -49,7 +86,14 @@ export function computeExpectedPremiumThroughAsOf(params: {
     params.statementGenerationUtc.getUTCDate()
   );
   const inclusiveDays = Math.max(0, utcInclusiveCalendarDays(policyStartStart, asOfEnd));
-  const periods = Math.floor(inclusiveDays / params.paymentCadenceDays);
+  let periods = Math.floor(inclusiveDays / params.paymentCadenceDays);
+  if (
+    params.expectedInstallmentCount != null &&
+    params.expectedInstallmentCount > 0 &&
+    periods > params.expectedInstallmentCount
+  ) {
+    periods = params.expectedInstallmentCount;
+  }
   const expectedPremium = periods * params.installmentAmount;
   return { inclusiveDays, periods, expectedPremium };
 }
@@ -94,6 +138,7 @@ export function computeMissedOrExcess(params: {
   installmentAmount: number;
   payments: Array<{ amount: unknown; paymentStatus: string; expectedPaymentDate: Date }>;
   confirmedStatuses: readonly string[];
+  expectedInstallmentCount?: number | null;
 }): { premiumDue: number; excessAmount: number } | null {
   if (params.paymentCadenceDays <= 0 || params.installmentAmount <= 0) {
     return null;
@@ -113,6 +158,7 @@ export function computeMissedOrExcess(params: {
     statementGenerationUtc: params.asOfUtc,
     paymentCadenceDays: params.paymentCadenceDays,
     installmentAmount: params.installmentAmount,
+    expectedInstallmentCount: params.expectedInstallmentCount,
   });
   const paidThroughAsOf = sumConfirmedPaidThroughAsOf(
     params.payments,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes prepaid phantom arrears after the schedule money target is paid (Nathaniel-style `eic × premium`), and aligns inactive timing with product (~30 days from first overdue).

## Changes
- Cap `computeExpectedPremiumThroughAsOf` / arrears / missed at `expectedInstallmentCount` (money target helper; payments may still arrive before/after nominal end)
- Add `premiumCompleted` / `premiumCompletedAt`; set when paid ≥ target; grace/suspend/inactive skip when complete
- `INACTIVE_AFTER_SUSPENDED_DAYS = 15` (was 30 days suspended)
- Unit tests for money-target cap, `isPremiumMoneyComplete`, arrears cap, and 15-day inactive threshold
- Migration `20260823150000_policy_premium_completed`

## Out of scope
- Bulk status reactivation / prepaid status audit (next task)
- Postpaid money-complete behavior

## Verification
- [x] Unit tests: `premium-statement-math.spec.ts`, `policy-due-date.util.spec.ts` (29 passed)
- [x] Root `pnpm lint` (0 errors)
- [x] Root `pnpm build` succeeded
- [ ] Deploy migration on target envs before relying on `premiumCompleted`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8fc4ae5b-5900-4014-adc6-db5a52bd24ad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8fc4ae5b-5900-4014-adc6-db5a52bd24ad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

