### PR TITLE
Add additional product for existing customers

### DIFF
--- a/apps/agent-registration/src/app/(main)/admin/customer/[customerId]/add-product/_lib/wizard-state.ts
+++ b/apps/agent-registration/src/app/(main)/admin/customer/[customerId]/add-product/_lib/wizard-state.ts
@@ -1,0 +1,74 @@
+export type AddProductWizardState = {
+  schemeId: number | null;
+  schemeName: string;
+  parentsSupported: boolean;
+  isPostpaid: boolean;
+  packageId: number | null;
+  packageName: string;
+  packageSlug: string | null;
+  packageSchemeId: number | null;
+  packagePlanId: number | null;
+  planName: string;
+  occupyingBlocked: boolean;
+  occupyingMessage: string;
+  existingDependantIds: string[];
+  newSpouses: Array<Record<string, string>>;
+  newChildren: Array<Record<string, string>>;
+  newParents: Array<Record<string, string>>;
+  beneficiaryId: string | null;
+  newBeneficiary: Record<string, string> | null;
+  extraSpouseCount: number;
+  householdSize: number;
+  familyCategoryKey: string;
+  premium: number;
+  annualPremium: number;
+  frequency: string;
+  skipPayment: boolean;
+};
+
+export const emptyWizardState = (): AddProductWizardState => ({
+  schemeId: null,
+  schemeName: '',
+  parentsSupported: false,
+  isPostpaid: false,
+  packageId: null,
+  packageName: '',
+  packageSlug: null,
+  packageSchemeId: null,
+  packagePlanId: null,
+  planName: '',
+  occupyingBlocked: false,
+  occupyingMessage: '',
+  existingDependantIds: [],
+  newSpouses: [],
+  newChildren: [],
+  newParents: [],
+  beneficiaryId: null,
+  newBeneficiary: null,
+  extraSpouseCount: 0,
+  householdSize: 1,
+  familyCategoryKey: '',
+  premium: 0,
+  annualPremium: 0,
+  frequency: '',
+  skipPayment: false,
+});
+
+export function wizardKey(customerId: string): string {
+  return `add-product-wizard-${customerId}`;
+}
+
+export function loadWizard(customerId: string): AddProductWizardState {
+  if (typeof window === 'undefined') return emptyWizardState();
+  const raw = sessionStorage.getItem(wizardKey(customerId));
+  if (!raw) return emptyWizardState();
+  try {
+    return { ...emptyWizardState(), ...JSON.parse(raw) };
+  } catch {
+    return emptyWizardState();
+  }
+}
+
+export function saveWizard(customerId: string, state: AddProductWizardState): void {
+  sessionStorage.setItem(wizardKey(customerId), JSON.stringify(state));
+}

--- a/apps/agent-registration/src/app/(main)/admin/customer/[customerId]/add-product/beneficiary/page.tsx
+++ b/apps/agent-registration/src/app/(main)/admin/customer/[customerId]/add-product/beneficiary/page.tsx
@@ -18,7 +18,7 @@ export default function AddProductBeneficiaryStep() {
   const [creatingNew, setCreatingNew] = useState(false);
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
-  const [relationship, setRelationship] = useState('spouse');
+  const [relationship] = useState('spouse');
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {

--- a/apps/agent-registration/src/app/(main)/admin/customer/[customerId]/add-product/beneficiary/page.tsx
+++ b/apps/agent-registration/src/app/(main)/admin/customer/[customerId]/add-product/beneficiary/page.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { getCustomerDetails, type CustomerDetailData } from '@/lib/api';
+import { loadWizard, saveWizard } from '../_lib/wizard-state';
+
+export default function AddProductBeneficiaryStep() {
+  const params = useParams();
+  const router = useRouter();
+  const customerId = params.customerId as string;
+  const [details, setDetails] = useState<CustomerDetailData | null>(null);
+  const [beneficiaryId, setBeneficiaryId] = useState<string>('');
+  const [creatingNew, setCreatingNew] = useState(false);
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [relationship, setRelationship] = useState('spouse');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const saved = loadWizard(customerId);
+    if (!saved.packageSchemeId) {
+      router.replace(`/admin/customer/${customerId}/add-product`);
+      return;
+    }
+    if (saved.beneficiaryId) setBeneficiaryId(saved.beneficiaryId);
+    void getCustomerDetails(customerId).then((res) => setDetails(res.data));
+  }, [customerId, router]);
+
+  const people = (details?.beneficiaries ?? []).filter((b) => !b.deletedAt);
+
+  const handleNext = () => {
+    setError(null);
+    if (!creatingNew && !beneficiaryId) {
+      setError('Select an existing next of kin or add a new one.');
+      return;
+    }
+    if (creatingNew && (!firstName.trim() || !lastName.trim())) {
+      setError('First and last name are required for a new next of kin.');
+      return;
+    }
+    const wizard = loadWizard(customerId);
+    saveWizard(customerId, {
+      ...wizard,
+      beneficiaryId: creatingNew ? null : beneficiaryId,
+      newBeneficiary: creatingNew
+        ? {
+            firstName: firstName.trim(),
+            lastName: lastName.trim(),
+            relationship,
+            gender: 'female',
+            dateOfBirth: '1990-01-01',
+            percentage: '100',
+          }
+        : null,
+    });
+    router.push(`/admin/customer/${customerId}/add-product/payment`);
+  };
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      <h1 className="text-2xl font-bold">Next of kin</h1>
+      <Card>
+        <CardHeader>
+          <CardTitle>Exactly one beneficiary at 100%</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            {people.map((b) => (
+              <label key={b.id} className="flex items-center gap-2 text-sm">
+                <input
+                  type="radio"
+                  name="nok"
+                  checked={!creatingNew && beneficiaryId === b.id}
+                  onChange={() => {
+                    setCreatingNew(false);
+                    setBeneficiaryId(b.id);
+                  }}
+                />
+                {b.firstName} {b.lastName}
+              </label>
+            ))}
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="radio"
+                name="nok"
+                checked={creatingNew}
+                onChange={() => {
+                  setCreatingNew(true);
+                  setBeneficiaryId('');
+                }}
+              />
+              Add a new next of kin
+            </label>
+          </div>
+          {creatingNew && (
+            <div className="grid grid-cols-2 gap-2">
+              <div>
+                <Label>First name</Label>
+                <Input value={firstName} onChange={(e) => setFirstName(e.target.value)} />
+              </div>
+              <div>
+                <Label>Last name</Label>
+                <Input value={lastName} onChange={(e) => setLastName(e.target.value)} />
+              </div>
+            </div>
+          )}
+          {error && <p className="text-sm text-destructive">{error}</p>}
+          <div className="flex justify-between">
+            <Button type="button" variant="outline" onClick={() => router.push(`/admin/customer/${customerId}/add-product/household`)}>
+              Back
+            </Button>
+            <Button type="button" onClick={handleNext}>Continue</Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/agent-registration/src/app/(main)/admin/customer/[customerId]/add-product/household/page.tsx
+++ b/apps/agent-registration/src/app/(main)/admin/customer/[customerId]/add-product/household/page.tsx
@@ -1,0 +1,205 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { getCustomerDetails, getPackagePricingBySlug, type CustomerDetailData } from '@/lib/api';
+import { extraSpouseAddonCount, householdCapsFromBands } from '@/lib/family-category';
+import { pricingBandsFromApi } from '@/lib/package-pricing-ui';
+import { loadWizard, saveWizard } from '../_lib/wizard-state';
+
+function emptyPerson() {
+  return { firstName: '', lastName: '', gender: 'female', dateOfBirth: '', phoneNumber: '', idNumber: '', idType: 'national' };
+}
+
+export default function AddProductHouseholdStep() {
+  const params = useParams();
+  const router = useRouter();
+  const customerId = params.customerId as string;
+  const [details, setDetails] = useState<CustomerDetailData | null>(null);
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [newSpouses, setNewSpouses] = useState<Array<ReturnType<typeof emptyPerson>>>([]);
+  const [newChildren, setNewChildren] = useState<Array<ReturnType<typeof emptyPerson>>>([]);
+  const [newParents, setNewParents] = useState<
+    Array<ReturnType<typeof emptyPerson> & { relationship: string }>
+  >([]);
+  const [error, setError] = useState<string | null>(null);
+  const [caps, setCaps] = useState(householdCapsFromBands([], false));
+
+  useEffect(() => {
+    const saved = loadWizard(customerId);
+    if (!saved.packageSchemeId) {
+      router.replace(`/admin/customer/${customerId}/add-product`);
+      return;
+    }
+    setSelectedIds(saved.existingDependantIds);
+    void getCustomerDetails(customerId).then((res) => setDetails(res.data));
+    if (saved.packageSlug) {
+      void getPackagePricingBySlug(saved.packageSlug).then((pricing) => {
+        setCaps(householdCapsFromBands(pricingBandsFromApi(pricing), saved.parentsSupported));
+      });
+    }
+  }, [customerId, router]);
+
+  const spouses = details?.dependants.filter((d) => d.relationship === 'SPOUSE' && !d.deletedAt) ?? [];
+  const children = details?.dependants.filter((d) => d.relationship === 'CHILD' && !d.deletedAt) ?? [];
+  const existingParents = details?.parents.filter((p) => !p.deletedAt) ?? [];
+
+  const extraCount = useMemo(() => {
+    const selected = [...spouses, ...children].filter((d) => selectedIds.includes(d.id)).length;
+    return selected + newSpouses.length + newChildren.length;
+  }, [spouses, children, selectedIds, newSpouses.length, newChildren.length]);
+
+  const toggle = (id: string) => {
+    setSelectedIds((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]));
+  };
+
+  const handleNext = () => {
+    setError(null);
+    if (caps.hasFamilyBands && extraCount > caps.maxExtraMembers) {
+      setError(`This package allows at most ${caps.maxExtraMembers} additional spouse(s)/child(ren).`);
+      return;
+    }
+    if (!caps.hasFamilyBands && extraCount > 0) {
+      setError('This package is member-only. Household members cannot be enrolled.');
+      return;
+    }
+    const selectedSpouses = spouses.filter((d) => selectedIds.includes(d.id)).length;
+    const wizard = loadWizard(customerId);
+    saveWizard(customerId, {
+      ...wizard,
+      existingDependantIds: selectedIds,
+      newSpouses: newSpouses.filter((s) => s.firstName.trim()),
+      newChildren: newChildren.filter((c) => c.firstName.trim()),
+      newParents: newParents.filter((p) => p.firstName.trim()),
+      extraSpouseCount: extraSpouseAddonCount(selectedSpouses + newSpouses.filter((s) => s.firstName.trim()).length),
+      householdSize: 1 + extraCount,
+    });
+    router.push(`/admin/customer/${customerId}/add-product/beneficiary`);
+  };
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      <h1 className="text-2xl font-bold">Household</h1>
+      <Card>
+        <CardHeader>
+          <CardTitle>Who should join this policy?</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {!caps.showSpouse && !caps.showChildren && (
+            <p className="text-sm text-muted-foreground">Member-only package. Spouse and children are hidden.</p>
+          )}
+          {caps.showSpouse && (
+            <div className="space-y-2">
+              <Label>Existing spouses</Label>
+              {spouses.map((s) => (
+                <label key={s.id} className="flex items-center gap-2 text-sm">
+                  <Checkbox checked={selectedIds.includes(s.id)} onCheckedChange={() => toggle(s.id)} />
+                  {s.firstName} {s.lastName}
+                </label>
+              ))}
+              <Button type="button" variant="outline" size="sm" disabled={extraCount >= caps.maxExtraMembers} onClick={() => setNewSpouses((p) => [...p, emptyPerson()])}>
+                Add new spouse
+              </Button>
+              {newSpouses.map((s, i) => (
+                <div key={i} className="grid grid-cols-2 gap-2">
+                  <Input placeholder="First name" value={s.firstName} onChange={(e) => setNewSpouses((p) => p.map((x, idx) => (idx === i ? { ...x, firstName: e.target.value } : x)))} />
+                  <Input placeholder="Last name" value={s.lastName} onChange={(e) => setNewSpouses((p) => p.map((x, idx) => (idx === i ? { ...x, lastName: e.target.value } : x)))} />
+                </div>
+              ))}
+            </div>
+          )}
+          {caps.showChildren && (
+            <div className="space-y-2">
+              <Label>Existing children</Label>
+              {children.map((c) => (
+                <label key={c.id} className="flex items-center gap-2 text-sm">
+                  <Checkbox checked={selectedIds.includes(c.id)} onCheckedChange={() => toggle(c.id)} />
+                  {c.firstName} {c.lastName}
+                </label>
+              ))}
+              <Button type="button" variant="outline" size="sm" disabled={extraCount >= caps.maxExtraMembers} onClick={() => setNewChildren((p) => [...p, emptyPerson()])}>
+                Add new child
+              </Button>
+              {newChildren.map((c, i) => (
+                <div key={i} className="grid grid-cols-2 gap-2">
+                  <Input placeholder="First name" value={c.firstName} onChange={(e) => setNewChildren((p) => p.map((x, idx) => (idx === i ? { ...x, firstName: e.target.value } : x)))} />
+                  <Input placeholder="Last name" value={c.lastName} onChange={(e) => setNewChildren((p) => p.map((x, idx) => (idx === i ? { ...x, lastName: e.target.value } : x)))} />
+                </div>
+              ))}
+            </div>
+          )}
+          {caps.showParents && (
+            <div className="space-y-2">
+              <Label>Parents (do not count toward family size)</Label>
+              {existingParents.length > 0 && (
+                <p className="text-xs text-muted-foreground">
+                  Existing: {existingParents.map((p) => `${p.firstName} ${p.lastName}`).join(', ')}
+                </p>
+              )}
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() =>
+                  setNewParents((p) => [
+                    ...p,
+                    { ...emptyPerson(), gender: 'female', relationship: 'MOTHER' },
+                  ])
+                }
+              >
+                Add new parent
+              </Button>
+              {newParents.map((parent, i) => (
+                <div key={i} className="grid grid-cols-3 gap-2">
+                  <Input
+                    placeholder="First name"
+                    value={parent.firstName}
+                    onChange={(e) =>
+                      setNewParents((p) =>
+                        p.map((x, idx) => (idx === i ? { ...x, firstName: e.target.value } : x))
+                      )
+                    }
+                  />
+                  <Input
+                    placeholder="Last name"
+                    value={parent.lastName}
+                    onChange={(e) =>
+                      setNewParents((p) =>
+                        p.map((x, idx) => (idx === i ? { ...x, lastName: e.target.value } : x))
+                      )
+                    }
+                  />
+                  <select
+                    className="h-9 rounded-md border bg-background px-2 text-sm"
+                    value={parent.relationship}
+                    onChange={(e) =>
+                      setNewParents((p) =>
+                        p.map((x, idx) => (idx === i ? { ...x, relationship: e.target.value } : x))
+                      )
+                    }
+                  >
+                    <option value="MOTHER">Mother</option>
+                    <option value="FATHER">Father</option>
+                    <option value="MOTHER_IN_LAW">Mother-in-law</option>
+                    <option value="FATHER_IN_LAW">Father-in-law</option>
+                  </select>
+                </div>
+              ))}
+            </div>
+          )}
+          <p className="text-xs text-muted-foreground">Extra members: {extraCount}/{caps.maxExtraMembers}. Parents do not count toward this cap.</p>
+          {error && <p className="text-sm text-destructive">{error}</p>}
+          <div className="flex justify-between">
+            <Button type="button" variant="outline" onClick={() => router.push(`/admin/customer/${customerId}/add-product`)}>Back</Button>
+            <Button type="button" onClick={handleNext}>Continue</Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/agent-registration/src/app/(main)/admin/customer/[customerId]/add-product/household/page.tsx
+++ b/apps/agent-registration/src/app/(main)/admin/customer/[customerId]/add-product/household/page.tsx
@@ -45,8 +45,14 @@ export default function AddProductHouseholdStep() {
     }
   }, [customerId, router]);
 
-  const spouses = details?.dependants.filter((d) => d.relationship === 'SPOUSE' && !d.deletedAt) ?? [];
-  const children = details?.dependants.filter((d) => d.relationship === 'CHILD' && !d.deletedAt) ?? [];
+  const spouses = useMemo(
+    () => details?.dependants.filter((d) => d.relationship === 'SPOUSE' && !d.deletedAt) ?? [],
+    [details]
+  );
+  const children = useMemo(
+    () => details?.dependants.filter((d) => d.relationship === 'CHILD' && !d.deletedAt) ?? [],
+    [details]
+  );
   const existingParents = details?.parents.filter((p) => !p.deletedAt) ?? [];
 
   const extraCount = useMemo(() => {

--- a/apps/agent-registration/src/app/(main)/admin/customer/[customerId]/add-product/page.tsx
+++ b/apps/agent-registration/src/app/(main)/admin/customer/[customerId]/add-product/page.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import SchemeTypeahead from '@/components/scheme-typeahead';
+import {
+  getCustomerPoliciesList,
+  getPackagePlans,
+  listPackagesForSchemes,
+  type Package,
+  type Plan,
+  type Scheme,
+} from '@/lib/api';
+import { loadWizard, saveWizard } from './_lib/wizard-state';
+
+export default function AddProductProductStep() {
+  const params = useParams();
+  const router = useRouter();
+  const customerId = params.customerId as string;
+
+  const [scheme, setScheme] = useState<Scheme | null>(null);
+  const [packages, setPackages] = useState<Package[]>([]);
+  const [packageId, setPackageId] = useState<number | null>(null);
+  const [plans, setPlans] = useState<Plan[]>([]);
+  const [planId, setPlanId] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loadingPackages, setLoadingPackages] = useState(false);
+
+  useEffect(() => {
+    const saved = loadWizard(customerId);
+    if (saved.schemeId) {
+      setScheme({
+        id: saved.schemeId,
+        name: saved.schemeName,
+        parentsSupported: saved.parentsSupported,
+      });
+      setPackageId(saved.packageId);
+      setPlanId(saved.packagePlanId);
+    }
+  }, [customerId]);
+
+  useEffect(() => {
+    if (!scheme) {
+      setPackages([]);
+      setPackageId(null);
+      setPlans([]);
+      setPlanId(null);
+      return;
+    }
+    setLoadingPackages(true);
+    void listPackagesForSchemes([scheme.id])
+      .then((list) => setPackages(list.filter((p) => p.isActive !== false)))
+      .catch(() => setPackages([]))
+      .finally(() => setLoadingPackages(false));
+  }, [scheme]);
+
+  useEffect(() => {
+    if (!packageId) {
+      setPlans([]);
+      setPlanId(null);
+      return;
+    }
+    void getPackagePlans(packageId)
+      .then((list) => setPlans(list.filter((p) => p.isActive !== false)))
+      .catch(() => setPlans([]));
+  }, [packageId]);
+
+  const selectedPackage = packages.find((p) => p.id === packageId) ?? null;
+
+  const handleNext = async () => {
+    setError(null);
+    if (!scheme || !selectedPackage || !planId) {
+      setError('Select a scheme, package, and plan.');
+      return;
+    }
+    const occupying = await getCustomerPoliciesList(customerId);
+    const samePackageOccupying = occupying.data.some(
+      (p) =>
+        (p.packageId != null
+          ? p.packageId === selectedPackage.id
+          : p.packageName === selectedPackage.name) &&
+        (p.status === 'ACTIVE' || p.status === 'PENDING_ACTIVATION' || p.status === 'SUSPENDED')
+    );
+    const plan = plans.find((p) => p.id === planId);
+    const next = {
+      ...loadWizard(customerId),
+      schemeId: scheme.id,
+      schemeName: scheme.name,
+      parentsSupported: Boolean(scheme.parentsSupported),
+      isPostpaid: Boolean(selectedPackage.isPostpaid),
+      packageId: selectedPackage.id,
+      packageName: selectedPackage.name,
+      packageSlug: selectedPackage.slug ?? null,
+      packageSchemeId: selectedPackage.packageSchemeId ?? null,
+      packagePlanId: planId,
+      planName: plan?.name ?? '',
+      occupyingBlocked: samePackageOccupying,
+      occupyingMessage: samePackageOccupying
+        ? 'This customer already has an occupying policy for this package. Deactivate it manually before adding the same package again.'
+        : '',
+    };
+    saveWizard(customerId, next);
+    if (samePackageOccupying) {
+      setError(next.occupyingMessage);
+      return;
+    }
+    router.push(`/admin/customer/${customerId}/add-product/household`);
+  };
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">Add product</h1>
+        <p className="text-muted-foreground">Search a scheme, then choose its package and plan.</p>
+      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle>Product</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <SchemeTypeahead selected={scheme} onSelect={setScheme} />
+          <div>
+            <Label>Package *</Label>
+            <Select
+              value={packageId?.toString() ?? ''}
+              onValueChange={(v) => setPackageId(Number(v))}
+              disabled={!scheme || loadingPackages}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder={loadingPackages ? 'Loading…' : 'Select package'} />
+              </SelectTrigger>
+              <SelectContent>
+                {packages.map((pkg) => (
+                  <SelectItem key={pkg.id} value={String(pkg.id)}>
+                    {pkg.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div>
+            <Label>Plan *</Label>
+            <Select
+              value={planId?.toString() ?? ''}
+              onValueChange={(v) => setPlanId(Number(v))}
+              disabled={!packageId}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Select plan" />
+              </SelectTrigger>
+              <SelectContent>
+                {plans.map((plan) => (
+                  <SelectItem key={plan.id} value={String(plan.id)}>
+                    {plan.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          {error && <p className="text-sm text-destructive">{error}</p>}
+          <div className="flex justify-between">
+            <Button type="button" variant="outline" onClick={() => router.push(`/admin/customer/${customerId}?tab=products`)}>
+              Cancel
+            </Button>
+            <Button type="button" onClick={() => void handleNext()}>
+              Continue
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/agent-registration/src/app/(main)/admin/customer/[customerId]/add-product/payment/page.tsx
+++ b/apps/agent-registration/src/app/(main)/admin/customer/[customerId]/add-product/payment/page.tsx
@@ -1,0 +1,199 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import {
+  createAdditionalPolicy,
+  getCustomerDetails,
+  getInternalConfig,
+  getPackagePricingBySlug,
+  initiateStkPush,
+} from '@/lib/api';
+import {
+  computeAnnualPremium,
+  computeInstallmentPremium,
+  isFrequencySupportedByPackage,
+  type PackagePaymentFrequencyOption,
+} from '@/lib/insurance-installment';
+import { extraSpouseAddonCount, resolveFamilyCategoryForHousehold } from '@/lib/family-category';
+import { mapPackagePricingToUi, pricingBandsFromApi } from '@/lib/package-pricing-ui';
+import { loadWizard } from '../_lib/wizard-state';
+
+export default function AddProductPaymentStep() {
+  const params = useParams();
+  const router = useRouter();
+  const customerId = params.customerId as string;
+  const wizard = loadWizard(customerId);
+  const [frequency, setFrequency] = useState('');
+  const [phone, setPhone] = useState('');
+  const [stkEnabled, setStkEnabled] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [premium, setPremium] = useState(0);
+  const [annual, setAnnual] = useState(0);
+  const [freqs, setFreqs] = useState<PackagePaymentFrequencyOption[]>([]);
+  const extraSpouse = wizard.extraSpouseCount;
+
+  useEffect(() => {
+    if (!wizard.packageSchemeId) {
+      router.replace(`/admin/customer/${customerId}/add-product`);
+      return;
+    }
+    void getCustomerDetails(customerId).then((res) => {
+      setPhone(res.data.customer.phoneNumber ?? '');
+    });
+    void getInternalConfig().then((c) => setStkEnabled(c.mpesaStkPushEnabled)).catch(() => setStkEnabled(false));
+    if (wizard.packageSlug) {
+      void getPackagePricingBySlug(wizard.packageSlug).then((data) => {
+        const ui = mapPackagePricingToUi(data);
+        const planKey = Object.keys(ui.plans).find(
+          (k) => ui.plans[k].name.toLowerCase() === wizard.planName.toLowerCase()
+        );
+        const bands = pricingBandsFromApi(data);
+        const resolved = resolveFamilyCategoryForHousehold(wizard.householdSize, bands);
+        const categoryKey = resolved.ok ? resolved.categoryKey : Object.keys(ui.plans[planKey ?? '']?.categories ?? {})[0];
+        const plan = planKey ? ui.plans[planKey] : undefined;
+        const category = plan && categoryKey ? plan.categories[categoryKey] : undefined;
+        const spouseUnits = extraSpouseAddonCount(extraSpouse + 1, categoryKey);
+        if (plan && category) {
+          const lookup = {
+            daily: (category.daily ?? 0) + spouseUnits * (plan.additional_spouse.daily ?? 0),
+            weekly: (category.weekly ?? 0) + spouseUnits * (plan.additional_spouse.weekly ?? 0),
+            monthly: (category.monthly ?? 0) + spouseUnits * (plan.additional_spouse.monthly ?? 0),
+            annually: (category.annually ?? 0) + spouseUnits * (plan.additional_spouse.annually ?? 0),
+          };
+          setPremium(lookup.monthly ?? lookup.daily ?? 0);
+          setAnnual(computeAnnualPremium({ daily: lookup.daily, lookupRates: lookup }));
+        }
+        setFreqs(
+          Object.entries(data.installmentCounts ?? {}).map(([frequency, installmentCount]) => ({
+            frequency,
+            installmentCount,
+          }))
+        );
+      });
+    }
+  }, [customerId, extraSpouse, router, wizard.householdSize, wizard.packageSchemeId, wizard.packageSlug, wizard.planName]);
+
+  const installment = useMemo(() => {
+    if (!frequency) return premium;
+    return computeInstallmentPremium({
+      frequency,
+      daily: premium,
+      weekly: premium,
+      lookupRates: { monthly: premium, annually: annual },
+    });
+  }, [annual, frequency, premium]);
+
+  const submit = async (skipPayment: boolean) => {
+    setError(null);
+    if (!wizard.isPostpaid && !skipPayment && !frequency) {
+      setError('Select a payment frequency.');
+      return;
+    }
+    if (wizard.packageSchemeId == null || wizard.packagePlanId == null) {
+      setError('Product selection is incomplete.');
+      return;
+    }
+    if (frequency && !wizard.isPostpaid && !isFrequencySupportedByPackage(frequency, freqs)) {
+      setError('Selected frequency is not supported for this package.');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const result = await createAdditionalPolicy(customerId, {
+        packageSchemeId: wizard.packageSchemeId,
+        packagePlanId: wizard.packagePlanId,
+        frequency: (wizard.isPostpaid ? 'MONTHLY' : frequency || 'MONTHLY') as 'MONTHLY',
+        premium: installment || premium,
+        annualPremium: annual,
+        productName: `${wizard.packageName} ${wizard.planName}`.trim(),
+        existingDependantIds: wizard.existingDependantIds,
+        newSpouses: wizard.newSpouses,
+        newChildren: wizard.newChildren,
+        newParents: wizard.newParents,
+        beneficiaryId: wizard.beneficiaryId ?? undefined,
+        newBeneficiary: wizard.newBeneficiary ?? undefined,
+        skipPayment: skipPayment || wizard.isPostpaid,
+      });
+      if (!skipPayment && !wizard.isPostpaid && stkEnabled && result.policy.paymentAcNumber) {
+        await initiateStkPush({
+          phoneNumber: phone,
+          amount: installment || premium,
+          accountReference: result.policy.paymentAcNumber,
+          transactionDesc: `Premium for additional product ${result.policy.productName}`,
+        });
+      }
+      sessionStorage.setItem(
+        `add-product-pan-${customerId}`,
+        result.policy.paymentAcNumber ?? ''
+      );
+      sessionStorage.removeItem(`add-product-wizard-${customerId}`);
+      router.push(`/admin/customer/${customerId}?tab=products`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to add product');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      <h1 className="text-2xl font-bold">Payment</h1>
+      <Card>
+        <CardHeader>
+          <CardTitle>Summary</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 text-sm">
+          <div className="flex justify-between"><span>Package / plan</span><span>{wizard.packageName} {wizard.planName}</span></div>
+          <div className="flex justify-between"><span>Family size</span><span>{wizard.householdSize}</span></div>
+          <div className="flex justify-between"><span>Extra spouses billed</span><span>{wizard.extraSpouseCount}</span></div>
+          <div className="flex justify-between"><span>Derived premium</span><span>{installment || premium}</span></div>
+          {!wizard.isPostpaid && (
+            <div>
+              <Label>Frequency *</Label>
+              <Select value={frequency} onValueChange={setFrequency}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select frequency" />
+                </SelectTrigger>
+                <SelectContent>
+                  {freqs.map((pf) => (
+                    <SelectItem key={pf.frequency} value={pf.frequency}>{pf.frequency}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+          {!wizard.isPostpaid && (
+            <div>
+              <Label>Phone</Label>
+              <Input value={phone} onChange={(e) => setPhone(e.target.value)} />
+            </div>
+          )}
+          {wizard.isPostpaid && (
+            <p className="text-muted-foreground">Postpaid products never send STK. The policy is created as pending activation.</p>
+          )}
+          {error && <p className="text-sm text-destructive">{error}</p>}
+          <div className="flex justify-between gap-2">
+            <Button type="button" variant="outline" onClick={() => router.push(`/admin/customer/${customerId}/add-product/beneficiary`)}>Back</Button>
+            <div className="flex gap-2">
+              {!wizard.isPostpaid && (
+                <Button type="button" variant="outline" disabled={submitting} onClick={() => void submit(true)}>
+                  Skip payment
+                </Button>
+              )}
+              <Button type="button" disabled={submitting} onClick={() => void submit(wizard.isPostpaid)}>
+                {wizard.isPostpaid ? 'Create policy' : 'Send STK'}
+              </Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/agent-registration/src/app/(main)/admin/customer/[customerId]/page.tsx
+++ b/apps/agent-registration/src/app/(main)/admin/customer/[customerId]/page.tsx
@@ -182,7 +182,11 @@ export default function CustomerDetailPage() {
         </TabsContent>
 
         <TabsContent value="products">
-          <ProductsTab customerId={customerId} basePath="admin" />
+          <ProductsTab
+            customerId={customerId}
+            basePath="admin"
+            customerStatus={customerData.customer.status}
+          />
         </TabsContent>
         <TabsContent value="payments">
           <PaymentsTab customerId={customerId} />

--- a/apps/agent-registration/src/app/(main)/customer/[customerId]/_components/modify-product-dialog.tsx
+++ b/apps/agent-registration/src/app/(main)/customer/[customerId]/_components/modify-product-dialog.tsx
@@ -123,14 +123,14 @@ export default function ModifyProductDialog({
     if (!plan) return null;
     const cat = plan.categories[options.familyCategory];
     if (!cat) return null;
-    const spouse = options.additionalSpouse;
-    const daily = (cat.daily ?? 0) + (spouse ? plan.additional_spouse.daily ?? 0 : 0);
-    const weekly = (cat.weekly ?? 0) + (spouse ? plan.additional_spouse.weekly ?? 0 : 0);
+    const spouseUnits = options.extraSpouseCount ?? (options.additionalSpouse ? 1 : 0);
+    const daily = (cat.daily ?? 0) + spouseUnits * (plan.additional_spouse.daily ?? 0);
+    const weekly = (cat.weekly ?? 0) + spouseUnits * (plan.additional_spouse.weekly ?? 0);
     const lookupRates: PricingRateBand = {
       daily,
       weekly,
-      monthly: (cat.monthly ?? 0) + (spouse ? plan.additional_spouse.monthly ?? 0 : 0),
-      annually: (cat.annually ?? 0) + (spouse ? plan.additional_spouse.annually ?? 0 : 0),
+      monthly: (cat.monthly ?? 0) + spouseUnits * (plan.additional_spouse.monthly ?? 0),
+      annually: (cat.annually ?? 0) + spouseUnits * (plan.additional_spouse.annually ?? 0),
     };
     return { daily, weekly, lookupRates };
   }, [pricing, options, selectedPlan]);

--- a/apps/agent-registration/src/app/(main)/customer/[customerId]/_components/policy-detail-view.tsx
+++ b/apps/agent-registration/src/app/(main)/customer/[customerId]/_components/policy-detail-view.tsx
@@ -314,6 +314,26 @@ export default function PolicyDetailView({
           </CardContent>
         </Card>
       </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Next of kin</CardTitle>
+          <CardDescription>This policy&apos;s beneficiary (100%)</CardDescription>
+        </CardHeader>
+        <CardContent className="text-sm">
+          {data.nextOfKin ? (
+            <div className="space-y-1">
+              <p className="font-medium">
+                {data.nextOfKin.firstName} {data.nextOfKin.middleName} {data.nextOfKin.lastName}
+              </p>
+              <p className="text-muted-foreground">{data.nextOfKin.relationship ?? '—'}</p>
+              <p className="text-muted-foreground">{data.nextOfKin.percentage}%</p>
+            </div>
+          ) : (
+            <p className="text-muted-foreground">No next of kin linked to this policy.</p>
+          )}
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/apps/agent-registration/src/app/(main)/customer/[customerId]/_components/products-tab.tsx
+++ b/apps/agent-registration/src/app/(main)/customer/[customerId]/_components/products-tab.tsx
@@ -42,6 +42,7 @@ interface ProductsTabProps {
   customerId: string;
   /** 'admin' | 'dashboard' | 'agent' — used for policy detail link */
   basePath: 'admin' | 'dashboard' | 'agent';
+  customerStatus?: string;
 }
 
 type RowAction =
@@ -54,7 +55,7 @@ type RowAction =
   | 'terminate'
   | null;
 
-export default function ProductsTab({ customerId, basePath }: ProductsTabProps) {
+export default function ProductsTab({ customerId, basePath, customerStatus }: ProductsTabProps) {
   const router = useRouter();
   const { isAdmin } = useAuth();
   const showAdminActions = basePath === 'admin' && isAdmin;
@@ -69,6 +70,11 @@ export default function ProductsTab({ customerId, basePath }: ProductsTabProps) 
   useEffect(() => {
     if (customerId) {
       void loadProducts();
+    }
+    const addedPan = sessionStorage.getItem(`add-product-pan-${customerId}`);
+    if (addedPan) {
+      setSuccessMessage(`Additional product created. Payment account number: ${addedPan}`);
+      sessionStorage.removeItem(`add-product-pan-${customerId}`);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [customerId]);
@@ -159,12 +165,31 @@ export default function ProductsTab({ customerId, basePath }: ProductsTabProps) 
   return (
     <>
       <Card>
-        <CardHeader>
-          <CardTitle>Products</CardTitle>
-          <CardDescription>
-            Policies this customer is enrolled in. Click a row to view product and enrollment
-            details.
-          </CardDescription>
+        <CardHeader className="flex flex-row items-start justify-between gap-4">
+          <div>
+            <CardTitle>Products</CardTitle>
+            <CardDescription>
+              Policies this customer is enrolled in. Click a row to view product and enrollment
+              details.
+            </CardDescription>
+          </div>
+          {showAdminActions && (
+            <Button
+              type="button"
+              disabled={
+                customerStatus === 'TERMINATED' ||
+                policies.some((p) => p.status === 'TERMINATED')
+              }
+              title={
+                customerStatus === 'TERMINATED' || policies.some((p) => p.status === 'TERMINATED')
+                  ? 'Cannot add a product while the customer or any policy is terminated'
+                  : 'Add another package for this customer'
+              }
+              onClick={() => router.push(`/admin/customer/${customerId}/add-product`)}
+            >
+              Add product
+            </Button>
+          )}
         </CardHeader>
         <CardContent>
           {successMessage && (

--- a/apps/agent-registration/src/app/(main)/dashboard/recovery/page.tsx
+++ b/apps/agent-registration/src/app/(main)/dashboard/recovery/page.tsx
@@ -5,7 +5,6 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Checkbox } from '@/components/ui/checkbox';
 import {
   Dialog,
   DialogContent,
@@ -26,6 +25,7 @@ import {
   getCustomersWithoutPolicyNoPayments,
   createPolicyFromRecovery,
   createPolicyWithoutPayments,
+  getCustomerDetails,
   getPackagePlans,
   getPackagePricingBySlug,
   type RecoveryCustomer,
@@ -38,6 +38,7 @@ import {
   nextInstallmentPremiumFormValue,
   type PricingRateBand,
 } from '@/lib/insurance-installment';
+import { extraSpouseAddonCount } from '@/lib/family-category';
 import { mapPackagePricingToUi, type UiInsurancePricing } from '@/lib/package-pricing-ui';
 import { formatTransactionReferenceForDisplay } from '@/lib/transaction-reference-display';
 import { formatDate } from '@/lib/utils';
@@ -62,7 +63,7 @@ export default function RecoveryPage() {
   const [formData, setFormData] = useState({
     selectedPlan: '',
     selectedCategory: '',
-    additionalSpouse: false,
+    spouseCount: 0,
     packagePlanId: '',
     premium: '',
     frequency: 'DAILY' as string,
@@ -95,7 +96,7 @@ export default function RecoveryPage() {
     setFormData({
       selectedPlan: '',
       selectedCategory: '',
-      additionalSpouse: false,
+      spouseCount: 0,
       packagePlanId: '',
       premium: '',
       frequency: 'DAILY',
@@ -106,6 +107,11 @@ export default function RecoveryPage() {
     setPaymentFrequencies([]);
     setCreateDialogOpen(true);
     try {
+      const details = await getCustomerDetails(customer.id);
+      const spouseCount = details.data.dependants.filter(
+        (d) => d.relationship === 'SPOUSE' && !d.deletedAt
+      ).length;
+      setFormData((f) => ({ ...f, spouseCount }));
       const plansData = await getPackagePlans(customer.packageId);
       setPlans(plansData);
 
@@ -162,17 +168,14 @@ export default function RecoveryPage() {
       return { daily: 0, weekly: 0, totalDaily: 0, totalWeekly: 0, lookupRates: null };
     }
     const spousePremium = plan.additional_spouse;
-    const spouseDaily = formData.additionalSpouse ? spousePremium.daily ?? 0 : 0;
-    const spouseWeekly = formData.additionalSpouse ? spousePremium.weekly ?? 0 : 0;
+    const spouseUnits = extraSpouseAddonCount(formData.spouseCount, formData.selectedCategory);
+    const spouseDaily = spouseUnits * (spousePremium.daily ?? 0);
+    const spouseWeekly = spouseUnits * (spousePremium.weekly ?? 0);
     const lookupRates: PricingRateBand = {
       daily: (category.daily ?? 0) + spouseDaily,
       weekly: (category.weekly ?? 0) + spouseWeekly,
-      monthly:
-        (category.monthly ?? 0) +
-        (formData.additionalSpouse ? spousePremium.monthly ?? 0 : 0),
-      annually:
-        (category.annually ?? 0) +
-        (formData.additionalSpouse ? spousePremium.annually ?? 0 : 0),
+      monthly: (category.monthly ?? 0) + spouseUnits * (spousePremium.monthly ?? 0),
+      annually: (category.annually ?? 0) + spouseUnits * (spousePremium.annually ?? 0),
     };
     return {
       daily: category.daily ?? 0,
@@ -185,7 +188,7 @@ export default function RecoveryPage() {
     pricingData,
     formData.selectedPlan,
     formData.selectedCategory,
-    formData.additionalSpouse,
+    formData.spouseCount,
   ]);
 
   // Sync installment premium from pricing inputs. Bail out when unchanged;
@@ -470,17 +473,10 @@ export default function RecoveryPage() {
                 </SelectContent>
               </Select>
             </div>
-            <div className="flex items-center space-x-2">
-              <Checkbox
-                id="additionalSpouse"
-                checked={formData.additionalSpouse}
-                onCheckedChange={(checked) => setFormData((f) => ({ ...f, additionalSpouse: checked === true }))}
-                disabled={!formData.selectedCategory || formData.selectedCategory === 'member_only'}
-              />
-              <Label htmlFor="additionalSpouse" className="text-sm">
-                Additional Spouse Premium
-              </Label>
-            </div>
+            <p className="text-sm text-muted-foreground">
+              Extra-spouse add-on ×{' '}
+              {extraSpouseAddonCount(formData.spouseCount, formData.selectedCategory)}
+            </p>
             <div>
               <Label>Installment (KES)</Label>
               <Input

--- a/apps/agent-registration/src/app/(main)/register/beneficiary/page.tsx
+++ b/apps/agent-registration/src/app/(main)/register/beneficiary/page.tsx
@@ -255,6 +255,7 @@ export default function BeneficiaryStep() {
 
       // Save form data for next steps
       localStorage.setItem('beneficiaryFormData', JSON.stringify(formData));
+      localStorage.setItem('beneficiaryId', beneficiaryResult.beneficiaryIds[0]);
       console.log('✅ NoK form data saved to localStorage');
 
       console.log('🔍 Step 5: Navigating to payment page...');

--- a/apps/agent-registration/src/app/(main)/register/customer/page.tsx
+++ b/apps/agent-registration/src/app/(main)/register/customer/page.tsx
@@ -3,7 +3,6 @@
 import { useState, useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import * as Sentry from '@sentry/nextjs';
-import { supabase } from '@/lib/supabase';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -12,7 +11,18 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Plus, Trash2, Loader2, CheckCircle, LayoutDashboard } from 'lucide-react';
-import { createCustomer, createAgentRegistration, CustomerRegistrationRequest } from '@/lib/api';
+import {
+  createCustomer,
+  createAgentRegistration,
+  CustomerRegistrationRequest,
+  getPackagePlans,
+  getPackagePricingBySlug,
+  listPackagesForSchemes,
+  type Scheme,
+} from '@/lib/api';
+import SchemeTypeahead from '@/components/scheme-typeahead';
+import { householdCapsFromBands } from '@/lib/family-category';
+import { pricingBandsFromApi } from '@/lib/package-pricing-ui';
 import { useAuth } from '@/hooks/useAuth';
 import { useBrandAmbassador } from '@/hooks/useBrandAmbassador';
 import DateOfBirthInput from '@/components/date-of-birth-input';
@@ -172,15 +182,21 @@ export default function CustomerStep() {
   const [formData, setFormData] = useState<CustomerFormData>(initialFormData);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
-  // Package and scheme selection state
-  const [packages, setPackages] = useState<Array<{id: number, name: string}>>([]);
-  const [schemes, setSchemes] = useState<Array<{id: number, name: string, description?: string, packageSchemeId?: number, parentsSupported?: boolean}>>([]);
+  // Scheme → package → plan selection
+  const [selectedScheme, setSelectedScheme] = useState<{id: number, name: string, parentsSupported?: boolean} | null>(null);
+  const [packages, setPackages] = useState<Array<{id: number, name: string, packageSchemeId?: number, slug?: string | null}>>([]);
   const [selectedPackageId, setSelectedPackageId] = useState<number | null>(null);
   const [selectedSchemeId, setSelectedSchemeId] = useState<number | null>(null);
-  const [loadingSchemes, setLoadingSchemes] = useState(false);
-  const selectedSchemeParentsSupported = Boolean(
-    schemes.find((s) => s.id === selectedSchemeId)?.parentsSupported
-  );
+  const [plans, setPlans] = useState<Array<{id: number, name: string}>>([]);
+  const [selectedPlanId, setSelectedPlanId] = useState<number | null>(null);
+  const [householdCaps, setHouseholdCaps] = useState({
+    showSpouse: true,
+    showChildren: true,
+    showParents: false,
+    maxExtraMembers: 7,
+    hasFamilyBands: true,
+  });
+  const selectedSchemeParentsSupported = Boolean(selectedScheme?.parentsSupported);
 
   // Date constraints - set after mount to avoid server/client hydration mismatch (new Date() differs by timezone)
   const [minDateAdults, setMinDateAdults] = useState<string | undefined>(undefined);
@@ -207,114 +223,73 @@ export default function CustomerStep() {
     }
   }, [searchParams, router]);
 
-  // Load packages on mount and restore last selections from localStorage
   useEffect(() => {
-    fetchPackages();
-
+    const savedScheme = localStorage.getItem('lastSelectedScheme');
     const savedPackageId = localStorage.getItem('lastSelectedPackageId');
-    const savedSchemeId = localStorage.getItem('lastSelectedSchemeId');
-
-    if (savedPackageId) {
-      const pkgId = parseInt(savedPackageId);
-      setSelectedPackageId(pkgId);
-      fetchSchemes(pkgId, savedSchemeId ? parseInt(savedSchemeId) : null);
+    const savedPlanId = localStorage.getItem('lastSelectedPlanId');
+    if (savedScheme) {
+      try {
+        const parsed = JSON.parse(savedScheme) as Scheme;
+        setSelectedScheme(parsed);
+        setSelectedSchemeId(parsed.id);
+      } catch {
+        /* ignore */
+      }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    if (savedPackageId) setSelectedPackageId(parseInt(savedPackageId, 10));
+    if (savedPlanId) setSelectedPlanId(parseInt(savedPlanId, 10));
   }, []);
 
-  // Helper to get Supabase token for API calls
-  const getSupabaseToken = async () => {
-    const { data: session } = await supabase.auth.getSession();
-    return session.session?.access_token;
-  };
-
-  // Fetch all active packages
-  const fetchPackages = async () => {
-    try {
-      const token = await getSupabaseToken();
-      const response = await fetch(
-        `${process.env.NEXT_PUBLIC_INTERNAL_API_BASE_URL}/internal/product-management/packages`,
-        {
-          headers: {
-            'Authorization': `Bearer ${token}`,
-            'x-correlation-id': `req-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`
-          }
-        }
-      );
-
-      if (!response.ok) {
-        throw new Error('Failed to fetch packages');
-      }
-
-      const data = await response.json();
-      setPackages(data.data ?? []);
-    } catch (err) {
-      console.error('Error fetching packages:', err);
-      Sentry.captureException(err, {
-        tags: { component: 'CustomerStep', action: 'fetchPackages' }
-      });
-      setError('Failed to load packages. Please refresh the page.');
+  useEffect(() => {
+    if (!selectedScheme) {
+      setPackages([]);
+      return;
     }
-  };
-
-  // Fetch schemes for a selected package
-  const fetchSchemes = async (packageId: number, preselectedSchemeId?: number | null) => {
-    setLoadingSchemes(true);
-    try {
-      const token = await getSupabaseToken();
-      const response = await fetch(
-        `${process.env.NEXT_PUBLIC_INTERNAL_API_BASE_URL}/internal/product-management/packages/${packageId}/schemes`,
-        {
-          headers: {
-            'Authorization': `Bearer ${token}`,
-            'x-correlation-id': `req-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`
-          }
-        }
-      );
-
-      if (!response.ok) {
-        throw new Error('Failed to fetch schemes');
-      }
-
-      const data = await response.json();
-      setSchemes(data.data ?? []);
-
-      // If preselected scheme exists and is in the list, select it
-      if (preselectedSchemeId && data.data?.some((s: { id: number }) => s.id === preselectedSchemeId)) {
-        setSelectedSchemeId(preselectedSchemeId);
-      }
-    } catch (err) {
-      console.error('Error fetching schemes:', err);
-      Sentry.captureException(err, {
-        tags: { component: 'CustomerStep', action: 'fetchSchemes' }
+    void listPackagesForSchemes([selectedScheme.id])
+      .then((list) => setPackages(list.filter((p) => p.isActive !== false)))
+      .catch((err) => {
+        Sentry.captureException(err, { tags: { component: 'CustomerStep', action: 'listPackages' } });
+        setError('Failed to load packages for this scheme.');
       });
-      setError('Failed to load schemes for this package.');
-    } finally {
-      setLoadingSchemes(false);
+  }, [selectedScheme]);
+
+  useEffect(() => {
+    if (!selectedPackageId) {
+      setPlans([]);
+      return;
     }
+    void getPackagePlans(selectedPackageId)
+      .then((list) => setPlans(list.filter((p) => p.isActive !== false)))
+      .catch(() => setPlans([]));
+    const slug = packages.find((p) => p.id === selectedPackageId)?.slug;
+    if (slug) {
+      void getPackagePricingBySlug(slug).then((pricing) => {
+        setHouseholdCaps(
+          householdCapsFromBands(pricingBandsFromApi(pricing), Boolean(selectedScheme?.parentsSupported))
+        );
+      }).catch(() => undefined);
+    }
+  }, [packages, selectedPackageId, selectedScheme?.parentsSupported]);
+
+  const handleSchemeSelect = (scheme: Scheme | null) => {
+    setSelectedScheme(scheme);
+    setSelectedSchemeId(scheme?.id ?? null);
+    setSelectedPackageId(null);
+    setSelectedPlanId(null);
+    setFormData((prev) => ({ ...prev, parents: [], spouses: [], children: [] }));
+    if (scheme) localStorage.setItem('lastSelectedScheme', JSON.stringify(scheme));
+    else localStorage.removeItem('lastSelectedScheme');
+    localStorage.removeItem('lastSelectedPackageId');
+    localStorage.removeItem('lastSelectedPlanId');
   };
 
-  // Handle package selection change
   const handlePackageChange = (value: string) => {
-    const packageId = parseInt(value);
+    const packageId = parseInt(value, 10);
     setSelectedPackageId(packageId);
-    setSelectedSchemeId(null); // Reset scheme when package changes
-    setSchemes([]); // Clear schemes
+    setSelectedPlanId(null);
     setFormData((prev) => ({ ...prev, parents: [] }));
-    fetchSchemes(packageId);
     localStorage.setItem('lastSelectedPackageId', value);
-    localStorage.removeItem('lastSelectedSchemeId'); // Clear saved scheme
-  };
-
-  // Handle scheme selection change
-  const handleSchemeChange = (value: string) => {
-    const schemeId = parseInt(value);
-    setSelectedSchemeId(schemeId);
-    localStorage.setItem('lastSelectedSchemeId', value);
-    const scheme = schemes.find((s) => s.id === schemeId);
-    if (!scheme?.parentsSupported) {
-      setFormData((prev) => ({ ...prev, parents: [] }));
-    }
+    localStorage.removeItem('lastSelectedPlanId');
   };
 
   const handleInputChange = (field: keyof CustomerFormData, value: string) => {
@@ -333,8 +308,9 @@ export default function CustomerStep() {
     }));
   };
 
+  const extraHouseholdCount = formData.spouses.length + formData.children.length;
   const addSpouse = () => {
-    if (formData.spouses.length < 2) {
+    if (householdCaps.showSpouse && extraHouseholdCount < householdCaps.maxExtraMembers) {
       setFormData(prev => ({
         ...prev,
         spouses: [...prev.spouses, { firstName: '', middleName: '', lastName: '', gender: '', dateOfBirth: '', phoneNumber: '', idType: 'NATIONAL_ID', idNumber: '' }]
@@ -350,7 +326,7 @@ export default function CustomerStep() {
   };
 
   const addChild = () => {
-    if (formData.children.length < 7) {
+    if (householdCaps.showChildren && extraHouseholdCount < householdCaps.maxExtraMembers) {
       setFormData(prev => ({
         ...prev,
         children: [...prev.children, { firstName: '', middleName: '', lastName: '', gender: 'MALE', dateOfBirth: '', phoneNumber: '', idType: 'BIRTH_CERTIFICATE', idNumber: '' }]
@@ -439,19 +415,21 @@ export default function CustomerStep() {
     // Clear any previous errors
     setError(null);
 
-    // Validate package and scheme selection
-    if (!selectedPackageId || !selectedSchemeId) {
-      setError('Please select both a package and a scheme before continuing');
+    if (!selectedPackageId || !selectedSchemeId || !selectedPlanId) {
+      setError('Please select a scheme, package, and plan before continuing');
       return;
     }
 
-    // Get packageSchemeId from the selected scheme
-    const selectedScheme = schemes.find(s => s.id === selectedSchemeId);
-    const packageSchemeId = selectedScheme?.packageSchemeId;
-
+    const selectedPkg = packages.find((p) => p.id === selectedPackageId);
+    const packageSchemeId = selectedPkg?.packageSchemeId;
     if (!packageSchemeId) {
       setError('Invalid package/scheme combination. Please select again.');
       return;
+    }
+    const selectedPlan = plans.find((p) => p.id === selectedPlanId);
+    localStorage.setItem('lastSelectedPlanId', String(selectedPlanId));
+    if (selectedPlan) {
+      localStorage.setItem('lastSelectedPlanName', selectedPlan.name);
     }
 
     // Validate required fields BEFORE setting isSubmitting
@@ -759,48 +737,54 @@ export default function CustomerStep() {
         </Alert>
       )}
 
-      {/* Product Selection */}
       <Card>
         <CardHeader>
           <CardTitle>Select Product</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            {/* Package Dropdown */}
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <SchemeTypeahead
+              selected={selectedScheme}
+              onSelect={handleSchemeSelect}
+            />
             <div>
               <Label htmlFor="package">Package *</Label>
-              <Select value={selectedPackageId?.toString() ?? ''} onValueChange={handlePackageChange}>
+              <Select
+                value={selectedPackageId?.toString() ?? ''}
+                onValueChange={handlePackageChange}
+                disabled={!selectedScheme}
+              >
                 <SelectTrigger id="package">
                   <SelectValue placeholder="Select package" />
                 </SelectTrigger>
                 <SelectContent>
-                  {packages.map(pkg => (
+                  {packages.map((pkg) => (
                     <SelectItem key={pkg.id} value={pkg.id.toString()}>{pkg.name}</SelectItem>
                   ))}
                 </SelectContent>
               </Select>
             </div>
-
-            {/* Scheme Dropdown */}
             <div>
-              <Label htmlFor="scheme">Scheme *</Label>
+              <Label htmlFor="plan">Plan *</Label>
               <Select
-                value={selectedSchemeId?.toString() ?? ''}
-                onValueChange={handleSchemeChange}
-                disabled={!selectedPackageId || loadingSchemes}
+                value={selectedPlanId?.toString() ?? ''}
+                onValueChange={(v) => {
+                  setSelectedPlanId(parseInt(v, 10));
+                  localStorage.setItem('lastSelectedPlanId', v);
+                  const plan = plans.find((p) => p.id === parseInt(v, 10));
+                  if (plan) localStorage.setItem('lastSelectedPlanName', plan.name);
+                }}
+                disabled={!selectedPackageId}
               >
-                <SelectTrigger id="scheme">
-                  <SelectValue placeholder={loadingSchemes ? "Loading..." : "Select scheme"} />
+                <SelectTrigger id="plan">
+                  <SelectValue placeholder="Select plan" />
                 </SelectTrigger>
                 <SelectContent>
-                  {schemes.map(scheme => (
-                    <SelectItem key={scheme.id} value={scheme.id.toString()}>{scheme.name}</SelectItem>
+                  {plans.map((plan) => (
+                    <SelectItem key={plan.id} value={plan.id.toString()}>{plan.name}</SelectItem>
                   ))}
                 </SelectContent>
               </Select>
-              {selectedPackageId && schemes.length === 0 && !loadingSchemes && (
-                <p className="text-sm text-red-500 mt-1">This package has no schemes.</p>
-              )}
             </div>
           </div>
         </CardContent>
@@ -977,15 +961,20 @@ export default function CustomerStep() {
           <CardTitle>Dependants</CardTitle>
         </CardHeader>
         <CardContent className="space-y-6">
-          {/* Spouses */}
+          {!householdCaps.showSpouse && !householdCaps.showChildren && (
+            <p className="text-sm text-muted-foreground">Member-only package. Spouse and children are hidden.</p>
+          )}
+          {householdCaps.showSpouse && (
           <div>
             <div className="flex items-center justify-between mb-4">
-              <h3 className="text-lg font-semibold">Spouses ({formData.spouses.length}/2)</h3>
+              <h3 className="text-lg font-semibold">
+                Spouses ({formData.spouses.length}/{householdCaps.maxExtraMembers})
+              </h3>
               <Button
                 variant="outline"
                 size="sm"
                 onClick={addSpouse}
-                disabled={formData.spouses.length >= 2}
+                disabled={extraHouseholdCount >= householdCaps.maxExtraMembers}
               >
                 <Plus className="h-4 w-4 mr-2" />
                 Add Spouse
@@ -1106,17 +1095,20 @@ export default function CustomerStep() {
             ))}
           </div>
 
-          <Separator />
+          </div>
+          )}
 
-          {/* Children */}
+          {householdCaps.showChildren && (
           <div>
             <div className="flex items-center justify-between mb-4">
-              <h3 className="text-lg font-semibold">Children ({formData.children.length}/7)</h3>
+              <h3 className="text-lg font-semibold">
+                Children ({formData.children.length}/{householdCaps.maxExtraMembers})
+              </h3>
               <Button
                 variant="outline"
                 size="sm"
                 onClick={addChild}
-                disabled={formData.children.length >= 7}
+                disabled={extraHouseholdCount >= householdCaps.maxExtraMembers}
               >
                 <Plus className="h-4 w-4 mr-2" />
                 Add Child
@@ -1192,8 +1184,9 @@ export default function CustomerStep() {
               </div>
             ))}
           </div>
+          )}
 
-          {selectedSchemeParentsSupported && (
+          {householdCaps.showParents && (
             <>
               <Separator />
 

--- a/apps/agent-registration/src/app/(main)/register/customer/page.tsx
+++ b/apps/agent-registration/src/app/(main)/register/customer/page.tsx
@@ -1094,8 +1094,6 @@ export default function CustomerStep() {
               </div>
             ))}
           </div>
-
-          </div>
           )}
 
           {householdCaps.showChildren && (

--- a/apps/agent-registration/src/app/(main)/register/payment/page.tsx
+++ b/apps/agent-registration/src/app/(main)/register/payment/page.tsx
@@ -7,7 +7,6 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Checkbox } from '@/components/ui/checkbox';
 // import { Separator } from '@/components/ui/separator';
 import { CheckCircle, CreditCard, Users, User, Loader2, XCircle, Clock, LayoutDashboard } from 'lucide-react';
 import {
@@ -36,8 +35,9 @@ import {
   type PricingRateBand,
 } from '@/lib/insurance-installment';
 import {
-  hasAdditionalSpousePremium,
+  extraSpouseAddonCount,
   householdSizeFromRegistrationForm,
+  resolveFamilyCategoryForHousehold,
   validateSelectedFamilyCategory,
 } from '@/lib/family-category';
 import type { PackagePricingData } from '@/lib/api';
@@ -140,7 +140,6 @@ export default function PaymentStep() {
   const [pricingLoadError, setPricingLoadError] = useState<string | null>(null);
   const [selectedPlan, setSelectedPlan] = useState<string>('');
   const [selectedCategory, setSelectedCategory] = useState<string>('');
-  const [additionalSpouse, setAdditionalSpouse] = useState(false);
   const [calculatedPricing, setCalculatedPricing] = useState({
     daily: 0,
     weekly: 0,
@@ -166,6 +165,16 @@ export default function PaymentStep() {
       .then((data) => {
         setPricingApiData(data);
         setPricingData(mapPackagePricingToUi(data));
+        const saved = localStorage.getItem('customerFormData');
+        if (saved) {
+          const customer = JSON.parse(saved) as CustomerFormData;
+          const size = householdSizeFromRegistrationForm({
+            spouses: customer.spouses,
+            children: customer.children,
+          });
+          const resolved = resolveFamilyCategoryForHousehold(size, pricingBandsFromApi(data));
+          if (resolved.ok) setSelectedCategory(resolved.categoryKey);
+        }
       })
       .catch((err) => {
         console.error('Error loading pricing data:', err);
@@ -225,6 +234,10 @@ export default function PaymentStep() {
       const customer = JSON.parse(savedCustomerData);
       setCustomerData(customer);
       setPaymentPhone(customer.phoneNumber); // Pre-populate with customer phone
+    }
+    const savedPlanName = localStorage.getItem('lastSelectedPlanName');
+    if (savedPlanName) {
+      setSelectedPlan(savedPlanName.toLowerCase());
     }
 
     if (savedBeneficiaryData) {
@@ -314,14 +327,16 @@ export default function PaymentStep() {
 
     const baseDaily = category.daily ?? 0;
     const baseWeekly = category.weekly ?? 0;
-    const spouseDaily = additionalSpouse ? spousePremium.daily ?? 0 : 0;
-    const spouseWeekly = additionalSpouse ? spousePremium.weekly ?? 0 : 0;
+    const spouseCount = customerData?.spouses.filter((s) => s.firstName?.trim()).length ?? 0;
+    const spouseUnits = extraSpouseAddonCount(spouseCount, selectedCategory);
+    const spouseDaily = spouseUnits * (spousePremium.daily ?? 0);
+    const spouseWeekly = spouseUnits * (spousePremium.weekly ?? 0);
 
     const lookupRates: PricingRateBand = {
-      daily: (category.daily ?? 0) + (additionalSpouse ? spousePremium.daily ?? 0 : 0),
-      weekly: (category.weekly ?? 0) + (additionalSpouse ? spousePremium.weekly ?? 0 : 0),
-      monthly: (category.monthly ?? 0) + (additionalSpouse ? spousePremium.monthly ?? 0 : 0),
-      annually: (category.annually ?? 0) + (additionalSpouse ? spousePremium.annually ?? 0 : 0),
+      daily: (category.daily ?? 0) + spouseUnits * (spousePremium.daily ?? 0),
+      weekly: (category.weekly ?? 0) + spouseUnits * (spousePremium.weekly ?? 0),
+      monthly: (category.monthly ?? 0) + spouseUnits * (spousePremium.monthly ?? 0),
+      annually: (category.annually ?? 0) + spouseUnits * (spousePremium.annually ?? 0),
     };
 
     setCalculatedPricing({
@@ -331,7 +346,7 @@ export default function PaymentStep() {
       totalWeekly: baseWeekly + spouseWeekly,
       lookupRates,
     });
-  }, [pricingData, selectedPlan, selectedCategory, additionalSpouse]);
+  }, [pricingData, selectedPlan, selectedCategory, customerData]);
 
   const installmentForSelection = (frequency: string) =>
     computeInstallmentPremium({
@@ -347,7 +362,6 @@ export default function PaymentStep() {
   useEffect(() => {
     if (selectedPlan) {
       setSelectedCategory('');
-      setAdditionalSpouse(false);
     }
   }, [selectedPlan]);
 
@@ -446,17 +460,6 @@ export default function PaymentStep() {
         return;
       }
 
-      const spouseCount = customerData.spouses.filter((s) => s.firstName?.trim()).length;
-      if (
-        additionalSpouse &&
-        !hasAdditionalSpousePremium(selectedCategory, spouseCount, {
-          optedIn: true,
-          householdKnown: true,
-        })
-      ) {
-        setError('Additional spouse premium only applies when there is more than one spouse.');
-        return;
-      }
     }
 
     // Validate plan and category selection
@@ -595,6 +598,15 @@ export default function PaymentStep() {
         now.getUTCSeconds()
       ));
 
+      const storedBeneficiaryId = localStorage.getItem('beneficiaryId') ?? undefined;
+      let dependantIds: string[] | undefined;
+      try {
+        const details = await (await import('@/lib/api')).getCustomerDetails(customerId);
+        dependantIds = details.data.dependants.filter((d) => !d.deletedAt).map((d) => d.id);
+      } catch {
+        dependantIds = undefined;
+      }
+
       const policyRequest: CreatePolicyRequest = {
         customerId,
         packageId,
@@ -603,6 +615,8 @@ export default function PaymentStep() {
         premium,
         annualPremium,
         productName,
+        dependantIds,
+        beneficiaryId: storedBeneficiaryId,
         paymentData: {
           paymentType: paymentType as 'MPESA' | 'SASAPAY',
           transactionReference: placeholderTransactionRef, // Placeholder - real ref will come from IPN
@@ -711,7 +725,7 @@ export default function PaymentStep() {
                 <Select
                   value={selectedPlan}
                   onValueChange={setSelectedPlan}
-                  disabled={!pricingData}
+                  disabled
                 >
                   <SelectTrigger id="planSelection">
                     <SelectValue placeholder={pricingData ? 'Select insurance plan' : 'No pricing available'} />
@@ -799,23 +813,13 @@ export default function PaymentStep() {
               )}
             </div>
 
-            {/* Additional Spouse Checkbox */}
-            <div className="flex items-center space-x-2">
-              <Checkbox
-                id="additionalSpouse"
-                checked={additionalSpouse}
-                onCheckedChange={(checked) => setAdditionalSpouse(checked === true)}
-                disabled={!selectedCategory || selectedCategory === 'member_only'}
-              />
-              <Label htmlFor="additionalSpouse" className="text-sm">
-                Additional Spouse Premium
-                {pricingData && selectedPlan && pricingData.plans[selectedPlan] && selectedCategory !== 'member_only' && (
-                  <span className="text-gray-500 ml-1">
-                    (+{pricingData.plans[selectedPlan].additional_spouse.daily ?? 0} KES/day, +{pricingData.plans[selectedPlan].additional_spouse.weekly ?? 0} KES/week)
-                  </span>
-                )}
-              </Label>
-            </div>
+            <p className="text-sm text-muted-foreground">
+              Extra-spouse add-on ×{' '}
+              {extraSpouseAddonCount(
+                customerData?.spouses.filter((s) => s.firstName?.trim()).length ?? 0,
+                selectedCategory
+              )}
+            </p>
 
             <div className="flex items-center justify-between p-4 bg-blue-50 rounded-lg">
               <div>

--- a/apps/agent-registration/src/components/scheme-typeahead.tsx
+++ b/apps/agent-registration/src/components/scheme-typeahead.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { listSchemesForPicker, type Scheme } from '@/lib/api';
+import { isSchemeTypeaheadQueryReady } from '@/lib/duplicate-person';
+
+interface SchemeTypeaheadProps {
+  label?: string;
+  selected: Scheme | null;
+  onSelect: (scheme: Scheme | null) => void;
+  disabled?: boolean;
+}
+
+export default function SchemeTypeahead({
+  label = 'Scheme',
+  selected,
+  onSelect,
+  disabled = false,
+}: SchemeTypeaheadProps) {
+  const [query, setQuery] = useState(selected?.name ?? '');
+  const [results, setResults] = useState<Scheme[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (selected) {
+      setQuery(selected.name);
+    }
+  }, [selected]);
+
+  useEffect(() => {
+    if (selected && query === selected.name) {
+      setResults([]);
+      return;
+    }
+    if (!isSchemeTypeaheadQueryReady(query)) {
+      setResults([]);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    const handle = setTimeout(() => {
+      void listSchemesForPicker(query.trim())
+        .then((schemes) => {
+          if (!cancelled) setResults(schemes.filter((s) => s.isActive !== false));
+        })
+        .catch(() => {
+          if (!cancelled) setResults([]);
+        })
+        .finally(() => {
+          if (!cancelled) setLoading(false);
+        });
+    }, 250);
+    return () => {
+      cancelled = true;
+      clearTimeout(handle);
+    };
+  }, [query, selected]);
+
+  return (
+    <div className="relative">
+      <Label htmlFor="scheme-typeahead">{label} *</Label>
+      <Input
+        id="scheme-typeahead"
+        value={query}
+        disabled={disabled}
+        placeholder="Type at least 2 letters"
+        autoComplete="off"
+        onFocus={() => setOpen(true)}
+        onChange={(e) => {
+          setQuery(e.target.value);
+          setOpen(true);
+          if (selected && e.target.value !== selected.name) {
+            onSelect(null);
+          }
+        }}
+      />
+      {query.trim().length > 0 && query.trim().length < 2 && (
+        <p className="text-xs text-muted-foreground mt-1">Type at least 2 letters to search.</p>
+      )}
+      {open && isSchemeTypeaheadQueryReady(query) && !selected && (
+        <div className="absolute z-20 mt-1 max-h-56 w-full overflow-auto rounded-md border bg-popover shadow-md">
+          {loading && <p className="px-3 py-2 text-sm text-muted-foreground">Searching…</p>}
+          {!loading && results.length === 0 && (
+            <p className="px-3 py-2 text-sm text-muted-foreground">No matching schemes</p>
+          )}
+          {!loading &&
+            results.map((scheme) => (
+              <button
+                key={scheme.id}
+                type="button"
+                className="block w-full px-3 py-2 text-left text-sm hover:bg-muted"
+                onClick={() => {
+                  onSelect(scheme);
+                  setQuery(scheme.name);
+                  setOpen(false);
+                }}
+              >
+                {scheme.name}
+              </button>
+            ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/agent-registration/src/lib/api.ts
+++ b/apps/agent-registration/src/lib/api.ts
@@ -999,6 +999,7 @@ export interface CustomerPolicyListItem {
   id: string
   productName: string
   packageName: string
+  packageId?: number
   planName?: string | null
   schemeName: string
   underwriterName?: string | null
@@ -1065,6 +1066,15 @@ export interface CustomerPolicyDetail {
   missedPaymentsApproximate?: boolean
   paymentsMadeCount?: number
   missedPaymentsAmount: MissedPaymentsAmount
+  nextOfKin?: {
+    id: string
+    firstName: string
+    middleName: string | null
+    lastName: string
+    relationship: string | null
+    phoneNumber: string | null
+    percentage: number
+  } | null
 }
 
 export interface CustomerPolicyDetailResponse {
@@ -1959,6 +1969,8 @@ export interface Package {
   parentsSupported?: boolean
   maximumFamilySize?: number
   paymentFrequencies?: Array<{ frequency: string; installmentCount: number }>
+  packageSchemeId?: number
+  isPostpaid?: boolean
 }
 
 export interface Scheme {
@@ -2053,11 +2065,12 @@ export async function getPackages(options?: { includeInactive?: boolean }): Prom
   }
 }
 
-/** All schemes including inactive (for campaign audience pickers). */
-export async function listSchemesForPicker(): Promise<Scheme[]> {
+/** Schemes for pickers. Pass q (min 2 chars) for prefix typeahead; omit q to list all. */
+export async function listSchemesForPicker(query?: string): Promise<Scheme[]> {
   const token = await getSupabaseToken()
+  const params = query != null ? `?q=${encodeURIComponent(query)}` : ''
   const response = await fetch(
-    `${process.env.NEXT_PUBLIC_INTERNAL_API_BASE_URL}/internal/product-management/schemes`,
+    `${process.env.NEXT_PUBLIC_INTERNAL_API_BASE_URL}/internal/product-management/schemes${params}`,
     {
       method: 'GET',
       headers: {
@@ -2429,6 +2442,8 @@ export interface CreatePolicyRequest {
     paymentMessageBlob?: string
   }
   customDays?: number
+  dependantIds?: string[]
+  beneficiaryId?: string
 }
 
 export interface CompletePostpaidEnrollmentRequest {
@@ -2489,6 +2504,62 @@ export async function createPolicy(data: CreatePolicyRequest): Promise<CreatePol
     console.error('Error creating policy:', error)
     throw error
   }
+}
+
+export interface CreateAdditionalPolicyRequest {
+  packageSchemeId: number
+  packagePlanId: number
+  frequency: CreatePolicyRequest['frequency']
+  premium: number
+  annualPremium?: number
+  productName: string
+  existingDependantIds?: string[]
+  newSpouses?: Array<Record<string, unknown>>
+  newChildren?: Array<Record<string, unknown>>
+  newParents?: Array<Record<string, unknown>>
+  beneficiaryId?: string
+  newBeneficiary?: Record<string, unknown>
+  confirmNewPersonKeys?: string[]
+  skipPayment?: boolean
+  customDays?: number
+}
+
+export interface CreateAdditionalPolicyResponse {
+  status: number
+  correlationId: string
+  message: string
+  policy: {
+    id: string
+    policyNumber: string | null
+    status: string
+    productName: string
+    premium: number
+    paymentAcNumber: string | null
+  }
+}
+
+export async function createAdditionalPolicy(
+  customerId: string,
+  data: CreateAdditionalPolicyRequest
+): Promise<CreateAdditionalPolicyResponse> {
+  const token = await getSupabaseToken()
+  const response = await fetch(
+    `${process.env.NEXT_PUBLIC_INTERNAL_API_BASE_URL}/internal/customers/${customerId}/additional-policies`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+        'x-correlation-id': `additional-policy-${Date.now()}`,
+      },
+      body: JSON.stringify(data),
+    }
+  )
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}))
+    throw new Error(errorData.error?.message ?? `Failed to add product: ${response.statusText}`)
+  }
+  return response.json()
 }
 
 /** Update postpaid shell policy with plan/premium at registration payment step (no STK). */
@@ -3182,6 +3253,7 @@ export interface ModifyPolicyOptions {
   paymentFrequencies: Array<{ frequency: string; installmentCount: number }>
   familyCategory: string
   additionalSpouse: boolean
+  extraSpouseCount?: number
   currentPackagePlanId: number
   currentPlanName?: string
   currentPremium: number

--- a/apps/agent-registration/src/lib/duplicate-person.ts
+++ b/apps/agent-registration/src/lib/duplicate-person.ts
@@ -1,0 +1,72 @@
+export type PersonIdentity = {
+  firstName: string;
+  lastName: string;
+  idNumber?: string | null;
+  phoneNumber?: string | null;
+};
+
+export type IdentifiedPerson = PersonIdentity & { id: string };
+
+export type DuplicatePersonMatch =
+  | { kind: 'same_person'; existing: IdentifiedPerson }
+  | { kind: 'ambiguous'; existing: IdentifiedPerson }
+  | { kind: 'distinct' };
+
+function normalizeName(value: string | null | undefined): string {
+  return (value ?? '').trim().toLowerCase();
+}
+
+function normalizeToken(value: string | null | undefined): string {
+  return (value ?? '').trim().replace(/\s/g, '').toLowerCase();
+}
+
+export function namesMatch(a: PersonIdentity, b: PersonIdentity): boolean {
+  return (
+    normalizeName(a.firstName) === normalizeName(b.firstName) &&
+    normalizeName(a.lastName) === normalizeName(b.lastName)
+  );
+}
+
+export function matchDuplicatePerson(
+  candidate: PersonIdentity,
+  existingPeople: IdentifiedPerson[]
+): DuplicatePersonMatch {
+  const candidateId = normalizeToken(candidate.idNumber);
+  const candidatePhone = normalizeToken(candidate.phoneNumber);
+
+  for (const existing of existingPeople) {
+    if (!namesMatch(candidate, existing)) {
+      continue;
+    }
+
+    const existingId = normalizeToken(existing.idNumber);
+    const existingPhone = normalizeToken(existing.phoneNumber);
+
+    if (candidateId && existingId) {
+      if (candidateId === existingId) {
+        return { kind: 'same_person', existing };
+      }
+      return { kind: 'distinct' };
+    }
+
+    if (candidatePhone && existingPhone && candidatePhone === existingPhone) {
+      return { kind: 'same_person', existing };
+    }
+
+    if (!candidateId && !existingId && !candidatePhone && !existingPhone) {
+      return { kind: 'ambiguous', existing };
+    }
+  }
+
+  return { kind: 'distinct' };
+}
+
+export function isSchemeTypeaheadQueryReady(query: string): boolean {
+  return query.trim().length >= 2;
+}
+
+export function schemeNamePrefixMatches(schemeName: string, query: string): boolean {
+  const q = query.trim().toLowerCase();
+  if (q.length < 2) return false;
+  return schemeName.trim().toLowerCase().startsWith(q);
+}

--- a/apps/agent-registration/src/lib/family-category.ts
+++ b/apps/agent-registration/src/lib/family-category.ts
@@ -10,6 +10,23 @@ export type FamilyCategoryResolution =
   | { ok: true; categoryKey: string }
   | { ok: false; reason: 'OVERFLOW' | 'UNDERSIZED' | 'UNKNOWN_CATEGORY' };
 
+export function resolveFamilyCategoryForHousehold(
+  householdSize: number,
+  bands: PackagePricingBand[]
+): FamilyCategoryResolution {
+  if (householdSize <= 1) {
+    const memberOnly = bands.find((b) => b.kind === 'MEMBER_ONLY');
+    if (!memberOnly) return { ok: false, reason: 'OVERFLOW' };
+    return { ok: true, categoryKey: memberOnly.key };
+  }
+  const upTo = bands
+    .filter((b) => b.kind === 'UP_TO_N' && b.maxMembers != null && b.maxMembers >= 2)
+    .sort((a, b) => (a.maxMembers ?? 0) - (b.maxMembers ?? 0));
+  const fit = upTo.find((b) => (b.maxMembers ?? 0) >= householdSize);
+  if (!fit) return { ok: false, reason: 'OVERFLOW' };
+  return { ok: true, categoryKey: fit.key };
+}
+
 export function validateSelectedFamilyCategory(params: {
   selectedCategoryKey: string;
   householdSize: number | null | undefined;
@@ -39,6 +56,14 @@ export function validateSelectedFamilyCategory(params: {
   return { ok: true, categoryKey: selectedCategoryKey };
 }
 
+export function extraSpouseAddonCount(
+  spouseCount: number,
+  category?: string | null
+): number {
+  if (category === 'member_only' || category === 'MEMBER_ONLY') return 0;
+  return Math.max(0, spouseCount - 1);
+}
+
 export function hasAdditionalSpousePremium(
   category: string,
   spouseCount: number,
@@ -51,8 +76,7 @@ export function hasAdditionalSpousePremium(
     return options.optedIn === true;
   }
 
-  if (spouseCount <= 1) return false;
-  return true;
+  return extraSpouseAddonCount(spouseCount, category) > 0;
 }
 
 export function householdSizeFromRegistrationForm(params: {
@@ -62,4 +86,43 @@ export function householdSizeFromRegistrationForm(params: {
   const spouseCount = params.spouses.filter((s) => s.firstName?.trim()).length;
   const childCount = params.children.filter((c) => c.firstName?.trim()).length;
   return 1 + spouseCount + childCount;
+}
+
+export type HouseholdCaps = {
+  hasFamilyBands: boolean;
+  maxMembers: number;
+  maxExtraMembers: number;
+  showSpouse: boolean;
+  showChildren: boolean;
+  showParents: boolean;
+};
+
+export function householdCapsFromBands(
+  bands: PackagePricingBand[],
+  parentsSupported: boolean
+): HouseholdCaps {
+  const upTo = bands.filter(
+    (b) => b.kind === 'UP_TO_N' && b.maxMembers != null && b.maxMembers >= 2
+  );
+  const hasFamilyBands = upTo.length > 0;
+  const maxMembers = hasFamilyBands
+    ? Math.max(...upTo.map((b) => b.maxMembers ?? 0))
+    : 1;
+  return {
+    hasFamilyBands,
+    maxMembers,
+    maxExtraMembers: hasFamilyBands ? maxMembers - 1 : 0,
+    showSpouse: hasFamilyBands,
+    showChildren: hasFamilyBands,
+    showParents: hasFamilyBands && parentsSupported,
+  };
+}
+
+/** N-1 extra people; "member plus one" (N=2) = spouse OR child, not both. */
+export function canAddHouseholdMember(
+  caps: HouseholdCaps,
+  currentExtraCount: number
+): boolean {
+  if (!caps.showSpouse && !caps.showChildren) return false;
+  return currentExtraCount < caps.maxExtraMembers;
 }

--- a/apps/agent-registration/tests/add-product-household.spec.ts
+++ b/apps/agent-registration/tests/add-product-household.spec.ts
@@ -1,0 +1,51 @@
+import {
+  canAddHouseholdMember,
+  extraSpouseAddonCount,
+  householdCapsFromBands,
+} from '../src/lib/family-category';
+import { isSchemeTypeaheadQueryReady, schemeNamePrefixMatches } from '../src/lib/duplicate-person';
+
+const bands = [
+  { key: 'member_only', kind: 'MEMBER_ONLY' as const },
+  { key: 'up_to_2', kind: 'UP_TO_N' as const, maxMembers: 2 },
+  { key: 'up_to_5', kind: 'UP_TO_N' as const, maxMembers: 5 },
+];
+
+describe('household caps and extra-spouse', () => {
+  it('hides household when package has no UP_TO_N band', () => {
+    const caps = householdCapsFromBands([{ key: 'member_only', kind: 'MEMBER_ONLY' }], true);
+    expect(caps.showSpouse).toBe(false);
+    expect(caps.showChildren).toBe(false);
+    expect(caps.showParents).toBe(false);
+  });
+
+  it('member plus one allows only one extra person', () => {
+    const caps = householdCapsFromBands(
+      [
+        { key: 'member_only', kind: 'MEMBER_ONLY' },
+        { key: 'up_to_2', kind: 'UP_TO_N', maxMembers: 2 },
+      ],
+      false
+    );
+    expect(caps.maxExtraMembers).toBe(1);
+    expect(canAddHouseholdMember(caps, 0)).toBe(true);
+    expect(canAddHouseholdMember(caps, 1)).toBe(false);
+  });
+
+  it('bills extra-spouse × 2 for 3 spouses', () => {
+    expect(extraSpouseAddonCount(3, 'up_to_5')).toBe(2);
+    expect(extraSpouseAddonCount(3, 'member_only')).toBe(0);
+  });
+});
+
+describe('scheme typeahead prefix', () => {
+  it('requires at least 2 letters', () => {
+    expect(isSchemeTypeaheadQueryReady('O')).toBe(false);
+    expect(isSchemeTypeaheadQueryReady('Oo')).toBe(true);
+  });
+
+  it('matches prefix case-insensitively', () => {
+    expect(schemeNamePrefixMatches('OOD Drivers', 'oo')).toBe(true);
+    expect(schemeNamePrefixMatches('OOD Drivers', 'dr')).toBe(false);
+  });
+});

--- a/apps/api/prisma/migrations/20260903180000_policy_beneficiaries/migration.sql
+++ b/apps/api/prisma/migrations/20260903180000_policy_beneficiaries/migration.sql
@@ -1,0 +1,88 @@
+-- Policy next-of-kin share join (one beneficiary per policy).
+-- RLS is auto-enabled on public tables via ensure_rls_on_public_tables.
+
+CREATE TABLE "policy_beneficiaries" (
+    "id" UUID NOT NULL,
+    "policyId" UUID NOT NULL,
+    "beneficiaryId" UUID NOT NULL,
+    "percentage" INTEGER NOT NULL DEFAULT 100,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "policy_beneficiaries_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "policy_beneficiaries_policyId_key" ON "policy_beneficiaries"("policyId");
+CREATE INDEX "policy_beneficiaries_beneficiaryId_idx" ON "policy_beneficiaries"("beneficiaryId");
+
+ALTER TABLE "policy_beneficiaries"
+  ADD CONSTRAINT "policy_beneficiaries_policyId_fkey"
+  FOREIGN KEY ("policyId") REFERENCES "policies"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "policy_beneficiaries"
+  ADD CONSTRAINT "policy_beneficiaries_beneficiaryId_fkey"
+  FOREIGN KEY ("beneficiaryId") REFERENCES "beneficiaries"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Backfill: for each customer, walk supersession chains (root = no supersedesPolicyId).
+-- Assign the earliest remaining beneficiary (prefer percentage=100) to every policy in the chain.
+-- Extra historical people stay on beneficiaries for later picking.
+WITH RECURSIVE chain_members AS (
+  SELECT
+    p.id,
+    p."customerId",
+    p.id AS "rootId",
+    p."createdAt" AS "rootCreatedAt"
+  FROM "policies" p
+  WHERE p."supersedesPolicyId" IS NULL
+
+  UNION ALL
+
+  SELECT
+    child.id,
+    child."customerId",
+    cm."rootId",
+    cm."rootCreatedAt"
+  FROM "policies" child
+  JOIN chain_members cm ON child."supersedesPolicyId" = cm.id
+),
+ranked_chains AS (
+  SELECT
+    "customerId",
+    "rootId",
+    MIN("rootCreatedAt") AS "chainCreatedAt",
+    ROW_NUMBER() OVER (
+      PARTITION BY "customerId"
+      ORDER BY MIN("rootCreatedAt") ASC, "rootId" ASC
+    ) AS "chainRn"
+  FROM chain_members
+  GROUP BY "customerId", "rootId"
+),
+ranked_beneficiaries AS (
+  SELECT
+    b.id AS "beneficiaryId",
+    b."customerId",
+    b.percentage,
+    ROW_NUMBER() OVER (
+      PARTITION BY b."customerId"
+      ORDER BY
+        CASE WHEN b.percentage = 100 THEN 0 ELSE 1 END,
+        b."createdAt" ASC,
+        b.id ASC
+    ) AS "beneficiaryRn"
+  FROM "beneficiaries" b
+  WHERE b."deletedAt" IS NULL
+)
+INSERT INTO "policy_beneficiaries" ("id", "policyId", "beneficiaryId", "percentage", "createdAt", "updatedAt")
+SELECT
+  gen_random_uuid(),
+  cm.id,
+  rb."beneficiaryId",
+  COALESCE(rb.percentage, 100),
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
+FROM ranked_chains rc
+JOIN ranked_beneficiaries rb
+  ON rb."customerId" = rc."customerId"
+ AND rb."beneficiaryRn" = rc."chainRn"
+JOIN chain_members cm
+  ON cm."rootId" = rc."rootId";

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -269,6 +269,8 @@ model Beneficiary {
   deletedAt DateTime? @db.Timestamptz
   deletedBy String?   @db.Uuid // User ID who deleted
 
+  policyBeneficiaries PolicyBeneficiary[]
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -376,6 +378,7 @@ model Policy {
   lifecycleNotifications PolicyLifecycleNotification[]
   policyMemberPrincipals PolicyMemberPrincipal[]
   policyMemberDependants PolicyMemberDependant[]
+  policyBeneficiaries    PolicyBeneficiary[]
   lctMemberSyncTargets   LctMemberSyncTarget[]
 
   supersedesPolicy       Policy?  @relation("PolicySupersedes", fields: [supersedesPolicyId], references: [id], onDelete: SetNull)
@@ -999,6 +1002,24 @@ model PolicyMemberPrincipal {
   @@index([memberNumber])
   @@index([customerId])
   @@map("policy_member_principals")
+}
+
+/// Next-of-kin share for a single policy (exactly one join per policy).
+model PolicyBeneficiary {
+  id            String @id @default(uuid()) @db.Uuid
+  policyId      String @db.Uuid
+  beneficiaryId String @db.Uuid
+  percentage    Int    @default(100)
+
+  policy      Policy      @relation(fields: [policyId], references: [id], onDelete: Cascade)
+  beneficiary Beneficiary @relation(fields: [beneficiaryId], references: [id], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([policyId])
+  @@index([beneficiaryId])
+  @@map("policy_beneficiaries")
 }
 
 model PolicyMemberDependant {

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -70,6 +70,7 @@ import { InternalLctExportsController } from './controllers/internal/lct-exports
 import { HealthcareProvidersController } from './controllers/internal/healthcare-providers.controller';
 import { HealthcareProviderService } from './services/healthcare-provider.service';
 import { IdNumberRevealService } from './services/id-number-reveal.service';
+import { AdditionalPolicyService } from './services/additional-policy.service';
 
 @Module({
   imports: [
@@ -90,7 +91,7 @@ import { IdNumberRevealService } from './services/id-number-reveal.service';
     CustomerPortalModule,
   ],
   controllers: [AppController, CustomerController, InternalCustomerController, InternalPartnerManagementController, PublicPartnerManagementController, SupabaseTestController, ConnectionMonitorController, SosController, AgentRegistrationController, BootstrapController, ProductManagementController, PolicyController, PolicyLifecycleController, PolicyLifecycleOpsController, UnderwriterController, UserController, MpesaPaymentsController, MpesaIpnController, MpesaStkPushController, MpesaStkPushPublicController, RecoveryController, TestCustomersController, InternalLctExportsController, HealthcareProvidersController],
-  providers: [AppService, ExternalIntegrationsService, CustomerService, PartnerManagementService, SupabaseService, SosService, AgentRegistrationService, MissingRequirementService, ProductManagementService, PackagePricingService, PolicyService, PolicyLifecycleService, PolicyLifecycleJobService, EntityStatusChangeService, UnderwriterService, MpesaPaymentsService, PaymentAccountNumberService, SchemeContactService, PostpaidSchemePaymentService, MpesaIpnService, MpesaStkPushService, MpesaDarajaApiService, MpesaErrorMapperService, TestCustomersService, BootstrapUserService, IpWhitelistGuard, RootOnlyGuard, BAAuthorizationGuard, PaymentStatusGateway, PremiumStatementService, LctSyncService, LctExportService, LctStorageService, HealthcareProviderService, IdNumberRevealService],
+  providers: [AppService, ExternalIntegrationsService, CustomerService, PartnerManagementService, SupabaseService, SosService, AgentRegistrationService, MissingRequirementService, ProductManagementService, PackagePricingService, PolicyService, PolicyLifecycleService, PolicyLifecycleJobService, EntityStatusChangeService, UnderwriterService, MpesaPaymentsService, PaymentAccountNumberService, SchemeContactService, PostpaidSchemePaymentService, MpesaIpnService, MpesaStkPushService, MpesaDarajaApiService, MpesaErrorMapperService, TestCustomersService, BootstrapUserService, IpWhitelistGuard, RootOnlyGuard, BAAuthorizationGuard, PaymentStatusGateway, PremiumStatementService, LctSyncService, LctExportService, LctStorageService, HealthcareProviderService, IdNumberRevealService, AdditionalPolicyService],
   exports: [PrismaModule], // Export PrismaModule so middleware can access PrismaService
 })
 export class AppModule implements NestModule {

--- a/apps/api/src/controllers/internal/customer.controller.ts
+++ b/apps/api/src/controllers/internal/customer.controller.ts
@@ -70,6 +70,11 @@ import {
   RevealIdNumberRequestDto,
   RevealIdNumberResponseDto,
 } from '../../dto/customers/reveal-id-number.dto';
+import { AdditionalPolicyService } from '../../services/additional-policy.service';
+import {
+  CreateAdditionalPolicyRequestDto,
+  AdditionalPolicyResponseDto,
+} from '../../dto/policies/additional-policy.dto';
 
 /**
  * Internal Customer Controller
@@ -93,6 +98,7 @@ export class InternalCustomerController {
     private readonly partnerManagementService: PartnerManagementService,
     private readonly prismaService: PrismaService,
     private readonly idNumberRevealService: IdNumberRevealService,
+    private readonly additionalPolicyService: AdditionalPolicyService,
   ) {}
 
   /**
@@ -778,6 +784,32 @@ export class InternalCustomerController {
    * Complete postpaid enrollment pricing (plan/premium/annual) without STK.
    * Must be registered before :policyId routes.
    */
+  @Post(':customerId/additional-policies')
+  @HttpCode(HttpStatus.CREATED)
+  @AdminOnly()
+  @ApiOperation({
+    summary: 'Add an additional product for an existing customer (admin)',
+    description:
+      'Enrols a customer who already has a policy into another package. registration_admin only. No BA registration row.',
+  })
+  @ApiParam({ name: 'customerId', description: 'Customer ID' })
+  @ApiResponse({ status: 201, description: 'Additional policy created', type: AdditionalPolicyResponseDto })
+  @ApiResponse({ status: 403, description: 'Only registration_admin can add a product' })
+  async createAdditionalPolicy(
+    @Param('customerId') customerId: string,
+    @Body() dto: CreateAdditionalPolicyRequestDto,
+    @CorrelationId() correlationId: string,
+    @Req() req: Request,
+  ): Promise<AdditionalPolicyResponseDto> {
+    const userRoles = req.user?.roles ?? [];
+    return this.additionalPolicyService.createAdditionalPolicy(
+      customerId,
+      dto,
+      userRoles,
+      correlationId
+    );
+  }
+
   @Patch(':customerId/policies/postpaid-enrollment')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({

--- a/apps/api/src/controllers/internal/policy.controller.ts
+++ b/apps/api/src/controllers/internal/policy.controller.ts
@@ -82,6 +82,8 @@ export class PolicyController {
         productName: createRequest.productName,
         tags: createRequest.tags,
         customDays: createRequest.customDays,
+        dependantIds: createRequest.dependantIds,
+        beneficiaryId: createRequest.beneficiaryId,
         paymentData: {
           paymentType: createRequest.paymentData.paymentType,
           transactionReference: createRequest.paymentData.transactionReference,

--- a/apps/api/src/controllers/internal/product-management.controller.ts
+++ b/apps/api/src/controllers/internal/product-management.controller.ts
@@ -153,8 +153,11 @@ export class ProductManagementController {
     description: 'All schemes with isActive flag (inactive rows are for display only).',
   })
   @ApiResponse({ status: 200, description: 'Schemes retrieved successfully' })
-  async listSchemesForPicker(@CorrelationId() correlationId: string) {
-    const schemes = await this.productManagementService.listSchemesForPicker(correlationId);
+  async listSchemesForPicker(
+    @CorrelationId() correlationId: string,
+    @Query('q') q?: string,
+  ) {
+    const schemes = await this.productManagementService.listSchemesForPicker(correlationId, q);
     return {
       status: HttpStatus.OK,
       correlationId,

--- a/apps/api/src/controllers/internal/recovery.controller.ts
+++ b/apps/api/src/controllers/internal/recovery.controller.ts
@@ -199,6 +199,9 @@ export class RecoveryController {
       userRoles,
       correlationId
     );
+    const dependantIds =
+      body.dependantIds ??
+      (await this.policyService.listActiveDependantIds(body.customerId));
     const policy = await this.policyService.createPolicyWithoutPayments(
       {
         customerId: body.customerId,
@@ -208,6 +211,8 @@ export class RecoveryController {
         annualPremium: body.annualPremium,
         frequency: body.frequency,
         customDays: body.customDays,
+        dependantIds,
+        beneficiaryId: body.beneficiaryId,
       },
       correlationId
     );

--- a/apps/api/src/dto/customers/customer-products.dto.ts
+++ b/apps/api/src/dto/customers/customer-products.dto.ts
@@ -48,6 +48,9 @@ export class CustomerPolicyListItemDto {
   @ApiProperty({ description: 'Package name' })
   packageName: string;
 
+  @ApiProperty({ description: 'Package ID' })
+  packageId: number;
+
   @ApiProperty({ description: 'Plan name', required: false })
   planName?: string | null;
 
@@ -179,6 +182,21 @@ export class CustomerPolicyDetailDto {
     enum: ['prepaid', 'postpaid'],
   })
   schemeBillingMode: 'prepaid' | 'postpaid';
+
+  @ApiProperty({
+    description: 'This policy next-of-kin from policy_beneficiaries',
+    required: false,
+    nullable: true,
+  })
+  nextOfKin?: {
+    id: string;
+    firstName: string;
+    middleName: string | null;
+    lastName: string;
+    relationship: string | null;
+    phoneNumber: string | null;
+    percentage: number;
+  } | null;
 }
 
 export class CustomerPolicyDetailResponseDto {

--- a/apps/api/src/dto/policies/additional-policy.dto.ts
+++ b/apps/api/src/dto/policies/additional-policy.dto.ts
@@ -1,0 +1,135 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsArray,
+  IsBoolean,
+  IsEnum,
+  IsInt,
+  IsNumber,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Min,
+  MinLength,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { PaymentFrequency } from '@prisma/client';
+import { SpouseDto } from '../family-members/spouse.dto';
+import { ChildDto } from '../family-members/child.dto';
+import { ParentDto } from '../family-members/parent.dto';
+import { BeneficiaryDto } from '../family-members/beneficiary.dto';
+
+export class CreateAdditionalPolicyRequestDto {
+  @ApiProperty({ description: 'PackageScheme junction id for the new product' })
+  @IsInt()
+  @Min(1)
+  packageSchemeId: number;
+
+  @ApiProperty({ description: 'Package plan ID' })
+  @IsInt()
+  @Min(1)
+  packagePlanId: number;
+
+  @ApiProperty({ enum: PaymentFrequency })
+  @IsEnum(PaymentFrequency)
+  frequency: PaymentFrequency;
+
+  @ApiProperty({ description: 'Installment premium' })
+  @IsNumber()
+  @Min(0)
+  premium: number;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  annualPremium?: number;
+
+  @ApiProperty({ example: 'MfanisiGo Gold' })
+  @IsString()
+  @MinLength(1)
+  productName: string;
+
+  @ApiProperty({ required: false, type: [String] })
+  @IsOptional()
+  @IsArray()
+  @IsUUID('4', { each: true })
+  existingDependantIds?: string[];
+
+  @ApiProperty({ required: false, type: [SpouseDto] })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => SpouseDto)
+  newSpouses?: SpouseDto[];
+
+  @ApiProperty({ required: false, type: [ChildDto] })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ChildDto)
+  newChildren?: ChildDto[];
+
+  @ApiProperty({ required: false, type: [ParentDto] })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ParentDto)
+  newParents?: ParentDto[];
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsUUID()
+  beneficiaryId?: string;
+
+  @ApiProperty({ required: false, type: BeneficiaryDto })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => BeneficiaryDto)
+  newBeneficiary?: BeneficiaryDto;
+
+  @ApiProperty({
+    description: 'When a name-only duplicate is shown, confirm creating a new person',
+    required: false,
+    type: [String],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  confirmNewPersonKeys?: string[];
+
+  @ApiProperty({
+    description: 'Skip STK and leave the new policy PENDING_ACTIVATION',
+    required: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  skipPayment?: boolean;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  customDays?: number;
+}
+
+export class AdditionalPolicyResponseDto {
+  @ApiProperty({ example: 201 })
+  status: number;
+
+  @ApiProperty()
+  correlationId: string;
+
+  @ApiProperty()
+  message: string;
+
+  @ApiProperty()
+  policy: {
+    id: string;
+    policyNumber: string | null;
+    status: string;
+    productName: string;
+    premium: number;
+    paymentAcNumber: string | null;
+  };
+}

--- a/apps/api/src/dto/policies/create-policy.dto.ts
+++ b/apps/api/src/dto/policies/create-policy.dto.ts
@@ -189,6 +189,24 @@ export class CreatePolicyRequestDto {
   @IsInt()
   @Min(1)
   customDays?: number;
+
+  @ApiProperty({
+    description: 'Dependant IDs to enrol on this policy only (PMD stubs)',
+    required: false,
+    type: [String],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  dependantIds?: string[];
+
+  @ApiProperty({
+    description: 'Beneficiary ID for this policy next-of-kin (100%)',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  beneficiaryId?: string;
 }
 
 export class PolicyResponseDto {

--- a/apps/api/src/dto/policy-lifecycle/policy-lifecycle.dto.ts
+++ b/apps/api/src/dto/policy-lifecycle/policy-lifecycle.dto.ts
@@ -183,6 +183,9 @@ export class ModifyPolicyOptionsResponseDto {
   @ApiProperty()
   additionalSpouse: boolean;
 
+  @ApiProperty({ description: 'Extra-spouse add-on units: max(0, spouseCount - 1)' })
+  extraSpouseCount: number;
+
   @ApiProperty()
   currentPackagePlanId: number;
 

--- a/apps/api/src/dto/recovery/recovery.dto.ts
+++ b/apps/api/src/dto/recovery/recovery.dto.ts
@@ -8,6 +8,7 @@ import {
   Min,
   IsString,
   MaxLength,
+  IsArray,
 } from 'class-validator';
 import { PaymentFrequency } from '@prisma/client';
 
@@ -104,6 +105,17 @@ export class CreatePolicyFromRecoveryRequestDto {
   @IsInt()
   @Min(1)
   customDays?: number;
+
+  @ApiProperty({ description: 'Dependant IDs to enrol on this policy', required: false, type: [String] })
+  @IsOptional()
+  @IsArray()
+  @IsUUID('4', { each: true })
+  dependantIds?: string[];
+
+  @ApiProperty({ description: 'Beneficiary ID for this policy next-of-kin', required: false })
+  @IsOptional()
+  @IsUUID()
+  beneficiaryId?: string;
 }
 
 /** Member number reconciliation: one row per policy (or per customer with no policy) */

--- a/apps/api/src/modules/lct/__tests__/lct-late-dependants.spec.ts
+++ b/apps/api/src/modules/lct/__tests__/lct-late-dependants.spec.ts
@@ -1,0 +1,96 @@
+/// <reference types="jest" />
+import { PolicyStatus } from '@prisma/client';
+import { LctSyncService } from '../lct-sync.service';
+
+describe('LctSyncService.ensureMemberRowsForLateDependants', () => {
+  const prisma = {
+    policy: { findUnique: jest.fn() },
+    policyMemberDependant: {
+      findMany: jest.fn(),
+      create: jest.fn(),
+    },
+  };
+  const policyService = {
+    orderDependantsForMemberNumbers: jest.fn((rows: Array<{ id: string }>) => rows),
+    generateMemberNumberForPolicy: jest.fn().mockResolvedValue('MN-01'),
+  };
+  const service = new LctSyncService(prisma as never, policyService as never);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('skips EXPIRED and TERMINATED policies', async () => {
+    prisma.policy.findUnique.mockResolvedValue({
+      id: 'p1',
+      status: PolicyStatus.EXPIRED,
+      policyNumber: 'P-1',
+      packageId: 1,
+      customer: {
+        dependants: [{ id: 'd-new' }],
+        policyMemberPrincipals: [{ id: 1 }],
+      },
+    });
+
+    await service.ensureMemberRowsForLateDependants('p1', 'corr', undefined, ['d-new']);
+    expect(prisma.policyMemberDependant.create).not.toHaveBeenCalled();
+
+    prisma.policy.findUnique.mockResolvedValue({
+      id: 'p2',
+      status: PolicyStatus.TERMINATED,
+      policyNumber: 'P-2',
+      packageId: 1,
+      customer: {
+        dependants: [{ id: 'd-new' }],
+        policyMemberPrincipals: [{ id: 1 }],
+      },
+    });
+    await service.ensureMemberRowsForLateDependants('p2', 'corr', undefined, ['d-new']);
+    expect(prisma.policyMemberDependant.create).not.toHaveBeenCalled();
+  });
+
+  it('only attaches newly added dependant IDs on occupying policies', async () => {
+    prisma.policy.findUnique.mockResolvedValue({
+      id: 'p1',
+      status: PolicyStatus.ACTIVE,
+      policyNumber: 'P-1',
+      packageId: 1,
+      customer: {
+        dependants: [
+          { id: 'old-child', relationship: 'CHILD', deletedAt: null },
+          { id: 'new-child', relationship: 'CHILD', deletedAt: null },
+        ],
+        policyMemberPrincipals: [{ id: 1 }],
+      },
+    });
+    prisma.policyMemberDependant.findMany.mockResolvedValue([{ dependantId: 'old-child' }]);
+
+    await service.ensureMemberRowsForLateDependants('p1', 'corr', undefined, ['new-child']);
+
+    expect(policyService.orderDependantsForMemberNumbers).toHaveBeenCalledWith([
+      expect.objectContaining({ id: 'new-child' }),
+    ]);
+    expect(prisma.policyMemberDependant.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ dependantId: 'new-child', policyId: 'p1' }),
+      })
+    );
+  });
+
+  it('does not attach every customer dependant when no new IDs are provided', async () => {
+    prisma.policy.findUnique.mockResolvedValue({
+      id: 'p1',
+      status: PolicyStatus.ACTIVE,
+      policyNumber: 'P-1',
+      packageId: 1,
+      customer: {
+        dependants: [{ id: 'policy-2-only', relationship: 'CHILD', deletedAt: null }],
+        policyMemberPrincipals: [{ id: 1 }],
+      },
+    });
+    prisma.policyMemberDependant.findMany.mockResolvedValue([]);
+
+    await service.ensureMemberRowsForLateDependants('p1', 'corr');
+    expect(prisma.policyMemberDependant.create).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/modules/lct/lct-sync.service.ts
+++ b/apps/api/src/modules/lct/lct-sync.service.ts
@@ -14,6 +14,7 @@ import {
   mapPolicyStatusToLctAction,
   shouldEnqueueStatusChange,
 } from './lct.types';
+import { OCCUPYING_POLICY_STATUSES } from '../../utils/occupying-policy.util';
 
 type Tx = Prisma.TransactionClient;
 
@@ -377,12 +378,14 @@ export class LctSyncService {
   }
 
   /**
-   * Ensure late-added dependants get PolicyMemberDependant rows for an active-ish policy.
+   * Ensure late-added dependants get PolicyMemberDependant rows for occupying policies only.
+   * When newlyAddedDependantIds is provided, only those IDs are attached.
    */
   async ensureMemberRowsForLateDependants(
     policyId: string,
     correlationId: string,
-    tx?: Tx
+    tx?: Tx,
+    newlyAddedDependantIds?: string[]
   ): Promise<void> {
     const client = tx ?? this.prisma;
     const policy = await client.policy.findUnique({
@@ -397,16 +400,27 @@ export class LctSyncService {
       },
     });
     if (!policy) return;
+    if (!OCCUPYING_POLICY_STATUSES.includes(policy.status)) return;
     if (policy.customer.policyMemberPrincipals.length === 0) return;
     if (!policy.policyNumber && policy.status === PolicyStatus.PENDING_ACTIVATION) return;
 
+    // Only attach explicitly added IDs. Omitting the list must not enrol every
+    // customer dependant (that would leak a policy-2-only child onto policy 1).
+    if (!newlyAddedDependantIds || newlyAddedDependantIds.length === 0) {
+      return;
+    }
+    const allowedIds = new Set(newlyAddedDependantIds);
     const existing = await client.policyMemberDependant.findMany({
       where: { policyId },
       select: { dependantId: true },
     });
     const existingIds = new Set(existing.map((e) => e.dependantId));
     const missing = this.policyService.orderDependantsForMemberNumbers(
-      policy.customer.dependants.filter((d) => !existingIds.has(d.id))
+      policy.customer.dependants.filter((d) => {
+        if (existingIds.has(d.id)) return false;
+        if (!allowedIds.has(d.id)) return false;
+        return true;
+      })
     );
     if (missing.length === 0) return;
 

--- a/apps/api/src/services/__tests__/additional-policy.service.spec.ts
+++ b/apps/api/src/services/__tests__/additional-policy.service.spec.ts
@@ -1,0 +1,82 @@
+/// <reference types="jest" />
+import { AdditionalPolicyService } from '../additional-policy.service';
+import { ValidationException } from '../../exceptions/validation.exception';
+import { ErrorCodes } from '../../enums/error-codes.enum';
+
+describe('AdditionalPolicyService authorization and eligibility', () => {
+  const prisma = {
+    customer: { findUnique: jest.fn() },
+  };
+  const policyService = {};
+  const service = new AdditionalPolicyService(prisma as never, policyService as never);
+
+  it('rejects non-admin roles', () => {
+    expect(() => service.assertRegistrationAdmin(['brand_ambassador'])).toThrow(
+      ValidationException
+    );
+    try {
+      service.assertRegistrationAdmin(['brand_ambassador']);
+    } catch (error) {
+      expect(error).toBeInstanceOf(ValidationException);
+      expect((error as ValidationException).errorCode).toBe(ErrorCodes.INSUFFICIENT_PERMISSIONS);
+    }
+  });
+
+  it('allows registration_admin', () => {
+    expect(() => service.assertRegistrationAdmin(['registration_admin'])).not.toThrow();
+  });
+
+  it('blocks terminated customers', async () => {
+    prisma.customer.findUnique.mockResolvedValue({
+      id: 'c1',
+      status: 'TERMINATED',
+      createdByPartnerId: 1,
+      dependants: [],
+      beneficiaries: [],
+      policies: [{ id: 'p1', status: 'EXPIRED' }],
+    });
+
+    await expect(
+      service.createAdditionalPolicy(
+        'c1',
+        {
+          packageSchemeId: 1,
+          packagePlanId: 1,
+          frequency: 'MONTHLY',
+          premium: 100,
+          productName: 'Test',
+          beneficiaryId: 'b1',
+        } as never,
+        ['registration_admin'],
+        'corr'
+      )
+    ).rejects.toBeInstanceOf(ValidationException);
+  });
+
+  it('blocks when any policy is TERMINATED', async () => {
+    prisma.customer.findUnique.mockResolvedValue({
+      id: 'c1',
+      status: 'ACTIVE',
+      createdByPartnerId: 1,
+      dependants: [],
+      beneficiaries: [],
+      policies: [{ id: 'p1', status: 'TERMINATED' }],
+    });
+
+    await expect(
+      service.createAdditionalPolicy(
+        'c1',
+        {
+          packageSchemeId: 1,
+          packagePlanId: 1,
+          frequency: 'MONTHLY',
+          premium: 100,
+          productName: 'Test',
+          beneficiaryId: 'b1',
+        } as never,
+        ['registration_admin'],
+        'corr'
+      )
+    ).rejects.toBeInstanceOf(ValidationException);
+  });
+});

--- a/apps/api/src/services/__tests__/payment-account-number.service.spec.ts
+++ b/apps/api/src/services/__tests__/payment-account-number.service.spec.ts
@@ -1,0 +1,68 @@
+/// <reference types="jest" />
+import { PaymentAccountNumberService } from '../payment-account-number.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+describe('PaymentAccountNumberService generateForPolicy', () => {
+  const prisma = {} as PrismaService;
+  const service = new PaymentAccountNumberService(prisma);
+
+  const makeTx = () => ({
+    customer: { findUnique: jest.fn() },
+    policy: {
+      count: jest.fn(),
+      findMany: jest.fn(),
+      updateMany: jest.fn(),
+    },
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('steals idNumber from EXPIRED/DEACTIVATED/INACTIVE when none occupy', async () => {
+    const tx = makeTx();
+    tx.customer.findUnique.mockResolvedValue({ idNumber: '12345678' });
+    tx.policy.count.mockResolvedValue(0);
+    tx.policy.updateMany.mockResolvedValue({ count: 2 });
+
+    const pan = await service.generateForPolicy('cust-1', tx as never, 'corr');
+
+    expect(pan).toBe('12345678');
+    expect(tx.policy.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          paymentAcNumber: '12345678',
+          status: { in: ['EXPIRED', 'DEACTIVATED', 'INACTIVE'] },
+        }),
+        data: { paymentAcNumber: null },
+      })
+    );
+  });
+
+  it('suffixes when an occupying policy already exists', async () => {
+    const tx = makeTx();
+    tx.customer.findUnique.mockResolvedValue({ idNumber: '12345678' });
+    tx.policy.count.mockResolvedValue(1);
+    tx.policy.findMany.mockResolvedValue([{ paymentAcNumber: '12345678' }]);
+
+    const pan = await service.generateForPolicy('cust-1', tx as never, 'corr');
+
+    expect(pan).toBe('12345678B');
+    expect(tx.policy.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('never reuses an existing suffix for a second occupying policy', async () => {
+    const tx = makeTx();
+    tx.customer.findUnique.mockResolvedValue({ idNumber: '12345678' });
+    tx.policy.count.mockResolvedValue(2);
+    tx.policy.findMany.mockResolvedValue([
+      { paymentAcNumber: '12345678' },
+      { paymentAcNumber: '12345678B' },
+    ]);
+
+    const pan = await service.generateForPolicy('cust-1', tx as never, 'corr');
+    expect(pan).toBe('12345678C');
+    expect(pan).not.toBe('12345678');
+    expect(pan).not.toBe('12345678B');
+  });
+});

--- a/apps/api/src/services/__tests__/policy-beneficiary-copy.spec.ts
+++ b/apps/api/src/services/__tests__/policy-beneficiary-copy.spec.ts
@@ -1,0 +1,72 @@
+/// <reference types="jest" />
+import { PolicyService } from '../policy.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { PaymentAccountNumberService } from '../payment-account-number.service';
+import { PaymentMessagingService } from '../../modules/messaging/payment-messaging.service';
+import { PolicyLifecycleMessagingService } from '../../modules/messaging/policy-lifecycle-messaging.service';
+
+describe('copyPolicyBeneficiaries', () => {
+  const service = new PolicyService(
+    {} as unknown as PrismaService,
+    {} as unknown as PaymentAccountNumberService,
+    { notifyMatchedPaymentSmsAsync: jest.fn() } as unknown as PaymentMessagingService,
+    { suppressPendingActivationReminders: jest.fn() } as unknown as PolicyLifecycleMessagingService,
+    { onPolicyActivated: jest.fn() } as never
+  );
+
+  it('copies the single join onto the new policy', async () => {
+    const tx = {
+      policyBeneficiary: {
+        findUnique: jest.fn().mockResolvedValue({
+          policyId: 'old',
+          beneficiaryId: 'ben-1',
+          percentage: 100,
+        }),
+        upsert: jest.fn(),
+      },
+    };
+
+    await service.copyPolicyBeneficiaries(tx as never, 'old', 'new', 'corr');
+
+    expect(tx.policyBeneficiary.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { policyId: 'new' },
+        create: expect.objectContaining({
+          policyId: 'new',
+          beneficiaryId: 'ben-1',
+          percentage: 100,
+        }),
+      })
+    );
+  });
+
+  it('copies dependant stubs onto the replacement policy', async () => {
+    const tx = {
+      policyMemberDependant: {
+        findMany: jest.fn().mockResolvedValue([{ dependantId: 'dep-1' }]),
+        findFirst: jest.fn().mockResolvedValue(null),
+        create: jest.fn(),
+      },
+      policyBeneficiary: { upsert: jest.fn() },
+    };
+
+    await service.copyPolicyDependantStubs(tx as never, 'old', 'new', 'corr');
+
+    expect(tx.policyMemberDependant.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ policyId: 'new', dependantId: 'dep-1' }),
+      })
+    );
+  });
+
+  it('no-ops when the source policy has no join', async () => {
+    const tx = {
+      policyBeneficiary: {
+        findUnique: jest.fn().mockResolvedValue(null),
+        upsert: jest.fn(),
+      },
+    };
+    await service.copyPolicyBeneficiaries(tx as never, 'old', 'new', 'corr');
+    expect(tx.policyBeneficiary.upsert).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/__tests__/policy.service.spec.ts
+++ b/apps/api/src/services/__tests__/policy.service.spec.ts
@@ -349,3 +349,113 @@ describe('PolicyService - assertRecoveryAccessToCustomer', () => {
     ).rejects.toBeInstanceOf(NotFoundException);
   });
 });
+
+describe('PolicyService - activatePolicy membership isolation', () => {
+  const lifecycleMessagingServiceMock = {
+    suppressPendingActivationReminders: jest.fn(),
+  };
+  const lctSyncServiceMock = {
+    onPolicyActivated: jest.fn(),
+  };
+
+  const tx = {
+    policy: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+    packageSchemeCustomer: { findFirst: jest.fn() },
+    policyMemberPrincipal: { findFirst: jest.fn(), create: jest.fn() },
+    policyMemberDependant: { updateMany: jest.fn(), create: jest.fn() },
+    customer: { update: jest.fn() },
+  };
+
+  let policyService: PolicyService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    policyService = new PolicyService(
+      {} as unknown as PrismaService,
+      {} as unknown as PaymentAccountNumberService,
+      { notifyMatchedPaymentSmsAsync: jest.fn() } as unknown as PaymentMessagingService,
+      lifecycleMessagingServiceMock as unknown as PolicyLifecycleMessagingService,
+      lctSyncServiceMock as never
+    );
+    jest.spyOn(policyService as never, 'generateMemberNumber').mockResolvedValue('MN-01' as never);
+  });
+
+  it('assigns numbers only for this policy PMD stubs and does not attach a policy-2-only child', async () => {
+    const shared = {
+      id: 'dep-shared',
+      relationship: 'CHILD',
+      deletedAt: null,
+    };
+    const policy2Only = {
+      id: 'dep-p2',
+      relationship: 'CHILD',
+      deletedAt: null,
+    };
+    tx.policy.findUnique.mockResolvedValue({
+      id: 'policy-1',
+      customerId: 'cust-1',
+      packageId: 1,
+      status: 'PENDING_ACTIVATION',
+      policyNumber: 'P-001',
+      startDate: new Date('2026-01-01T00:00:00.000Z'),
+      endDate: new Date('2026-12-31T00:00:00.000Z'),
+      expectedInstallmentCount: 12,
+      paymentCadence: 30,
+      nominalPaymentPeriodEndDate: new Date('2026-12-01T00:00:00.000Z'),
+      customer: { id: 'cust-1', status: 'PENDING_ACTIVATION' },
+      policyMemberDependants: [{ dependantId: 'dep-shared', dependant: shared }],
+    });
+    tx.packageSchemeCustomer.findFirst.mockResolvedValue(null);
+    tx.policyMemberPrincipal.findFirst.mockResolvedValue(null);
+    tx.policy.update.mockResolvedValue({ id: 'policy-1', status: 'ACTIVE' });
+
+    await policyService.activatePolicy('policy-1', 'corr', tx as never);
+
+    expect(tx.policyMemberDependant.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { policyId: 'policy-1', dependantId: 'dep-shared' },
+      })
+    );
+    expect(tx.policyMemberDependant.create).not.toHaveBeenCalled();
+    expect(tx.policyMemberDependant.updateMany).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ dependantId: policy2Only.id }),
+      })
+    );
+  });
+});
+
+describe('PolicyService - insertMembershipStubs', () => {
+  const policyService = new PolicyService(
+    {} as unknown as PrismaService,
+    {} as unknown as PaymentAccountNumberService,
+    { notifyMatchedPaymentSmsAsync: jest.fn() } as unknown as PaymentMessagingService,
+    { suppressPendingActivationReminders: jest.fn() } as unknown as PolicyLifecycleMessagingService,
+    { onPolicyActivated: jest.fn() } as never
+  );
+
+  it('allows the same dependantId on two policies', async () => {
+    const tx = {
+      policyMemberDependant: {
+        findFirst: jest.fn().mockResolvedValue(null),
+        create: jest.fn().mockResolvedValue({ id: 1 }),
+      },
+      policyBeneficiary: { upsert: jest.fn() },
+    };
+
+    await policyService.insertMembershipStubs(tx as never, 'policy-1', ['dep-1'], undefined, 'c1');
+    await policyService.insertMembershipStubs(tx as never, 'policy-2', ['dep-1'], undefined, 'c2');
+
+    expect(tx.policyMemberDependant.create).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ data: expect.objectContaining({ policyId: 'policy-1', dependantId: 'dep-1' }) })
+    );
+    expect(tx.policyMemberDependant.create).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ data: expect.objectContaining({ policyId: 'policy-2', dependantId: 'dep-1' }) })
+    );
+  });
+});

--- a/apps/api/src/services/__tests__/product-management-picker-lists.spec.ts
+++ b/apps/api/src/services/__tests__/product-management-picker-lists.spec.ts
@@ -65,24 +65,68 @@ describe('ProductManagementService picker lists', () => {
     ]);
     const result = await service.listSchemesForPicker('corr');
     expect(result).toEqual([
-      { id: 1, name: 'A', isActive: true },
-      { id: 2, name: 'B', isActive: false },
+      { id: 1, name: 'A', isActive: true, parentsSupported: undefined, isPostpaid: undefined },
+      { id: 2, name: 'B', isActive: false, parentsSupported: undefined, isPostpaid: undefined },
     ]);
+  });
+
+  it('listSchemesForPicker prefix-searches when q has at least 2 letters', async () => {
+    prisma.scheme.findMany.mockResolvedValue([{ id: 3, schemeName: 'Ood Drivers', isActive: true }]);
+    await service.listSchemesForPicker('corr', 'Oo');
+    expect(prisma.scheme.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { schemeName: { startsWith: 'Oo', mode: 'insensitive' } },
+      }),
+    );
+  });
+
+  it('listSchemesForPicker returns empty when q is a single letter', async () => {
+    const result = await service.listSchemesForPicker('corr', 'O');
+    expect(result).toEqual([]);
+    expect(prisma.scheme.findMany).not.toHaveBeenCalled();
   });
 
   it('listPackagesForSchemes returns distinct packages for scheme ids', async () => {
     prisma.packageScheme.findMany.mockResolvedValue([
-      { package: { id: 10, name: 'Pkg A', isActive: true } },
-      { package: { id: 10, name: 'Pkg A', isActive: true } },
-      { package: { id: 11, name: 'Pkg B', isActive: false } },
+      {
+        id: 1,
+        package: { id: 10, name: 'Pkg A', slug: 'a', isActive: true, parentsSupported: false },
+        scheme: { isPostpaid: false, parentsSupported: false },
+      },
+      {
+        id: 1,
+        package: { id: 10, name: 'Pkg A', slug: 'a', isActive: true, parentsSupported: false },
+        scheme: { isPostpaid: false, parentsSupported: false },
+      },
+      {
+        id: 2,
+        package: { id: 11, name: 'Pkg B', slug: 'b', isActive: false, parentsSupported: true },
+        scheme: { isPostpaid: true, parentsSupported: true },
+      },
     ]);
     const result = await service.listPackagesForSchemes([1, 2], 'corr');
     expect(prisma.packageScheme.findMany).toHaveBeenCalledWith(
       expect.objectContaining({ where: { schemeId: { in: [1, 2] } } }),
     );
     expect(result).toEqual([
-      { id: 10, name: 'Pkg A', isActive: true },
-      { id: 11, name: 'Pkg B', isActive: false },
+      {
+        id: 10,
+        name: 'Pkg A',
+        isActive: true,
+        slug: 'a',
+        parentsSupported: false,
+        isPostpaid: false,
+        packageSchemeId: 1,
+      },
+      {
+        id: 11,
+        name: 'Pkg B',
+        isActive: false,
+        slug: 'b',
+        parentsSupported: true,
+        isPostpaid: true,
+        packageSchemeId: 2,
+      },
     ]);
   });
 });

--- a/apps/api/src/services/additional-policy.service.ts
+++ b/apps/api/src/services/additional-policy.service.ts
@@ -1,0 +1,421 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { DependantRelationship, PaymentType, Prisma } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { PolicyService } from './policy.service';
+import { ValidationException } from '../exceptions/validation.exception';
+import { ErrorCodes } from '../enums/error-codes.enum';
+import { CreateAdditionalPolicyRequestDto } from '../dto/policies/additional-policy.dto';
+import { hasGlobalCustomerAccess } from '../utils/roles.util';
+import { OCCUPYING_POLICY_STATUSES } from '../utils/occupying-policy.util';
+import { matchDuplicatePerson, type IdentifiedPerson } from '../utils/duplicate-person.util';
+import { householdCapsFromBands } from '../utils/family-category.util';
+import { SharedMapperUtils } from '../mappers/shared.mapper.utils';
+import { SpouseDto } from '../dto/family-members/spouse.dto';
+import { ChildDto } from '../dto/family-members/child.dto';
+import { ParentDto } from '../dto/family-members/parent.dto';
+import { BeneficiaryDto } from '../dto/family-members/beneficiary.dto';
+
+@Injectable()
+export class AdditionalPolicyService {
+  private readonly logger = new Logger(AdditionalPolicyService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly policyService: PolicyService
+  ) {}
+
+  assertRegistrationAdmin(userRoles: string[]): void {
+    if (!hasGlobalCustomerAccess(userRoles) && !userRoles.includes('registration_admin')) {
+      throw ValidationException.forField(
+        'authorization',
+        'Only registration administrators can add an additional product',
+        ErrorCodes.INSUFFICIENT_PERMISSIONS
+      );
+    }
+    if (!userRoles.includes('registration_admin') && !userRoles.includes('system_admin')) {
+      throw ValidationException.forField(
+        'authorization',
+        'Only registration administrators can add an additional product',
+        ErrorCodes.INSUFFICIENT_PERMISSIONS
+      );
+    }
+  }
+
+  async createAdditionalPolicy(
+    customerId: string,
+    dto: CreateAdditionalPolicyRequestDto,
+    userRoles: string[],
+    correlationId: string
+  ) {
+    this.assertRegistrationAdmin(userRoles);
+
+    const customer = await this.prisma.customer.findUnique({
+      where: { id: customerId },
+      include: {
+        dependants: { where: { deletedAt: null } },
+        beneficiaries: { where: { deletedAt: null } },
+        policies: { select: { id: true, status: true } },
+      },
+    });
+    if (!customer) {
+      throw new NotFoundException(`Customer ${customerId} not found`);
+    }
+
+    const validationErrors: Record<string, string> = {};
+    if (customer.status === 'TERMINATED') {
+      validationErrors['status'] = 'Cannot add a product for a terminated customer';
+    }
+    if (customer.policies.some((p) => p.status === 'TERMINATED')) {
+      validationErrors['policy'] = 'Cannot add a product while any policy is terminated';
+    }
+    if (!dto.beneficiaryId && !dto.newBeneficiary) {
+      validationErrors['beneficiary'] = 'Exactly one beneficiary is required';
+    }
+    if (dto.beneficiaryId && dto.newBeneficiary) {
+      validationErrors['beneficiary'] = 'Choose an existing next of kin or create one, not both';
+    }
+    if (Object.keys(validationErrors).length > 0) {
+      throw ValidationException.withMultipleErrors(validationErrors);
+    }
+
+    const packageScheme = await this.prisma.packageScheme.findUnique({
+      where: { id: dto.packageSchemeId },
+      include: {
+        package: {
+          include: {
+            packagePricingCategories: true,
+            packagePlans: { where: { id: dto.packagePlanId } },
+          },
+        },
+        scheme: {
+          select: { isPostpaid: true, parentsSupported: true, schemeName: true },
+        },
+      },
+    });
+    if (!packageScheme) {
+      throw ValidationException.forField('packageSchemeId', 'Package scheme not found');
+    }
+    const plan = packageScheme.package.packagePlans[0];
+    if (!plan) {
+      throw ValidationException.forField('packagePlanId', 'Plan not found for this package');
+    }
+
+    const bands = packageScheme.package.packagePricingCategories.map((c) => ({
+      key: c.key,
+      kind: c.kind,
+      maxMembers: c.maxMembers,
+    }));
+    const caps = householdCapsFromBands(bands, packageScheme.scheme.parentsSupported);
+    if (!caps.showParents && (dto.newParents?.length ?? 0) > 0) {
+      throw ValidationException.forField(
+        'newParents',
+        'Parents are not available for this package and scheme'
+      );
+    }
+
+    const existingSelected = customer.dependants.filter((d) =>
+      (dto.existingDependantIds ?? []).includes(d.id)
+    );
+    const extraCount =
+      existingSelected.filter((d) => d.relationship === 'SPOUSE' || d.relationship === 'CHILD')
+        .length +
+      (dto.newSpouses?.length ?? 0) +
+      (dto.newChildren?.length ?? 0);
+    if (!caps.hasFamilyBands && extraCount > 0) {
+      throw ValidationException.forField(
+        'household',
+        'This package is member-only; spouses and children cannot be enrolled'
+      );
+    }
+    if (caps.hasFamilyBands && extraCount > caps.maxExtraMembers) {
+      throw ValidationException.forField(
+        'household',
+        `This package allows at most ${caps.maxExtraMembers} additional spouse(s)/child(ren)`
+      );
+    }
+
+    const partnerId = customer.createdByPartnerId;
+    const family = await this.prisma.$transaction(async (tx) => {
+      const dependantIds = [...(dto.existingDependantIds ?? [])];
+
+      if (dto.newSpouses?.length) {
+        for (const spouse of dto.newSpouses) {
+          const id = await this.createOrReuseDependant(
+            tx,
+            customerId,
+            partnerId,
+            'SPOUSE',
+            spouse,
+            customer.dependants,
+            dto.confirmNewPersonKeys ?? [],
+            correlationId
+          );
+          dependantIds.push(id);
+        }
+      }
+      if (dto.newChildren?.length) {
+        for (const child of dto.newChildren) {
+          const id = await this.createOrReuseDependant(
+            tx,
+            customerId,
+            partnerId,
+            'CHILD',
+            child,
+            customer.dependants,
+            dto.confirmNewPersonKeys ?? [],
+            correlationId
+          );
+          dependantIds.push(id);
+        }
+      }
+      if (dto.newParents?.length) {
+        for (const parent of dto.newParents) {
+          await this.createParent(tx, customerId, partnerId, parent);
+        }
+      }
+
+      let beneficiaryId = dto.beneficiaryId ?? null;
+      if (dto.newBeneficiary) {
+        beneficiaryId = await this.createOrReuseBeneficiary(
+          tx,
+          customerId,
+          partnerId,
+          dto.newBeneficiary,
+          customer.beneficiaries,
+          dto.confirmNewPersonKeys ?? []
+        );
+      }
+      if (!beneficiaryId) {
+        throw ValidationException.forField('beneficiary', 'Exactly one beneficiary is required');
+      }
+
+      await this.ensurePackageSchemeCustomer(
+        tx,
+        customerId,
+        dto.packageSchemeId,
+        packageScheme.packageId,
+        partnerId
+      );
+
+      return { dependantIds, beneficiaryId };
+    });
+
+    const isPostpaid = packageScheme.scheme.isPostpaid;
+    const skipPayment = dto.skipPayment === true || isPostpaid;
+
+    const created = skipPayment
+      ? await this.policyService.createPolicyWithoutPayments(
+          {
+            customerId,
+            packageId: packageScheme.packageId,
+            packagePlanId: dto.packagePlanId,
+            premium: dto.premium,
+            annualPremium: dto.annualPremium,
+            frequency: dto.frequency,
+            customDays: dto.customDays,
+            dependantIds: family.dependantIds,
+            beneficiaryId: family.beneficiaryId,
+          },
+          correlationId
+        )
+      : (
+          await this.policyService.createPolicyWithPayment(
+            {
+              customerId,
+              packageId: packageScheme.packageId,
+              packagePlanId: dto.packagePlanId,
+              frequency: dto.frequency,
+              premium: dto.premium,
+              annualPremium: dto.annualPremium,
+              productName: dto.productName,
+              dependantIds: family.dependantIds,
+              beneficiaryId: family.beneficiaryId,
+              paymentData: {
+                paymentType: PaymentType.MPESA,
+                transactionReference: `PENDING-STK-${Date.now()}-${Math.random()
+                  .toString(36)
+                  .slice(2, 10)
+                  .toUpperCase()}`,
+                amount: dto.premium,
+                expectedPaymentDate: new Date(
+                  Date.UTC(
+                    new Date().getUTCFullYear(),
+                    new Date().getUTCMonth(),
+                    new Date().getUTCDate(),
+                    new Date().getUTCHours(),
+                    new Date().getUTCMinutes(),
+                    new Date().getUTCSeconds()
+                  )
+                ),
+              },
+            },
+            correlationId
+          )
+        ).policy;
+
+    this.logger.log(
+      `[${correlationId}] Additional policy ${created.id} created for customer ${customerId} PAN=${created.paymentAcNumber}`
+    );
+
+    return {
+      status: 201,
+      correlationId,
+      message: 'Additional policy created successfully',
+      policy: {
+        id: created.id,
+        policyNumber: created.policyNumber,
+        status: created.status,
+        productName: created.productName,
+        premium: Number(created.premium),
+        paymentAcNumber: created.paymentAcNumber,
+      },
+    };
+  }
+
+  private personKey(person: { firstName: string; lastName: string }): string {
+    return `${person.firstName.trim().toLowerCase()}|${person.lastName.trim().toLowerCase()}`;
+  }
+
+  private async createOrReuseDependant(
+    tx: Prisma.TransactionClient,
+    customerId: string,
+    partnerId: number,
+    relationship: DependantRelationship,
+    person: SpouseDto | ChildDto,
+    existing: IdentifiedPerson[],
+    confirmNewPersonKeys: string[],
+    _correlationId: string
+  ): Promise<string> {
+    const match = matchDuplicatePerson(person, existing);
+    if (match.kind === 'same_person') {
+      return match.existing.id;
+    }
+    if (match.kind === 'ambiguous') {
+      const key = this.personKey(person);
+      if (!confirmNewPersonKeys.includes(key) && !confirmNewPersonKeys.includes(match.existing.id)) {
+        throw ValidationException.forField(
+          relationship === 'SPOUSE' ? 'newSpouses' : 'newChildren',
+          `A person named ${person.firstName} ${person.lastName} already exists. Confirm they are the same person or a new one.`
+        );
+      }
+    }
+
+    const trimmedIdNumber = person.idNumber?.trim();
+    const mappedIdType = person.idType
+      ? SharedMapperUtils.mapIdTypeFromDto(person.idType)
+      : null;
+    const created = await tx.dependant.create({
+      data: {
+        customerId,
+        firstName: person.firstName,
+        middleName: person.middleName ?? null,
+        lastName: person.lastName,
+        dateOfBirth: person.dateOfBirth ? new Date(person.dateOfBirth) : null,
+        gender: person.gender ? SharedMapperUtils.mapGenderFromDto(person.gender) : null,
+        phoneNumber: 'phoneNumber' in person ? (person.phoneNumber ?? null) : null,
+        idType: trimmedIdNumber ? mappedIdType : null,
+        idNumber: trimmedIdNumber ?? null,
+        relationship,
+        createdByPartnerId: partnerId,
+      },
+    });
+    return created.id;
+  }
+
+  private async createParent(
+    tx: Prisma.TransactionClient,
+    customerId: string,
+    partnerId: number,
+    parent: ParentDto
+  ): Promise<void> {
+    const trimmedIdNumber = parent.idNumber?.trim();
+    await tx.customerParent.create({
+      data: {
+        customerId,
+        firstName: parent.firstName,
+        middleName: parent.middleName ?? null,
+        lastName: parent.lastName,
+        dateOfBirth: parent.dateOfBirth ? new Date(parent.dateOfBirth) : null,
+        gender: SharedMapperUtils.mapGenderFromDto(parent.gender),
+        idType: trimmedIdNumber ? SharedMapperUtils.mapIdTypeFromDto(parent.idType) : null,
+        idNumber: trimmedIdNumber ?? null,
+        relationship: parent.relationship,
+        createdByPartnerId: partnerId,
+      },
+    });
+  }
+
+  private async createOrReuseBeneficiary(
+    tx: Prisma.TransactionClient,
+    customerId: string,
+    partnerId: number,
+    person: BeneficiaryDto,
+    existing: IdentifiedPerson[],
+    confirmNewPersonKeys: string[]
+  ): Promise<string> {
+    const match = matchDuplicatePerson(person, existing);
+    if (match.kind === 'same_person') {
+      return match.existing.id;
+    }
+    if (match.kind === 'ambiguous') {
+      const key = this.personKey(person);
+      if (!confirmNewPersonKeys.includes(key) && !confirmNewPersonKeys.includes(match.existing.id)) {
+        throw ValidationException.forField(
+          'newBeneficiary',
+          `A next of kin named ${person.firstName} ${person.lastName} already exists. Confirm they are the same person or a new one.`
+        );
+      }
+    }
+    const trimmedIdNumber = person.idNumber?.trim();
+    const created = await tx.beneficiary.create({
+      data: {
+        customerId,
+        firstName: person.firstName,
+        middleName: person.middleName ?? null,
+        lastName: person.lastName,
+        dateOfBirth: person.dateOfBirth ? new Date(person.dateOfBirth) : null,
+        gender: SharedMapperUtils.mapGenderFromDto(person.gender),
+        phoneNumber: person.phoneNumber ?? null,
+        email: person.email ?? null,
+        idType: trimmedIdNumber ? SharedMapperUtils.mapIdTypeFromDto(person.idType) : null,
+        idNumber: trimmedIdNumber ?? null,
+        relationship: person.relationship,
+        relationshipDescription: person.relationshipDescription ?? null,
+        percentage: 100,
+        createdByPartnerId: partnerId,
+      },
+    });
+    return created.id;
+  }
+
+  private async ensurePackageSchemeCustomer(
+    tx: Prisma.TransactionClient,
+    customerId: string,
+    packageSchemeId: number,
+    packageId: number,
+    partnerId: number
+  ): Promise<void> {
+    const existing = await tx.packageSchemeCustomer.findFirst({
+      where: {
+        customerId,
+        packageScheme: { packageId },
+      },
+    });
+    if (existing) {
+      await tx.packageSchemeCustomer.update({
+        where: { id: existing.id },
+        data: { packageSchemeId },
+      });
+      return;
+    }
+    await tx.packageSchemeCustomer.create({
+      data: {
+        customerId,
+        packageSchemeId,
+        partnerId,
+      },
+    });
+  }
+}
+
+export const ADDITIONAL_POLICY_OCCUPYING = OCCUPYING_POLICY_STATUSES;

--- a/apps/api/src/services/customer.service.ts
+++ b/apps/api/src/services/customer.service.ts
@@ -670,6 +670,21 @@ export class CustomerService {
         });
       }
 
+      // Attach only this registration's dependants/beneficiary to the postpaid shell.
+      if (postpaidPolicyId) {
+        const postpaidDependantIds = [
+          ...createdChildren.map((d) => d.id),
+          ...createdSpouses.map((d) => d.id),
+        ];
+        await this.policyService.insertMembershipStubs(
+          this.prismaService as never,
+          postpaidPolicyId,
+          postpaidDependantIds,
+          createdBeneficiaries[0]?.id,
+          correlationId
+        );
+      }
+
       // Postpaid historical map/activate only after dependants exist (Sharon/Kailani race).
       if (postpaidPolicyId && createdCustomer.idNumber) {
         const deferredPostpaidPolicyId = postpaidPolicyId;
@@ -687,7 +702,9 @@ export class CustomerService {
           // Safety net if activation ran with partial family, or map left policy already active.
           await this.lctSyncService.ensureMemberRowsForLateDependants(
             deferredPostpaidPolicyId,
-            correlationId
+            correlationId,
+            undefined,
+            postpaidDependantIds
           );
           await this.lctSyncService.upsertTargetsForPolicy(
             deferredPostpaidPolicyId,
@@ -1158,16 +1175,22 @@ export class CustomerService {
 
       this.logger.log(`[${correlationId}] Successfully added ${result.totalProcessed} dependants to customer ${customerId}`);
 
-      // Late dependants: create member numbers + LCT pending for syncable policies
+      // Late dependants: occupying policies only, newly added IDs only
+      const newDependantIds = result.addedDependants.map((d) => d.dependantId);
       const policies = await this.prismaService.policy.findMany({
         where: {
           customerId,
-          status: { in: ['ACTIVE', 'SUSPENDED', 'INACTIVE', 'DEACTIVATED', 'TERMINATED', 'EXPIRED'] },
+          status: { in: ['ACTIVE', 'PENDING_ACTIVATION', 'SUSPENDED'] },
         },
         select: { id: true },
       });
       for (const policy of policies) {
-        await this.lctSyncService.ensureMemberRowsForLateDependants(policy.id, correlationId);
+        await this.lctSyncService.ensureMemberRowsForLateDependants(
+          policy.id,
+          correlationId,
+          undefined,
+          newDependantIds
+        );
         await this.lctSyncService.upsertTargetsForPolicy(policy.id, correlationId);
         await this.lctSyncService.onPolicyActivated(policy.id, correlationId);
       }
@@ -2855,6 +2878,7 @@ export class CustomerService {
         id: p.id,
         productName: p.productName,
         packageName: p.package.name,
+        packageId: p.packageId,
         planName: p.packagePlan?.name ?? null,
         schemeName,
         underwriterName: p.package.underwriter?.name ?? null,
@@ -2906,6 +2930,20 @@ export class CustomerService {
           },
         },
         packagePlan: { select: { name: true } },
+        policyBeneficiaries: {
+          include: {
+            beneficiary: {
+              select: {
+                id: true,
+                firstName: true,
+                middleName: true,
+                lastName: true,
+                relationship: true,
+                phoneNumber: true,
+              },
+            },
+          },
+        },
         policyPayments: {
           where: notDetachedPaymentWhere(),
           select: {
@@ -3016,6 +3054,17 @@ export class CustomerService {
         paymentsMadeCount: countConfirmedPayments(policy.policyPayments),
         missedPaymentsAmount,
         schemeBillingMode,
+        nextOfKin: policy.policyBeneficiaries[0]
+          ? {
+              id: policy.policyBeneficiaries[0].beneficiary.id,
+              firstName: policy.policyBeneficiaries[0].beneficiary.firstName,
+              middleName: policy.policyBeneficiaries[0].beneficiary.middleName,
+              lastName: policy.policyBeneficiaries[0].beneficiary.lastName,
+              relationship: policy.policyBeneficiaries[0].beneficiary.relationship,
+              phoneNumber: policy.policyBeneficiaries[0].beneficiary.phoneNumber,
+              percentage: policy.policyBeneficiaries[0].percentage,
+            }
+          : null,
       },
     };
   }

--- a/apps/api/src/services/customer.service.ts
+++ b/apps/api/src/services/customer.service.ts
@@ -671,11 +671,11 @@ export class CustomerService {
       }
 
       // Attach only this registration's dependants/beneficiary to the postpaid shell.
+      const postpaidDependantIds = [
+        ...createdChildren.map((d) => d.id),
+        ...createdSpouses.map((d) => d.id),
+      ];
       if (postpaidPolicyId) {
-        const postpaidDependantIds = [
-          ...createdChildren.map((d) => d.id),
-          ...createdSpouses.map((d) => d.id),
-        ];
         await this.policyService.insertMembershipStubs(
           this.prismaService as never,
           postpaidPolicyId,

--- a/apps/api/src/services/payment-account-number.service.ts
+++ b/apps/api/src/services/payment-account-number.service.ts
@@ -2,6 +2,10 @@ import { Injectable, Logger } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { Prisma } from '@prisma/client';
 import * as Sentry from '@sentry/nestjs';
+import {
+  OCCUPYING_POLICY_STATUSES,
+  STEALABLE_PAN_STATUSES,
+} from '../utils/occupying-policy.util';
 
 /**
  * Letters for policy payment account suffix (2nd policy = B, 3rd = C, ...).
@@ -132,25 +136,70 @@ export class PaymentAccountNumberService {
   }
 
   /**
-   * Generate payment account number for a policy
-   * First policy: customer idNumber. Subsequent: idNumber + letter (B, C, D, ... excluding A, I, J, O).
-   *
-   * @param customerId - Customer UUID
-   * @param isFirstPolicy - Whether this is the customer's first policy
-   * @param tx - Prisma transaction client
-   * @param correlationId - Correlation ID for logging
-   * @returns Payment account number
+   * Collect letter suffixes already used on this customer's payment account numbers.
+   * Bare idNumber (no suffix) is treated as the first occupying slot.
+   */
+  usedPolicySuffixes(idNumber: string, paymentAcNumbers: Array<string | null>): Set<string> {
+    const used = new Set<string>();
+    const base = idNumber.trim();
+    for (const raw of paymentAcNumbers) {
+      const value = (raw ?? '').trim();
+      if (!value || !value.startsWith(base)) continue;
+      const suffix = value.slice(base.length);
+      if (suffix) used.add(suffix);
+    }
+    return used;
+  }
+
+  /**
+   * Next unused suffix from the letter set (B, C, …) given already-used suffixes.
+   */
+  nextUnusedPolicySuffix(usedSuffixes: Set<string>): string {
+    for (let i = 0; i < 500; i++) {
+      const suffix = this.getPolicySuffixLetter(i);
+      if (!usedSuffixes.has(suffix)) return suffix;
+    }
+    throw new Error('Exhausted payment account number suffixes');
+  }
+
+  /**
+   * Null paymentAcNumber on EXPIRED / DEACTIVATED / INACTIVE rows that still hold idNumber.
+   */
+  async stealIdNumberFromHistoricalPolicies(
+    customerId: string,
+    idNumber: string,
+    tx: Prisma.TransactionClient,
+    correlationId: string
+  ): Promise<number> {
+    const result = await tx.policy.updateMany({
+      where: {
+        customerId,
+        paymentAcNumber: idNumber,
+        status: { in: STEALABLE_PAN_STATUSES },
+      },
+      data: { paymentAcNumber: null },
+    });
+    if (result.count > 0) {
+      this.logger.log(
+        `[${correlationId}] Stole paymentAcNumber ${idNumber} from ${result.count} historical polic(ies)`
+      );
+    }
+    return result.count;
+  }
+
+  /**
+   * Generate payment account number for a policy.
+   * No occupying policy → customer idNumber (steal it off EXPIRED/DEACTIVATED/INACTIVE).
+   * Already occupying → idNumber + unused letter from the existing suffix set.
    */
   async generateForPolicy(
     customerId: string,
-    isFirstPolicy: boolean,
     tx: Prisma.TransactionClient,
     correlationId: string
   ): Promise<string> {
     try {
       this.logger.log(
-        `[${correlationId}] Generating payment account number for policy. ` +
-          `Customer: ${customerId}, First policy: ${isFirstPolicy}`
+        `[${correlationId}] Generating payment account number for policy. Customer: ${customerId}`
       );
 
       const customer = await tx.customer.findUnique({
@@ -167,20 +216,38 @@ export class PaymentAccountNumberService {
         throw new Error(`Customer ${customerId} has no idNumber`);
       }
 
-      if (isFirstPolicy) {
+      const occupyingCount = await tx.policy.count({
+        where: {
+          customerId,
+          status: { in: OCCUPYING_POLICY_STATUSES },
+        },
+      });
+
+      if (occupyingCount === 0) {
+        await this.stealIdNumberFromHistoricalPolicies(
+          customerId,
+          idNumber,
+          tx,
+          correlationId
+        );
         this.logger.log(
-          `[${correlationId}] Using customer ID number for first policy: ${idNumber}`
+          `[${correlationId}] No occupying policy — using customer ID number: ${idNumber}`
         );
         return idNumber;
       }
 
-      const existingCount = await tx.policy.count({
-        where: { customerId },
+      const existing = await tx.policy.findMany({
+        where: { customerId, paymentAcNumber: { not: null } },
+        select: { paymentAcNumber: true },
       });
-      const suffix = this.getPolicySuffixLetter(existingCount);
+      const used = this.usedPolicySuffixes(
+        idNumber,
+        existing.map((p) => p.paymentAcNumber)
+      );
+      const suffix = this.nextUnusedPolicySuffix(used);
       const paymentAcNumber = idNumber + suffix;
       this.logger.log(
-        `[${correlationId}] Using idNumber + suffix for policy ${existingCount + 1}: ${paymentAcNumber}`
+        `[${correlationId}] Occupying policies exist — using suffixed number: ${paymentAcNumber}`
       );
       return paymentAcNumber;
     } catch (error) {
@@ -194,7 +261,7 @@ export class PaymentAccountNumberService {
           operation: 'generateForPolicy',
           correlationId,
         },
-        extra: { customerId, isFirstPolicy },
+        extra: { customerId },
       });
       throw error;
     }
@@ -339,46 +406,36 @@ export class PaymentAccountNumberService {
   }
 
   /**
-   * Check if a customer has any existing policies
-   *
-   * @param customerId - Customer UUID
-   * @param tx - Prisma transaction client (optional)
-   * @param correlationId - Correlation ID for logging
-   * @returns True if customer has existing policies
+   * True when the customer has an occupying (ACTIVE / PENDING_ACTIVATION / SUSPENDED) policy.
+   * Do not count EXPIRED / DEACTIVATED / INACTIVE / TERMINATED history rows.
+   */
+  async customerHasOccupyingPolicies(
+    customerId: string,
+    tx: Prisma.TransactionClient | null,
+    correlationId: string
+  ): Promise<boolean> {
+    const prisma = tx ?? this.prismaService;
+    const policyCount = await prisma.policy.count({
+      where: {
+        customerId,
+        status: { in: OCCUPYING_POLICY_STATUSES },
+      },
+    });
+    this.logger.log(
+      `[${correlationId}] Customer ${customerId} has ${policyCount} occupying policies`
+    );
+    return policyCount > 0;
+  }
+
+  /**
+   * @deprecated Use customerHasOccupyingPolicies. Counts occupying rows only.
    */
   async customerHasExistingPolicies(
     customerId: string,
     tx: Prisma.TransactionClient | null,
     correlationId: string
   ): Promise<boolean> {
-    try {
-      const prisma = tx ?? this.prismaService;
-
-      const policyCount = await prisma.policy.count({
-        where: { customerId },
-      });
-
-      const hasExisting = policyCount > 0;
-      this.logger.log(
-        `[${correlationId}] Customer ${customerId} has ${policyCount} existing policies`
-      );
-
-      return hasExisting;
-    } catch (error) {
-      this.logger.error(
-        `[${correlationId}] Error checking customer policies`,
-        error instanceof Error ? error.stack : String(error)
-      );
-      Sentry.captureException(error, {
-        tags: {
-          service: 'PaymentAccountNumberService',
-          operation: 'customerHasExistingPolicies',
-          correlationId,
-        },
-        extra: { customerId },
-      });
-      throw error;
-    }
+    return this.customerHasOccupyingPolicies(customerId, tx, correlationId);
   }
 }
 

--- a/apps/api/src/services/policy-lifecycle.service.ts
+++ b/apps/api/src/services/policy-lifecycle.service.ts
@@ -27,9 +27,11 @@ import {
   nextDisabledPolicyNumber,
 } from '../utils/disabled-policy-number.util';
 import {
+  countActiveSpouses,
   deriveFamilyCategoryFromDependants,
-  hasAdditionalSpousePremium,
+  extraSpouseAddonCount,
 } from '../utils/family-category.util';
+import { nextCustomerStatusAfterPolicies } from '../utils/customer-status-after-policy.util';
 import {
   ActivatePolicyRequestDto,
   DeactivatePolicyRequestDto,
@@ -1082,6 +1084,9 @@ export class PolicyLifecycleService {
         },
       });
 
+      await this.policyService.copyPolicyBeneficiaries(tx, prior.id, created.id, correlationId);
+      await this.policyService.copyPolicyDependantStubs(tx, prior.id, created.id, correlationId);
+
       if (prior.status === PolicyStatus.SUSPENDED || prior.status === PolicyStatus.INACTIVE) {
         await this.statusChangeService.recordPolicyChange({
           customerId: prior.customerId,
@@ -1685,28 +1690,13 @@ export class PolicyLifecycleService {
     const customer = await tx.customer.findUnique({ where: { id: customerId } });
     if (!customer) return;
 
-    const closedStatus = options?.whenNoOpenPolicies ?? CustomerStatus.DEACTIVATED;
-
-    let nextStatus: CustomerStatus | null = null;
-    if (hasActive) {
-      if (
-        customer.status === CustomerStatus.DEACTIVATED ||
-        customer.status === CustomerStatus.SUSPENDED ||
-        customer.status === CustomerStatus.TERMINATED
-      ) {
-        nextStatus = CustomerStatus.ACTIVE;
-      }
-    } else if (hasPending) {
-      if (customer.status !== CustomerStatus.PENDING_ACTIVATION) {
-        nextStatus = CustomerStatus.PENDING_ACTIVATION;
-      }
-    } else if (hasSuspended) {
-      if (customer.status !== CustomerStatus.SUSPENDED) {
-        nextStatus = CustomerStatus.SUSPENDED;
-      }
-    } else {
-      nextStatus = closedStatus;
-    }
+    const nextStatus = nextCustomerStatusAfterPolicies({
+      customerStatus: customer.status,
+      hasActive,
+      hasPending,
+      hasSuspended,
+      whenNoOpenPolicies: options?.whenNoOpenPolicies ?? CustomerStatus.DEACTIVATED,
+    });
 
     if (nextStatus == null || nextStatus === customer.status) {
       return;
@@ -2160,7 +2150,11 @@ export class PolicyLifecycleService {
       where: { customerId, deletedAt: null },
     });
     const familyCategory = deriveFamilyCategoryFromDependants(dependants);
-    const additionalSpouse = hasAdditionalSpousePremium(familyCategory, dependants);
+    const extraSpouseCount = extraSpouseAddonCount(
+      countActiveSpouses(dependants),
+      familyCategory
+    );
+    const additionalSpouse = extraSpouseCount > 0;
 
     const completedPayments = await this.prisma.policyPayment.findMany({
       where: {
@@ -2201,6 +2195,7 @@ export class PolicyLifecycleService {
       })),
       familyCategory,
       additionalSpouse,
+      extraSpouseCount,
       currentPackagePlanId: policy.packagePlanId ?? 0,
       currentPlanName: policy.packagePlan?.name,
       currentPremium: Number(policy.premium),
@@ -2419,6 +2414,11 @@ export class PolicyLifecycleService {
         where: { id: policyId },
         data: { supersededByPolicyId: newPolicy.id },
       });
+
+      await this.policyService.copyPolicyBeneficiaries(tx, policyId, newPolicy.id, correlationId);
+      if (dto.policyNumberChoice === PolicyNumberChoice.GENERATE_NEW) {
+        await this.policyService.copyPolicyDependantStubs(tx, policyId, newPolicy.id, correlationId);
+      }
 
       if (dto.packageSchemeId != null) {
         await tx.packageSchemeCustomer.updateMany({

--- a/apps/api/src/services/policy.service.ts
+++ b/apps/api/src/services/policy.service.ts
@@ -27,6 +27,10 @@ import { notDetachedPaymentWhere } from '../utils/policy-payment-filters';
 import { computeNominalPaymentPeriodEndDate } from '../utils/package-payment-frequency.util';
 import { ValidationException } from '../exceptions/validation.exception';
 import { ErrorCodes } from '../enums/error-codes.enum';
+import {
+  evaluateOccupyingProductRules,
+  OCCUPYING_POLICY_STATUSES,
+} from '../utils/occupying-policy.util';
 
 /**
  * Policy Service
@@ -529,6 +533,8 @@ export class PolicyService {
       annualPremium?: number;
       productName: string;
       tags?: Array<{ id?: number; name: string }>;
+      dependantIds?: string[];
+      beneficiaryId?: string;
       paymentData: {
         paymentType: PaymentType;
         transactionReference: string;
@@ -610,19 +616,7 @@ export class PolicyService {
         );
       }
 
-      // At most one non-terminal policy per customer per package
-      const existingPolicyForPackage = await this.prismaService.policy.findFirst({
-        where: {
-          customerId: data.customerId,
-          packageId: data.packageId,
-          status: { in: ['ACTIVE', 'PENDING_ACTIVATION', 'SUSPENDED'] },
-        },
-      });
-      if (existingPolicyForPackage) {
-        throw new ConflictException(
-          `Customer already has an active policy for this package (policy ID: ${existingPolicyForPackage.id})`
-        );
-      }
+      await this.assertOccupyingProductRules(data.customerId, data.packageId);
 
       // Resolve scheme by package: customer's scheme for this package (not just any scheme)
       const customerScheme = await this.prismaService.packageSchemeCustomer.findFirst({
@@ -690,22 +684,14 @@ export class PolicyService {
           `[${correlationId}] ✓ Idempotency check passed: No existing payment found for transactionReference ${data.paymentData.transactionReference}. Proceeding with policy creation.`
         );
 
-        // Determine payment account number: first policy (any type) gets idNumber; subsequent get idNumber+letter
-        const isFirstPolicy = !(await this.paymentAccountNumberService.customerHasExistingPolicies(
-          data.customerId,
-          tx,
-          correlationId
-        ));
-
         const paymentAcNumber = await this.paymentAccountNumberService.generateForPolicy(
           data.customerId,
-          isFirstPolicy,
           tx,
           correlationId
         );
 
         this.logger.log(
-          `[${correlationId}] Payment account number for ${isPostpaidScheme ? 'postpaid' : 'prepaid'} policy: ${paymentAcNumber} (first policy: ${isFirstPolicy})`
+          `[${correlationId}] Payment account number for ${isPostpaidScheme ? 'postpaid' : 'prepaid'} policy: ${paymentAcNumber}`
         );
 
         // Calculate payment cadence
@@ -960,6 +946,14 @@ export class PolicyService {
             )
           );
         }
+
+        await this.insertMembershipStubs(
+          tx,
+          policy.id,
+          data.dependantIds ?? [],
+          data.beneficiaryId,
+          correlationId
+        );
 
         // Create policy payment. For PENDING-STK placeholders use customer.idNumber for accountNumber.
         const isPlaceholderStk =
@@ -1414,13 +1408,15 @@ export class PolicyService {
     try {
       // Use provided transaction or create a new one
       const executeActivation = async (txClient: Prisma.TransactionClient) => {
-        // Get policy with customer and dependants
         const policy = await txClient.policy.findUnique({
           where: { id: policyId },
           include: {
             customer: {
+              select: { id: true, status: true },
+            },
+            policyMemberDependants: {
               include: {
-                dependants: true,
+                dependant: true,
               },
             },
           },
@@ -1645,56 +1641,52 @@ export class PolicyService {
           `for customer ${policy.customerId}`
         );
 
-        // Create PolicyMemberDependant records for each dependant
-        // Order: spouses first (01, 02, ...), then others (e.g. children). Principal is always 00.
-        if (policy.customer.dependants && policy.customer.dependants.length > 0) {
-          const orderedDependants = this.orderDependantsForMemberNumbers(
-            policy.customer.dependants
+        // Assign member numbers only for PMD stubs already attached to THIS policy.
+        const stubDependants = (policy.policyMemberDependants ?? [])
+          .map((row) => row.dependant)
+          .filter((d): d is NonNullable<typeof d> => d != null && d.deletedAt == null);
+        const orderedDependants = this.orderDependantsForMemberNumbers(stubDependants);
+        this.logger.log(
+          `[${correlationId}] Assigning member numbers for ${orderedDependants.length} policy dependants (stubs only)`
+        );
+
+        for (let i = 0; i < orderedDependants.length; i++) {
+          const dependant = orderedDependants[i];
+          const dependantMemberNumber = await this.generateMemberNumber(
+            policy.packageId,
+            policyNumber,
+            txClient,
+            correlationId,
+            i + 1
           );
-          this.logger.log(
-            `[${correlationId}] Creating member records for ${orderedDependants.length} dependants (spouses first)`
-          );
 
-          for (let i = 0; i < orderedDependants.length; i++) {
-            const dependant = orderedDependants[i];
-            // Dependants start at sequence 1 (formatted as 01), then 2 (02), etc.
-            const dependantMemberNumber = await this.generateMemberNumber(
-              policy.packageId,
-              policyNumber,
-              txClient,
-              correlationId,
-              i + 1 // Dependant sequence: 1 -> 01, 2 -> 02, etc.
-            );
-
-            await txClient.policyMemberDependant.create({
-              data: {
-                dependantId: dependant.id,
-                policyId: policyId,
-                memberNumber: dependantMemberNumber,
-              },
-            });
-
-            this.logger.log(
-              `[${correlationId}] Created dependant member record with number ${dependantMemberNumber} ` +
-              `for dependant ${dependant.id}`
-            );
-          }
-        }
-
-        // Update customer status to ACTIVE if this is the first policy
-        const customerPoliciesCount = await txClient.policy.count({
-          where: { customerId: policy.customerId },
-        });
-
-        if (customerPoliciesCount === 1) {
-          // This is the first policy - update customer status to ACTIVE
-          await txClient.customer.update({
-            where: { id: policy.customerId },
-            data: { status: 'ACTIVE' },
+          await txClient.policyMemberDependant.updateMany({
+            where: { policyId, dependantId: dependant.id },
+            data: {
+              memberNumber: dependantMemberNumber,
+              updatedAt: new Date(),
+            },
           });
 
           this.logger.log(
-            `[${correlationId}] Updated customer ${policy.customerId} status to ACTIVE (first policy)`
+            `[${correlationId}] Assigned dependant member number ${dependantMemberNumber} ` +
+            `for dependant ${dependant.id} on policy ${policyId}`
+          );
+        }
+
+        const customerStatus = policy.customer.status;
+        if (
+          customerStatus === 'DEACTIVATED' ||
+          customerStatus === 'PENDING_ACTIVATION' ||
+          customerStatus === 'SUSPENDED'
+        ) {
+          await txClient.customer.update({
+            where: { id: policy.customerId },
+            data: { status: 'ACTIVE', deactivatedAt: null },
+          });
+
+          this.logger.log(
+            `[${correlationId}] Updated customer ${policy.customerId} status to ACTIVE from ${customerStatus}`
           );
         }
 
@@ -2087,6 +2079,15 @@ export class PolicyService {
     });
     const isPostpaidScheme = customerScheme?.packageScheme?.scheme?.isPostpaid ?? false;
 
+    const dependantIds = customer.dependants
+      .filter((d) => d.deletedAt == null)
+      .map((d) => d.id);
+    const firstBeneficiary = await this.prismaService.beneficiary.findFirst({
+      where: { customerId: data.customerId, deletedAt: null },
+      orderBy: { createdAt: 'asc' },
+      select: { id: true },
+    });
+
     return this.prismaService.$transaction(async (tx) => {
       const policyNumber = isPostpaidScheme
         ? null
@@ -2110,6 +2111,14 @@ export class PolicyService {
           endDate: null,
         },
       });
+
+      await this.insertMembershipStubs(
+        tx,
+        policy.id,
+        dependantIds,
+        firstBeneficiary?.id,
+        correlationId
+      );
 
       const mapped = await this.mapUnmappedMpesaItemsToPolicy(
         policy.id,
@@ -2142,6 +2151,8 @@ export class PolicyService {
       annualPremium?: number;
       frequency: PaymentFrequency;
       customDays?: number;
+      dependantIds?: string[];
+      beneficiaryId?: string;
     },
     _correlationId: string
   ) {
@@ -2175,9 +2186,15 @@ export class PolicyService {
       data.packageId,
       data.frequency
     );
-    const paymentAcNumber = customer.idNumber ?? null;
+    await this.assertOccupyingProductRules(data.customerId, data.packageId);
 
     return this.prismaService.$transaction(async (tx) => {
+      const paymentAcNumber = await this.paymentAccountNumberService.generateForPolicy(
+        data.customerId,
+        tx,
+        _correlationId
+      );
+
       const policy = await tx.policy.create({
         data: {
           policyNumber: null,
@@ -2196,6 +2213,14 @@ export class PolicyService {
           expectedInstallmentCount,
         },
       });
+
+      await this.insertMembershipStubs(
+        tx,
+        policy.id,
+        data.dependantIds ?? [],
+        data.beneficiaryId,
+        _correlationId
+      );
 
       // Defensive: if any historical M-Pesa items match, map them (list path usually has none)
       if (paymentAcNumber) {
@@ -2458,6 +2483,167 @@ export class PolicyService {
     await this.lctSyncService.onPolicyActivated(policyId, correlationId);
 
     this.logger.log(`[${correlationId}] Successfully reconciled member numbers for policy ${policyId}`);
+  }
+
+  /**
+   * Occupying uniqueness + prepaid/postpaid mix rules for a new policy on this package.
+   */
+  async assertOccupyingProductRules(
+    customerId: string,
+    packageId: number,
+    tx?: Prisma.TransactionClient
+  ): Promise<void> {
+    const client = tx ?? this.prismaService;
+    const occupying = await client.policy.findMany({
+      where: {
+        customerId,
+        status: { in: OCCUPYING_POLICY_STATUSES },
+      },
+      select: { id: true, packageId: true },
+    });
+
+    const occupyingWithBilling = await Promise.all(
+      occupying.map(async (policy) => ({
+        id: policy.id,
+        packageId: policy.packageId,
+        isPostpaid: await this.isPackagePostpaidForCustomer(customerId, policy.packageId, client),
+      }))
+    );
+
+    const newIsPostpaid = await this.isPackagePostpaidForCustomer(customerId, packageId, client);
+    const result = evaluateOccupyingProductRules({
+      occupying: occupyingWithBilling,
+      newPackageId: packageId,
+      newIsPostpaid,
+    });
+    if (!result.ok) {
+      throw ValidationException.forField(result.field, result.message, ErrorCodes.RESOURCE_CONFLICT);
+    }
+  }
+
+  async isPackagePostpaidForCustomer(
+    customerId: string,
+    packageId: number,
+    tx?: Prisma.TransactionClient
+  ): Promise<boolean> {
+    const client = tx ?? this.prismaService;
+    const psc = await client.packageSchemeCustomer.findFirst({
+      where: {
+        customerId,
+        packageScheme: { packageId },
+      },
+      include: {
+        packageScheme: {
+          include: { scheme: { select: { isPostpaid: true } } },
+        },
+      },
+    });
+    return psc?.packageScheme?.scheme?.isPostpaid ?? false;
+  }
+
+  /**
+   * Create PMD stubs (placeholder member numbers) and optional policy_beneficiaries row.
+   */
+  async insertMembershipStubs(
+    tx: Prisma.TransactionClient | PrismaService,
+    policyId: string,
+    dependantIds: string[],
+    beneficiaryId: string | undefined,
+    correlationId: string
+  ): Promise<void> {
+    const uniqueDependantIds = [...new Set(dependantIds.filter(Boolean))];
+    for (const dependantId of uniqueDependantIds) {
+      const existing = await tx.policyMemberDependant.findFirst({
+        where: { policyId, dependantId },
+        select: { id: true },
+      });
+      if (existing) continue;
+      await tx.policyMemberDependant.create({
+        data: {
+          dependantId,
+          policyId,
+          memberNumber: `STUB:${policyId.slice(0, 8)}:${dependantId.slice(0, 8)}`,
+        },
+      });
+    }
+
+    if (beneficiaryId) {
+      await tx.policyBeneficiary.upsert({
+        where: { policyId },
+        create: {
+          policyId,
+          beneficiaryId,
+          percentage: 100,
+        },
+        update: {
+          beneficiaryId,
+          percentage: 100,
+        },
+      });
+    }
+
+    this.logger.log(
+      `[${correlationId}] Inserted ${uniqueDependantIds.length} PMD stub(s)` +
+        `${beneficiaryId ? ' and policy beneficiary' : ''} for policy ${policyId}`
+    );
+  }
+
+  async copyPolicyBeneficiaries(
+    tx: Prisma.TransactionClient,
+    fromPolicyId: string,
+    toPolicyId: string,
+    correlationId: string
+  ): Promise<void> {
+    const source = await tx.policyBeneficiary.findUnique({
+      where: { policyId: fromPolicyId },
+    });
+    if (!source) return;
+    await tx.policyBeneficiary.upsert({
+      where: { policyId: toPolicyId },
+      create: {
+        policyId: toPolicyId,
+        beneficiaryId: source.beneficiaryId,
+        percentage: source.percentage,
+      },
+      update: {
+        beneficiaryId: source.beneficiaryId,
+        percentage: source.percentage,
+      },
+    });
+    this.logger.log(
+      `[${correlationId}] Copied policy beneficiary ${source.beneficiaryId} from ${fromPolicyId} to ${toPolicyId}`
+    );
+  }
+
+  /**
+   * Copy existing PMD dependant IDs onto a replacement policy as stubs.
+   * Does not detach rows from the source policy.
+   */
+  async listActiveDependantIds(customerId: string): Promise<string[]> {
+    const rows = await this.prismaService.dependant.findMany({
+      where: { customerId, deletedAt: null },
+      select: { id: true },
+    });
+    return rows.map((row) => row.id);
+  }
+
+  async copyPolicyDependantStubs(
+    tx: Prisma.TransactionClient,
+    fromPolicyId: string,
+    toPolicyId: string,
+    correlationId: string
+  ): Promise<void> {
+    const rows = await tx.policyMemberDependant.findMany({
+      where: { policyId: fromPolicyId },
+      select: { dependantId: true },
+    });
+    await this.insertMembershipStubs(
+      tx,
+      toPolicyId,
+      rows.map((row) => row.dependantId),
+      undefined,
+      correlationId
+    );
   }
 }
 

--- a/apps/api/src/services/product-management.service.ts
+++ b/apps/api/src/services/product-management.service.ts
@@ -234,21 +234,34 @@ export class ProductManagementService {
   /**
    * Flat scheme list for pickers (includes inactive; UI disables inactive rows).
    */
-  async listSchemesForPicker(correlationId: string) {
-    this.logger.log(`[${correlationId}] Listing schemes for picker`);
+  async listSchemesForPicker(correlationId: string, query?: string) {
+    this.logger.log(`[${correlationId}] Listing schemes for picker query="${query ?? ''}"`);
     try {
+      const trimmed = (query ?? '').trim();
+      if (trimmed.length > 0 && trimmed.length < 2) {
+        return [];
+      }
       const schemes = await this.prismaService.scheme.findMany({
+        where:
+          trimmed.length >= 2
+            ? { schemeName: { startsWith: trimmed, mode: 'insensitive' } }
+            : undefined,
         select: {
           id: true,
           schemeName: true,
           isActive: true,
+          parentsSupported: true,
+          isPostpaid: true,
         },
         orderBy: { schemeName: 'asc' },
+        take: trimmed.length >= 2 ? 25 : undefined,
       });
       return schemes.map((s) => ({
         id: s.id,
         name: s.schemeName,
         isActive: s.isActive,
+        parentsSupported: s.parentsSupported,
+        isPostpaid: s.isPostpaid,
       }));
     } catch (error) {
       this.logger.error(
@@ -272,18 +285,43 @@ export class ProductManagementService {
       const rows = await this.prismaService.packageScheme.findMany({
         where: { schemeId: { in: schemeIds } },
         select: {
+          id: true,
           package: {
-            select: { id: true, name: true, isActive: true },
+            select: {
+              id: true,
+              name: true,
+              slug: true,
+              isActive: true,
+              parentsSupported: true,
+            },
+          },
+          scheme: {
+            select: { isPostpaid: true, parentsSupported: true },
           },
         },
       });
-      const byId = new Map<number, { id: number; name: string; isActive: boolean }>();
+      const byId = new Map<
+        number,
+        {
+          id: number;
+          name: string;
+          isActive: boolean;
+          slug?: string | null;
+          parentsSupported?: boolean;
+          isPostpaid?: boolean;
+          packageSchemeId?: number;
+        }
+      >();
       for (const row of rows) {
         if (!row.package) continue;
         byId.set(row.package.id, {
           id: row.package.id,
           name: row.package.name,
           isActive: row.package.isActive,
+          slug: row.package.slug,
+          parentsSupported: row.package.parentsSupported,
+          isPostpaid: row.scheme.isPostpaid,
+          packageSchemeId: row.id,
         });
       }
       return Array.from(byId.values()).sort((a, b) => a.name.localeCompare(b.name));

--- a/apps/api/src/utils/__tests__/customer-status-after-policy.util.spec.ts
+++ b/apps/api/src/utils/__tests__/customer-status-after-policy.util.spec.ts
@@ -1,0 +1,49 @@
+/// <reference types="jest" />
+import { CustomerStatus } from '@prisma/client';
+import { nextCustomerStatusAfterPolicies } from '../customer-status-after-policy.util';
+
+describe('nextCustomerStatusAfterPolicies', () => {
+  it('leaves SUSPENDED unchanged when only a pending extra policy exists', () => {
+    expect(
+      nextCustomerStatusAfterPolicies({
+        customerStatus: CustomerStatus.SUSPENDED,
+        hasActive: false,
+        hasPending: true,
+        hasSuspended: true,
+      })
+    ).toBeNull();
+  });
+
+  it('leaves DEACTIVATED unchanged when an unpaid extra policy is pending', () => {
+    expect(
+      nextCustomerStatusAfterPolicies({
+        customerStatus: CustomerStatus.DEACTIVATED,
+        hasActive: false,
+        hasPending: true,
+        hasSuspended: false,
+      })
+    ).toBeNull();
+  });
+
+  it('moves DEACTIVATED to ACTIVE when a policy is paid and active', () => {
+    expect(
+      nextCustomerStatusAfterPolicies({
+        customerStatus: CustomerStatus.DEACTIVATED,
+        hasActive: true,
+        hasPending: true,
+        hasSuspended: false,
+      })
+    ).toBe(CustomerStatus.ACTIVE);
+  });
+
+  it('moves PENDING_ACTIVATION to ACTIVE when a policy becomes active', () => {
+    expect(
+      nextCustomerStatusAfterPolicies({
+        customerStatus: CustomerStatus.PENDING_ACTIVATION,
+        hasActive: true,
+        hasPending: false,
+        hasSuspended: false,
+      })
+    ).toBe(CustomerStatus.ACTIVE);
+  });
+});

--- a/apps/api/src/utils/__tests__/duplicate-person.util.spec.ts
+++ b/apps/api/src/utils/__tests__/duplicate-person.util.spec.ts
@@ -1,0 +1,52 @@
+/// <reference types="jest" />
+import { matchDuplicatePerson } from '../duplicate-person.util';
+
+describe('matchDuplicatePerson', () => {
+  const jane = {
+    id: 'dep-1',
+    firstName: 'Jane',
+    lastName: 'Doe',
+    idNumber: '12345678',
+    phoneNumber: '254700000001',
+  };
+
+  it('matches same person by case-insensitive names and idNumber', () => {
+    expect(
+      matchDuplicatePerson(
+        { firstName: 'JANE', lastName: 'doe', idNumber: '12345678' },
+        [jane]
+      )
+    ).toEqual({ kind: 'same_person', existing: jane });
+  });
+
+  it('matches same person by names and phone when ids are missing', () => {
+    expect(
+      matchDuplicatePerson(
+        { firstName: 'Jane', lastName: 'Doe', phoneNumber: '254700000001' },
+        [{ ...jane, idNumber: null }]
+      )
+    ).toEqual({ kind: 'same_person', existing: { ...jane, idNumber: null } });
+  });
+
+  it('treats same names with different IDs as different people', () => {
+    expect(
+      matchDuplicatePerson(
+        { firstName: 'Jane', lastName: 'Doe', idNumber: '99999999' },
+        [jane]
+      )
+    ).toEqual({ kind: 'distinct' });
+  });
+
+  it('is ambiguous when names match and both ID and phone are empty', () => {
+    const unnamed = { id: 'dep-2', firstName: 'Pat', lastName: 'Kim', idNumber: null, phoneNumber: null };
+    expect(
+      matchDuplicatePerson({ firstName: 'Pat', lastName: 'Kim' }, [unnamed])
+    ).toEqual({ kind: 'ambiguous', existing: unnamed });
+  });
+
+  it('is distinct when names differ', () => {
+    expect(
+      matchDuplicatePerson({ firstName: 'John', lastName: 'Doe', idNumber: '12345678' }, [jane])
+    ).toEqual({ kind: 'distinct' });
+  });
+});

--- a/apps/api/src/utils/__tests__/family-category.util.spec.ts
+++ b/apps/api/src/utils/__tests__/family-category.util.spec.ts
@@ -1,6 +1,8 @@
 /// <reference types="jest" />
 import {
+  extraSpouseAddonCount,
   hasAdditionalSpousePremium,
+  householdCapsFromBands,
   resolveFamilyCategoryForHousehold,
   validateSelectedFamilyCategory,
 } from '../family-category.util';
@@ -84,5 +86,43 @@ describe('hasAdditionalSpousePremium', () => {
 
   it('is true for non-member-only with >1 spouse', () => {
     expect(hasAdditionalSpousePremium('up_to_5', twoSpouses)).toBe(true);
+  });
+});
+
+describe('extraSpouseAddonCount', () => {
+  it('bills add-on × 2 for 3 spouses', () => {
+    expect(extraSpouseAddonCount(3, 'up_to_8')).toBe(2);
+  });
+
+  it('is 0 for member-only even with multiple spouses', () => {
+    expect(extraSpouseAddonCount(3, 'member_only')).toBe(0);
+  });
+
+  it('is 0 for a single spouse', () => {
+    expect(extraSpouseAddonCount(1, 'up_to_5')).toBe(0);
+  });
+});
+
+describe('householdCapsFromBands', () => {
+  it('hides spouse, children, and parents when there is no UP_TO_N band', () => {
+    expect(
+      householdCapsFromBands([{ key: 'member_only', kind: 'MEMBER_ONLY' }], true)
+    ).toMatchObject({
+      showSpouse: false,
+      showChildren: false,
+      showParents: false,
+      maxExtraMembers: 0,
+    });
+  });
+
+  it('caps extra members at N-1 and shows parents only when scheme supports them', () => {
+    expect(householdCapsFromBands(bands, true)).toMatchObject({
+      maxMembers: 8,
+      maxExtraMembers: 7,
+      showSpouse: true,
+      showChildren: true,
+      showParents: true,
+    });
+    expect(householdCapsFromBands(bands, false).showParents).toBe(false);
   });
 });

--- a/apps/api/src/utils/__tests__/occupying-policy.util.spec.ts
+++ b/apps/api/src/utils/__tests__/occupying-policy.util.spec.ts
@@ -1,0 +1,63 @@
+/// <reference types="jest" />
+import { evaluateOccupyingProductRules } from '../occupying-policy.util';
+
+describe('evaluateOccupyingProductRules', () => {
+  it('blocks same package while occupying', () => {
+    const result = evaluateOccupyingProductRules({
+      occupying: [{ id: 'p1', packageId: 10, isPostpaid: false }],
+      newPackageId: 10,
+      newIsPostpaid: false,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toMatch(/Deactivate it manually/);
+    }
+  });
+
+  it('allows two prepaid policies on different packages', () => {
+    expect(
+      evaluateOccupyingProductRules({
+        occupying: [{ id: 'p1', packageId: 10, isPostpaid: false }],
+        newPackageId: 20,
+        newIsPostpaid: false,
+      })
+    ).toEqual({ ok: true });
+  });
+
+  it('blocks occupying prepaid + add postpaid', () => {
+    const result = evaluateOccupyingProductRules({
+      occupying: [{ id: 'p1', packageId: 10, isPostpaid: false }],
+      newPackageId: 20,
+      newIsPostpaid: true,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toMatch(/postpaid product while a prepaid/);
+    }
+  });
+
+  it('blocks occupying postpaid + any additional product', () => {
+    const prepaidAdd = evaluateOccupyingProductRules({
+      occupying: [{ id: 'p1', packageId: 10, isPostpaid: true }],
+      newPackageId: 20,
+      newIsPostpaid: false,
+    });
+    const postpaidAdd = evaluateOccupyingProductRules({
+      occupying: [{ id: 'p1', packageId: 10, isPostpaid: true }],
+      newPackageId: 20,
+      newIsPostpaid: true,
+    });
+    expect(prepaidAdd.ok).toBe(false);
+    expect(postpaidAdd.ok).toBe(false);
+  });
+
+  it('allows a new occupying policy when none occupy', () => {
+    expect(
+      evaluateOccupyingProductRules({
+        occupying: [],
+        newPackageId: 10,
+        newIsPostpaid: true,
+      })
+    ).toEqual({ ok: true });
+  });
+});

--- a/apps/api/src/utils/customer-status-after-policy.util.ts
+++ b/apps/api/src/utils/customer-status-after-policy.util.ts
@@ -1,0 +1,49 @@
+import { CustomerStatus } from '@prisma/client';
+
+export function nextCustomerStatusAfterPolicies(params: {
+  customerStatus: CustomerStatus;
+  hasActive: boolean;
+  hasPending: boolean;
+  hasSuspended: boolean;
+  whenNoOpenPolicies?: CustomerStatus;
+}): CustomerStatus | null {
+  const {
+    customerStatus,
+    hasActive,
+    hasPending,
+    hasSuspended,
+    whenNoOpenPolicies = CustomerStatus.DEACTIVATED,
+  } = params;
+
+  if (hasActive) {
+    if (
+      customerStatus === CustomerStatus.DEACTIVATED ||
+      customerStatus === CustomerStatus.SUSPENDED ||
+      customerStatus === CustomerStatus.TERMINATED ||
+      customerStatus === CustomerStatus.PENDING_ACTIVATION
+    ) {
+      return CustomerStatus.ACTIVE;
+    }
+    return null;
+  }
+
+  if (hasPending) {
+    if (
+      customerStatus === CustomerStatus.SUSPENDED ||
+      customerStatus === CustomerStatus.DEACTIVATED ||
+      customerStatus === CustomerStatus.TERMINATED
+    ) {
+      return null;
+    }
+    if (customerStatus !== CustomerStatus.PENDING_ACTIVATION) {
+      return CustomerStatus.PENDING_ACTIVATION;
+    }
+    return null;
+  }
+
+  if (hasSuspended) {
+    return customerStatus === CustomerStatus.SUSPENDED ? null : CustomerStatus.SUSPENDED;
+  }
+
+  return whenNoOpenPolicies === customerStatus ? null : whenNoOpenPolicies;
+}

--- a/apps/api/src/utils/duplicate-person.util.ts
+++ b/apps/api/src/utils/duplicate-person.util.ts
@@ -1,0 +1,86 @@
+export type PersonIdentity = {
+  firstName: string;
+  lastName: string;
+  idNumber?: string | null;
+  phoneNumber?: string | null;
+};
+
+export type IdentifiedPerson = PersonIdentity & { id: string };
+
+export type DuplicatePersonMatch =
+  | { kind: 'same_person'; existing: IdentifiedPerson }
+  | { kind: 'ambiguous'; existing: IdentifiedPerson }
+  | { kind: 'distinct' };
+
+function normalizeName(value: string | null | undefined): string {
+  return (value ?? '').trim().toLowerCase();
+}
+
+function normalizeToken(value: string | null | undefined): string {
+  return (value ?? '').trim().replace(/\s/g, '').toLowerCase();
+}
+
+export function namesMatch(a: PersonIdentity, b: PersonIdentity): boolean {
+  return (
+    normalizeName(a.firstName) === normalizeName(b.firstName) &&
+    normalizeName(a.lastName) === normalizeName(b.lastName)
+  );
+}
+
+/**
+ * Duplicate net-new match:
+ * - case-insensitive firstName+lastName AND
+ *   (same idNumber if both have one OR same phone if both have one)
+ * - names match but IDs differ → different people
+ * - names match and both ID and phone empty → ambiguous (force pick-or-confirm)
+ */
+export function matchDuplicatePerson(
+  candidate: PersonIdentity,
+  existingPeople: IdentifiedPerson[]
+): DuplicatePersonMatch {
+  const candidateId = normalizeToken(candidate.idNumber);
+  const candidatePhone = normalizeToken(candidate.phoneNumber);
+
+  for (const existing of existingPeople) {
+    if (!namesMatch(candidate, existing)) {
+      continue;
+    }
+
+    const existingId = normalizeToken(existing.idNumber);
+    const existingPhone = normalizeToken(existing.phoneNumber);
+
+    if (candidateId && existingId) {
+      if (candidateId === existingId) {
+        return { kind: 'same_person', existing };
+      }
+      return { kind: 'distinct' };
+    }
+
+    if (candidatePhone && existingPhone && candidatePhone === existingPhone) {
+      return { kind: 'same_person', existing };
+    }
+
+    if (!candidateId && !existingId && !candidatePhone && !existingPhone) {
+      return { kind: 'ambiguous', existing };
+    }
+  }
+
+  return { kind: 'distinct' };
+}
+
+export function findAllAmbiguousMatches(
+  candidate: PersonIdentity,
+  existingPeople: IdentifiedPerson[]
+): IdentifiedPerson[] {
+  const candidateId = normalizeToken(candidate.idNumber);
+  const candidatePhone = normalizeToken(candidate.phoneNumber);
+  if (candidateId || candidatePhone) {
+    return [];
+  }
+  return existingPeople.filter((existing) => {
+    if (!namesMatch(candidate, existing)) {
+      return false;
+    }
+    return !normalizeToken(existing.idNumber) && !normalizeToken(existing.phoneNumber);
+  });
+}

--- a/apps/api/src/utils/family-category.util.ts
+++ b/apps/api/src/utils/family-category.util.ts
@@ -101,6 +101,68 @@ export function validateSelectedFamilyCategory(params: {
 }
 
 /**
+ * Extra-spouse units billed: (spouseCount - 1), never negative.
+ * Member-only products never bill extra-spouse.
+ */
+export function extraSpouseAddonCount(
+  spouseCount: number,
+  category?: string | null
+): number {
+  if (category === 'member_only' || category === 'MEMBER_ONLY') return 0;
+  return Math.max(0, spouseCount - 1);
+}
+
+/** @deprecated Use extraSpouseAddonCount */
+export function additionalSpouseUnits(
+  spouseCount: number,
+  category?: string | null
+): number {
+  return extraSpouseAddonCount(spouseCount, category);
+}
+
+export type HouseholdCaps = {
+  hasFamilyBands: boolean;
+  maxMembers: number;
+  maxExtraMembers: number;
+  showSpouse: boolean;
+  showChildren: boolean;
+  showParents: boolean;
+};
+
+/**
+ * Household UI caps from PACKAGE pricing bands (not the plan).
+ * No UP_TO_N → member-only: hide spouse, children, and parents.
+ * Largest UP_TO_N maxMembers = N → at most N-1 spouses/children.
+ * Parents only when scheme supports them AND the package has family bands.
+ */
+export function householdCapsFromBands(
+  bands: PackagePricingBand[],
+  parentsSupported: boolean
+): HouseholdCaps {
+  const upTo = bands.filter(
+    (b) => b.kind === 'UP_TO_N' && b.maxMembers != null && b.maxMembers >= 2
+  );
+  const hasFamilyBands = upTo.length > 0;
+  const maxMembers = hasFamilyBands
+    ? Math.max(...upTo.map((b) => b.maxMembers ?? 0))
+    : 1;
+  return {
+    hasFamilyBands,
+    maxMembers,
+    maxExtraMembers: hasFamilyBands ? maxMembers - 1 : 0,
+    showSpouse: hasFamilyBands,
+    showChildren: hasFamilyBands,
+    showParents: hasFamilyBands && parentsSupported,
+  };
+}
+
+export function countActiveSpouses(
+  dependants: Array<{ relationship: DependantRelationship; deletedAt?: Date | null }>
+): number {
+  return dependants.filter((d) => d.deletedAt == null && d.relationship === 'SPOUSE').length;
+}
+
+/**
  * Additional spouse add-on applies when category is not Member only, agent opts in,
  * and (when household known) there is more than one spouse.
  */
@@ -112,14 +174,11 @@ export function hasAdditionalSpousePremium(
   if (category === 'member_only' || category === 'MEMBER_ONLY') return false;
   if (options?.optedIn === false) return false;
 
-  const spouseCount = dependants.filter(
-    (d) => d.deletedAt == null && d.relationship === 'SPOUSE'
-  ).length;
+  const spouseCount = countActiveSpouses(dependants);
 
   if (options?.householdKnown === false) {
     return options.optedIn === true;
   }
 
-  if (spouseCount <= 1) return false;
-  return true;
+  return extraSpouseAddonCount(spouseCount, category) > 0;
 }

--- a/apps/api/src/utils/occupying-policy.util.ts
+++ b/apps/api/src/utils/occupying-policy.util.ts
@@ -1,0 +1,72 @@
+import { PolicyStatus } from '@prisma/client';
+
+/** Statuses that occupy a package / payment-account slot. */
+export const OCCUPYING_POLICY_STATUSES: PolicyStatus[] = [
+  PolicyStatus.ACTIVE,
+  PolicyStatus.PENDING_ACTIVATION,
+  PolicyStatus.SUSPENDED,
+];
+
+/** Historical rows that may still hold paymentAcNumber and can yield it. */
+export const STEALABLE_PAN_STATUSES: PolicyStatus[] = [
+  PolicyStatus.EXPIRED,
+  PolicyStatus.DEACTIVATED,
+  PolicyStatus.INACTIVE,
+];
+
+export type OccupyingPolicyBilling = {
+  id: string;
+  packageId: number;
+  isPostpaid: boolean;
+};
+
+export type OccupyingProductRuleResult =
+  | { ok: true }
+  | { ok: false; field: string; message: string };
+
+/**
+ * Occupying uniqueness:
+ * - one occupying policy per package
+ * - two prepaid different packages allowed
+ * - occupying postpaid blocks any additional occupying policy
+ * - occupying prepaid blocks adding postpaid
+ */
+export function evaluateOccupyingProductRules(params: {
+  occupying: OccupyingPolicyBilling[];
+  newPackageId: number;
+  newIsPostpaid: boolean;
+}): OccupyingProductRuleResult {
+  const { occupying, newPackageId, newIsPostpaid } = params;
+
+  const samePackage = occupying.find((p) => p.packageId === newPackageId);
+  if (samePackage) {
+    return {
+      ok: false,
+      field: 'packageId',
+      message:
+        'Customer already has an occupying policy for this package. Deactivate it manually before adding the same package again.',
+    };
+  }
+
+  const occupyingPostpaid = occupying.some((p) => p.isPostpaid);
+  if (occupyingPostpaid) {
+    return {
+      ok: false,
+      field: 'packageId',
+      message:
+        'Customer already has an occupying postpaid policy. Add product is blocked until that postpaid policy is expired, deactivated, or inactive.',
+    };
+  }
+
+  const occupyingPrepaid = occupying.some((p) => !p.isPostpaid);
+  if (newIsPostpaid && occupyingPrepaid) {
+    return {
+      ok: false,
+      field: 'packageId',
+      message:
+        'Cannot add a postpaid product while a prepaid policy is occupying. Deactivate the prepaid policy first.',
+    };
+  }
+
+  return { ok: true };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Admin-only **Add product** lets a customer who already has a policy enrol in another package. First-time BA registration is unchanged. Repair-center / inventory / module 5 is out of scope.

### Schema
- New `policy_beneficiaries` join (`PolicyBeneficiary`): exactly one next-of-kin per policy at 100%.
- Backfill walks each customer’s supersession chains and assigns the earliest remaining beneficiary (prefer `percentage=100`). Extra historical people stay on `beneficiaries` for later picking.

### Backend
- Occupying statuses: `ACTIVE`, `PENDING_ACTIVATION`, `SUSPENDED`.
- One occupying policy per package (same-package occupying is blocked; admin must deactivate). Historical `EXPIRED` / `DEACTIVATED` / `INACTIVE` same package is allowed.
- Two prepaid different packages allowed. Occupying prepaid + add postpaid blocked. Occupying postpaid blocks any additional occupying product.
- `paymentAcNumber` is globally unique: steal `idNumber` from historical rows when none occupy; suffix `B`, `C`, … when occupying.
- `createPolicyWithPayment` / `createPolicyWithoutPayments` accept `dependantIds[]` and `beneficiaryId` and insert PMD stubs + the policy beneficiary join.
- `activatePolicy` numbers only existing PMD stubs for that `policyId` (does not attach all customer dependants).
- LCT late-add and `addDependants` only touch occupying policies and explicitly new dependant IDs.
- Modify-product and renewal copy `policy_beneficiaries` (and dependant stubs on generate-new / renew).
- Extra-spouse premium is `(spouseCount - 1) × additional-spouse rate` (member-only = 0).
- Unpaid extra policy does not flip `SUSPENDED` / `DEACTIVATED` customers to `PENDING_ACTIVATION`. Paying the new policy can move the customer to `ACTIVE`.
- New admin endpoint: `POST /internal/customers/:customerId/additional-policies` (`registration_admin` only). No BA `agent_registrations` / `ba_payouts`.

### Frontend
- Add product button on the customer Products tab only when `basePath === 'admin' && isAdmin`. Disabled if the customer or any policy is `TERMINATED`. After success, stay on Products and show the new `paymentAcNumber`.
- Wizard under `/admin/customer/[customerId]/add-product/...`: scheme typeahead (min 2 letters, prefix) → package → plan → household (package-band caps) → one beneficiary → payment (frequency blank until selected; STK = this policy’s first installment or skip; postpaid never STK).
- Normal registration inverted to the same scheme → package → plan order; household hide/caps from package bands; extra-spouse × count; plan read-only on payment summary.
- Policy detail shows that policy’s next of kin from `policy_beneficiaries`.

### Tests
Covers PAN steal/suffix, activatePolicy isolation, LCT late-add, occupying uniqueness, extra-spouse, duplicate-person matcher, beneficiary copy, customer status, additional-policy 403/terminated, and FE household/typeahead helpers.

## How to test
1. As `registration_admin`, open a customer Products tab and use **Add product**.
2. Confirm scheme typeahead requires 2 letters and does not dump the full list.
3. Same occupying package → blocked with a manual-deactivate message.
4. Two different prepaid packages → allowed; two occupying policies get two PANs.
5. Occupying postpaid, or prepaid + add postpaid → blocked.
6. Skip STK → new policy `PENDING_ACTIVATION`; customer `SUSPENDED`/`DEACTIVATED` stays unchanged.
7. Pay the new policy → that policy activates; customer can become `ACTIVE`.
8. Policy-2-only child must not appear on policy 1 member rows.
9. Policy screen shows this policy’s one NOK; Customer Details stays a flat unique NOK list.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b414295-f68c-4b59-baba-ddedc58f07dd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b414295-f68c-4b59-baba-ddedc58f07dd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

