### PR TITLE
Add additional product for existing customers

### DIFF
--- a/apps/agent-registration/src/app/(main)/admin/customer/[customerId]/add-product/page.tsx
+++ b/apps/agent-registration/src/app/(main)/admin/customer/[customerId]/add-product/page.tsx
@@ -1,0 +1,661 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import SchemeTypeahead from '@/components/scheme-typeahead';
+import {
+  createAdditionalPolicy,
+  getAdditionalPolicyEligibility,
+  getCustomerDetails,
+  getPackagePlans,
+  getPackagePricing,
+  getPackageSchemes,
+  listPackagesForSchemes,
+  type CustomerDetailData,
+  type Package,
+  type PackagePricingData,
+  type Plan,
+  type Scheme,
+} from '@/lib/api';
+import {
+  additionalSpouseCount,
+  maxDependantSlots,
+  packageHasFamilyBands,
+  resolveFamilyCategoryForHousehold,
+} from '@/lib/family-category';
+import { mapPackagePricingToUi, pricingBandsFromApi } from '@/lib/package-pricing-ui';
+import {
+  computeAnnualPremium,
+  computeInstallmentPremium,
+  type PricingRateBand,
+} from '@/lib/insurance-installment';
+
+type Step = 'product' | 'household' | 'beneficiary' | 'payment';
+
+type NewPerson = {
+  firstName: string;
+  lastName: string;
+  gender: string;
+  dateOfBirth: string;
+  idNumber: string;
+  phoneNumber: string;
+};
+
+const emptyPerson = (): NewPerson => ({
+  firstName: '',
+  lastName: '',
+  gender: 'female',
+  dateOfBirth: '',
+  idNumber: '',
+  phoneNumber: '',
+});
+
+function usablePhone(value?: string): string {
+  if (!value || value.includes('*')) return '';
+  return value;
+}
+
+function filledPerson(p: NewPerson): boolean {
+  return Boolean(p.firstName.trim() && p.lastName.trim());
+}
+
+export default function AddProductPage() {
+  const params = useParams();
+  const router = useRouter();
+  const customerId = params.customerId as string;
+
+  const [step, setStep] = useState<Step>('product');
+  const [error, setError] = useState<string | null>(null);
+  const [blocked, setBlocked] = useState<string[]>([]);
+  const [scheme, setScheme] = useState<Scheme | null>(null);
+  const [packages, setPackages] = useState<Package[]>([]);
+  const [packageId, setPackageId] = useState<number | null>(null);
+  const [plans, setPlans] = useState<Plan[]>([]);
+  const [planId, setPlanId] = useState<number | null>(null);
+  const [packageSchemeId, setPackageSchemeId] = useState<number | null>(null);
+  const [samePackageOccupying, setSamePackageOccupying] = useState(false);
+  const [isPostpaid, setIsPostpaid] = useState(false);
+  const [schemeFrequency, setSchemeFrequency] = useState<string | null>(null);
+  const [hasFamily, setHasFamily] = useState(true);
+  const [dependantCap, setDependantCap] = useState(0);
+  const [parentsSupported, setParentsSupported] = useState(false);
+  const [pricingApi, setPricingApi] = useState<PackagePricingData | null>(null);
+
+  const [existingDependants, setExistingDependants] = useState<
+    Array<{ id: string; firstName: string; lastName: string; relationship: string; deletedAt?: string | null }>
+  >([]);
+  const [existingBeneficiaries, setExistingBeneficiaries] = useState<
+    Array<{ id: string; firstName: string; lastName: string }>
+  >([]);
+  const [occupyingPolicies, setOccupyingPolicies] = useState<
+    Array<{ packageId?: number; status: string }>
+  >([]);
+  const [selectedDependantIds, setSelectedDependantIds] = useState<string[]>([]);
+  const [newSpouses, setNewSpouses] = useState<NewPerson[]>([]);
+  const [newChildren, setNewChildren] = useState<NewPerson[]>([]);
+  const [beneficiaryId, setBeneficiaryId] = useState<string>('');
+  const [newBeneficiary, setNewBeneficiary] = useState<NewPerson | null>(null);
+  const [customerPhone, setCustomerPhone] = useState('');
+
+  const [frequency, setFrequency] = useState('');
+  const [paymentPhone, setPaymentPhone] = useState('');
+  const [skipPayment, setSkipPayment] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  useEffect(() => {
+    void getAdditionalPolicyEligibility(customerId)
+      .then((res) => {
+        const payload = (res as { canAdd?: boolean; blockedReasons?: string[]; data?: { canAdd: boolean; blockedReasons: string[] } });
+        const body = payload.data ?? payload;
+        if (!body.canAdd) setBlocked(body.blockedReasons ?? ['Cannot add a product']);
+      })
+      .catch((err) => setError(err instanceof Error ? err.message : 'Eligibility check failed'));
+
+    void getCustomerDetails(customerId)
+      .then((res) => {
+        const data: CustomerDetailData = res.data;
+        setExistingDependants((data.dependants ?? []).filter((d) => !d.deletedAt));
+        setExistingBeneficiaries((data.beneficiaries ?? []).filter((b) => !b.deletedAt));
+        const phone = usablePhone(data.customer.phoneNumber);
+        setCustomerPhone(phone);
+        setPaymentPhone(phone);
+        setOccupyingPolicies(data.policies ?? []);
+      })
+      .catch(() => undefined);
+  }, [customerId]);
+
+  const occupyingStatuses = useMemo(() => ['ACTIVE', 'PENDING_ACTIVATION', 'SUSPENDED'], []);
+
+  const onScheme = async (next: Scheme) => {
+    setScheme(next);
+    setPackageId(null);
+    setPlanId(null);
+    setPackageSchemeId(null);
+    setPricingApi(null);
+    const pkgs = await listPackagesForSchemes([next.id]);
+    setPackages(pkgs.filter((p) => p.isActive !== false));
+  };
+
+  const onPackage = async (id: number) => {
+    setPackageId(id);
+    setPlanId(null);
+    const [pkgPlans, pkgSchemes, pricing] = await Promise.all([
+      getPackagePlans(id),
+      getPackageSchemes(id),
+      getPackagePricing(id).catch(() => null),
+    ]);
+    setPlans(pkgPlans.filter((p) => p.isActive !== false));
+    const junction = pkgSchemes.find((s) => s.id === scheme?.id);
+    setPackageSchemeId(junction?.packageSchemeId ?? null);
+    setParentsSupported(Boolean(junction?.parentsSupported));
+    setIsPostpaid(Boolean(junction?.isPostpaid));
+    setSchemeFrequency(null);
+    const bands = pricing ? pricingBandsFromApi(pricing) : [];
+    setHasFamily(packageHasFamilyBands(bands));
+    setDependantCap(maxDependantSlots(bands));
+    setPricingApi(pricing);
+    if (!packageHasFamilyBands(bands)) {
+      setSelectedDependantIds([]);
+      setNewSpouses([]);
+      setNewChildren([]);
+    }
+    setSamePackageOccupying(
+      occupyingPolicies.some((p) => p.packageId === id && occupyingStatuses.includes(p.status))
+    );
+  };
+
+  const selectedPlan = plans.find((p) => p.id === planId);
+  const selectedExisting = existingDependants.filter((d) => selectedDependantIds.includes(d.id));
+  const filledNewSpouses = newSpouses.filter(filledPerson);
+  const filledNewChildren = newChildren.filter(filledPerson);
+  const spouseSelected =
+    selectedExisting.filter((d) => d.relationship === 'SPOUSE').length + filledNewSpouses.length;
+  const childSelected =
+    selectedExisting.filter((d) => d.relationship === 'CHILD').length + filledNewChildren.length;
+  const householdSize = 1 + spouseSelected + childSelected;
+  const bands = pricingApi ? pricingBandsFromApi(pricingApi) : [];
+  const categoryResolution = resolveFamilyCategoryForHousehold(householdSize, bands);
+  const categoryKey = categoryResolution.ok ? categoryResolution.categoryKey : '';
+  const extraSpouse = additionalSpouseCount(categoryKey || (hasFamily ? 'up_to_n' : 'member_only'), spouseSelected);
+
+  const enabledFrequencies = pricingApi?.enabledFrequencies ?? ['DAILY', 'WEEKLY', 'MONTHLY', 'QUARTERLY', 'ANNUALLY'];
+  const effectiveFrequency = isPostpaid ? (schemeFrequency ?? frequency) : frequency;
+
+  const priced = useMemo(() => {
+    if (!pricingApi || !selectedPlan || !categoryKey) return null;
+    const ui = mapPackagePricingToUi(pricingApi);
+    const planKey = Object.keys(ui.plans).find(
+      (k) => ui.plans[k].name.toLowerCase() === selectedPlan.name.toLowerCase()
+    );
+    if (!planKey) return null;
+    const plan = ui.plans[planKey];
+    const category = plan.categories[categoryKey];
+    if (!category) return null;
+    const spousePremium = plan.additional_spouse;
+    const lookupRates: PricingRateBand = {
+      daily: (category.daily ?? 0) + extraSpouse * (spousePremium.daily ?? 0),
+      weekly: (category.weekly ?? 0) + extraSpouse * (spousePremium.weekly ?? 0),
+      monthly: (category.monthly ?? 0) + extraSpouse * (spousePremium.monthly ?? 0),
+      annually: (category.annually ?? 0) + extraSpouse * (spousePremium.annually ?? 0),
+    };
+    const freq = effectiveFrequency || 'MONTHLY';
+    return {
+      premium: computeInstallmentPremium({
+        frequency: freq,
+        daily: lookupRates.daily,
+        weekly: lookupRates.weekly,
+        lookupRates,
+      }),
+      annualPremium: computeAnnualPremium({ daily: lookupRates.daily, lookupRates }),
+      lookupRates,
+    };
+  }, [pricingApi, selectedPlan, categoryKey, extraSpouse, effectiveFrequency]);
+
+  const householdSlotsUsed = spouseSelected + childSelected;
+
+  const goNext = () => {
+    setError(null);
+    if (step === 'product') {
+      if (!scheme || !packageId || !planId || !packageSchemeId) {
+        setError('Select scheme, package, and plan');
+        return;
+      }
+      if (samePackageOccupying) {
+        setError('Deactivate the occupying policy for this package before adding another.');
+        return;
+      }
+      setStep(hasFamily ? 'household' : 'beneficiary');
+      return;
+    }
+    if (step === 'household') {
+      if (householdSlotsUsed > dependantCap) {
+        setError(`This product allows at most ${dependantCap} spouse(s) or children`);
+        return;
+      }
+      if (!categoryResolution.ok) {
+        setError('Household is larger than this package allows');
+        return;
+      }
+      setStep('beneficiary');
+      return;
+    }
+    if (step === 'beneficiary') {
+      if (!beneficiaryId && (!newBeneficiary || !filledPerson(newBeneficiary))) {
+        setError('Select an existing beneficiary or add a new one');
+        return;
+      }
+      if (beneficiaryId && newBeneficiary && filledPerson(newBeneficiary)) {
+        setError('Select an existing beneficiary or create one, not both');
+        return;
+      }
+      setStep('payment');
+    }
+  };
+
+  const submit = async () => {
+    if (!packageId || !planId || !packageSchemeId || !selectedPlan) return;
+    if (!isPostpaid && !frequency && !skipPayment) {
+      setError('Select a payment frequency');
+      return;
+    }
+    if (!priced || priced.premium <= 0) {
+      setError('Could not calculate premium for this household and frequency');
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const result = await createAdditionalPolicy(customerId, {
+        packageId,
+        packagePlanId: planId,
+        packageSchemeId,
+        frequency: (isPostpaid ? schemeFrequency : frequency) || 'MONTHLY',
+        premium: priced.premium,
+        annualPremium: priced.annualPremium,
+        productName: `${selectedPlan.name}`,
+        dependantIds: hasFamily ? selectedDependantIds : [],
+        newSpouses: hasFamily
+          ? filledNewSpouses.map((s) => ({
+              firstName: s.firstName.trim(),
+              lastName: s.lastName.trim(),
+              gender: s.gender,
+              dateOfBirth: s.dateOfBirth || undefined,
+              idNumber: s.idNumber || undefined,
+              phoneNumber: s.phoneNumber || undefined,
+            }))
+          : [],
+        newChildren: hasFamily
+          ? filledNewChildren.map((c) => ({
+              firstName: c.firstName.trim(),
+              lastName: c.lastName.trim(),
+              gender: c.gender,
+              dateOfBirth: c.dateOfBirth || undefined,
+              idNumber: c.idNumber || undefined,
+              phoneNumber: c.phoneNumber || undefined,
+            }))
+          : [],
+        beneficiaryId: beneficiaryId || undefined,
+        newBeneficiary:
+          !beneficiaryId && newBeneficiary && filledPerson(newBeneficiary)
+            ? {
+                firstName: newBeneficiary.firstName.trim(),
+                lastName: newBeneficiary.lastName.trim(),
+                gender: newBeneficiary.gender,
+                dateOfBirth: newBeneficiary.dateOfBirth || '1990-01-01',
+                relationship: 'other',
+                idNumber: newBeneficiary.idNumber || undefined,
+                phoneNumber: newBeneficiary.phoneNumber || undefined,
+              }
+            : undefined,
+        skipPayment: isPostpaid ? true : skipPayment,
+        paymentPhone,
+        initiateStk: !isPostpaid && !skipPayment,
+      });
+      setSuccess(
+        `Policy created (${result.data.policy.status}). Payment account: ${result.data.policy.paymentAcNumber ?? '—'}`
+      );
+      setTimeout(() => router.push(`/admin/customer/${customerId}?tab=products`), 1500);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to add product');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (blocked.length > 0) {
+    return (
+      <Card className="m-6">
+        <CardHeader>
+          <CardTitle>Cannot add product</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ul className="list-disc pl-5 text-sm text-destructive">
+            {blocked.map((reason) => (
+              <li key={reason}>{reason}</li>
+            ))}
+          </ul>
+          <Button className="mt-4" variant="outline" onClick={() => router.back()}>
+            Back
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="p-6 max-w-3xl space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Add product</h1>
+        <Button variant="ghost" onClick={() => router.push(`/admin/customer/${customerId}?tab=products`)}>
+          Cancel
+        </Button>
+      </div>
+      {error && <p className="text-sm text-destructive">{error}</p>}
+      {success && <p className="text-sm text-green-700">{success}</p>}
+
+      {step === 'product' && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Product</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <SchemeTypeahead
+              value={scheme?.id}
+              selectedName={scheme?.name}
+              onSelect={(s) => void onScheme(s)}
+            />
+            <div>
+              <Label>Package *</Label>
+              <Select
+                value={packageId?.toString() ?? ''}
+                onValueChange={(v) => void onPackage(parseInt(v, 10))}
+                disabled={!scheme}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select package" />
+                </SelectTrigger>
+                <SelectContent>
+                  {packages.map((pkg) => (
+                    <SelectItem key={pkg.id} value={pkg.id.toString()}>
+                      {pkg.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label>Plan *</Label>
+              <Select
+                value={planId?.toString() ?? ''}
+                onValueChange={(v) => setPlanId(parseInt(v, 10))}
+                disabled={!packageId}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select plan" />
+                </SelectTrigger>
+                <SelectContent>
+                  {plans.map((plan) => (
+                    <SelectItem key={plan.id} value={plan.id.toString()}>
+                      {plan.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            {samePackageOccupying && (
+              <p className="text-sm text-destructive">
+                This customer already has an occupying policy for this package. Deactivate it first.
+              </p>
+            )}
+            <Button onClick={goNext}>Continue</Button>
+          </CardContent>
+        </Card>
+      )}
+
+      {step === 'household' && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Household</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <p className="text-sm text-muted-foreground">
+              Select existing people or add new ones for this policy (max {dependantCap} spouses or
+              children). They stay on their current policies. Parents{' '}
+              {parentsSupported ? 'can' : 'cannot'} be collected on customer details for this scheme
+              and do not count toward the family size.
+            </p>
+            {existingDependants.map((d) => (
+              <label key={d.id} className="flex items-center gap-2 text-sm">
+                <Checkbox
+                  checked={selectedDependantIds.includes(d.id)}
+                  onCheckedChange={(checked) => {
+                    setSelectedDependantIds((ids) =>
+                      checked === true ? [...ids, d.id] : ids.filter((id) => id !== d.id)
+                    );
+                  }}
+                />
+                {d.firstName} {d.lastName} ({d.relationship})
+              </label>
+            ))}
+            {existingDependants.length === 0 && (
+              <p className="text-sm text-muted-foreground">No existing dependants on file.</p>
+            )}
+
+            <div className="space-y-2 pt-2">
+              <div className="flex items-center justify-between">
+                <Label>New spouses</Label>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  disabled={householdSlotsUsed >= dependantCap}
+                  onClick={() => setNewSpouses((rows) => [...rows, emptyPerson()])}
+                >
+                  Add spouse
+                </Button>
+              </div>
+              {newSpouses.map((person, index) => (
+                <div key={`ns-${index}`} className="grid grid-cols-2 gap-2">
+                  <Input
+                    placeholder="First name"
+                    value={person.firstName}
+                    onChange={(e) =>
+                      setNewSpouses((rows) =>
+                        rows.map((r, i) => (i === index ? { ...r, firstName: e.target.value } : r))
+                      )
+                    }
+                  />
+                  <Input
+                    placeholder="Last name"
+                    value={person.lastName}
+                    onChange={(e) =>
+                      setNewSpouses((rows) =>
+                        rows.map((r, i) => (i === index ? { ...r, lastName: e.target.value } : r))
+                      )
+                    }
+                  />
+                </div>
+              ))}
+            </div>
+
+            <div className="space-y-2 pt-2">
+              <div className="flex items-center justify-between">
+                <Label>New children</Label>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  disabled={householdSlotsUsed >= dependantCap}
+                  onClick={() => setNewChildren((rows) => [...rows, emptyPerson()])}
+                >
+                  Add child
+                </Button>
+              </div>
+              {newChildren.map((person, index) => (
+                <div key={`nc-${index}`} className="grid grid-cols-2 gap-2">
+                  <Input
+                    placeholder="First name"
+                    value={person.firstName}
+                    onChange={(e) =>
+                      setNewChildren((rows) =>
+                        rows.map((r, i) => (i === index ? { ...r, firstName: e.target.value } : r))
+                      )
+                    }
+                  />
+                  <Input
+                    placeholder="Last name"
+                    value={person.lastName}
+                    onChange={(e) =>
+                      setNewChildren((rows) =>
+                        rows.map((r, i) => (i === index ? { ...r, lastName: e.target.value } : r))
+                      )
+                    }
+                  />
+                </div>
+              ))}
+            </div>
+
+            <div className="flex gap-2">
+              <Button variant="outline" onClick={() => setStep('product')}>
+                Back
+              </Button>
+              <Button onClick={goNext}>Continue</Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {step === 'beneficiary' && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Beneficiary</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <Label>Existing next of kin</Label>
+            <Select
+              value={beneficiaryId}
+              onValueChange={(v) => {
+                setBeneficiaryId(v);
+                setNewBeneficiary(null);
+              }}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Select beneficiary" />
+              </SelectTrigger>
+              <SelectContent>
+                {existingBeneficiaries.map((b) => (
+                  <SelectItem key={b.id} value={b.id}>
+                    {b.firstName} {b.lastName}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground">Or add a new next of kin for this policy.</p>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                setBeneficiaryId('');
+                setNewBeneficiary(emptyPerson());
+              }}
+            >
+              Add new beneficiary
+            </Button>
+            {newBeneficiary && (
+              <div className="grid grid-cols-2 gap-2">
+                <Input
+                  placeholder="First name"
+                  value={newBeneficiary.firstName}
+                  onChange={(e) => setNewBeneficiary({ ...newBeneficiary, firstName: e.target.value })}
+                />
+                <Input
+                  placeholder="Last name"
+                  value={newBeneficiary.lastName}
+                  onChange={(e) => setNewBeneficiary({ ...newBeneficiary, lastName: e.target.value })}
+                />
+              </div>
+            )}
+            <div className="flex gap-2">
+              <Button variant="outline" onClick={() => setStep(hasFamily ? 'household' : 'product')}>
+                Back
+              </Button>
+              <Button onClick={goNext}>Continue</Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {step === 'payment' && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Payment summary</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <p className="text-sm">
+              {selectedPlan?.name} · household {householdSize} · extra spouse add-ons: {extraSpouse}
+            </p>
+            <p className="text-sm">
+              Installment: {priced?.premium ?? 0} · Annual: {priced?.annualPremium ?? 0}
+            </p>
+            {isPostpaid ? (
+              <p className="text-sm text-muted-foreground">
+                Postpaid products never send STK. Frequency comes from the scheme.
+              </p>
+            ) : (
+              <div>
+                <Label>Payment frequency *</Label>
+                <Select value={frequency} onValueChange={setFrequency}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select frequency" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {enabledFrequencies.map((f) => (
+                      <SelectItem key={f} value={f}>
+                        {f}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+            {!isPostpaid && (
+              <>
+                <div>
+                  <Label>Phone for STK</Label>
+                  <Input value={paymentPhone} onChange={(e) => setPaymentPhone(e.target.value)} />
+                  <p className="text-xs text-muted-foreground mt-1">
+                    Default is {customerPhone || 'the customer phone (enter it if masked)'}
+                  </p>
+                </div>
+                <label className="flex items-center gap-2 text-sm">
+                  <Checkbox checked={skipPayment} onCheckedChange={(c) => setSkipPayment(c === true)} />
+                  Do not collect payment now
+                </label>
+              </>
+            )}
+            <div className="flex gap-2">
+              <Button variant="outline" onClick={() => setStep('beneficiary')}>
+                Back
+              </Button>
+              <Button onClick={() => void submit()} disabled={submitting}>
+                {submitting
+                  ? 'Saving…'
+                  : isPostpaid || skipPayment
+                    ? 'Create policy'
+                    : 'Create and STK'}
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/apps/agent-registration/src/app/(main)/admin/customer/[customerId]/add-product/page.tsx
+++ b/apps/agent-registration/src/app/(main)/admin/customer/[customerId]/add-product/page.tsx
@@ -276,7 +276,7 @@ export default function AddProductPage() {
         packageId,
         packagePlanId: planId,
         packageSchemeId,
-        frequency: (isPostpaid ? schemeFrequency : frequency) || 'MONTHLY',
+        frequency: (isPostpaid ? schemeFrequency : frequency) ?? 'MONTHLY',
         premium: priced.premium,
         annualPremium: priced.annualPremium,
         productName: `${selectedPlan.name}`,

--- a/apps/agent-registration/src/app/(main)/admin/customer/[customerId]/page.tsx
+++ b/apps/agent-registration/src/app/(main)/admin/customer/[customerId]/page.tsx
@@ -182,7 +182,11 @@ export default function CustomerDetailPage() {
         </TabsContent>
 
         <TabsContent value="products">
-          <ProductsTab customerId={customerId} basePath="admin" />
+          <ProductsTab
+            customerId={customerId}
+            basePath="admin"
+            customerStatus={customerData.customer.status}
+          />
         </TabsContent>
         <TabsContent value="payments">
           <PaymentsTab customerId={customerId} />

--- a/apps/agent-registration/src/app/(main)/customer/[customerId]/_components/modify-product-dialog.tsx
+++ b/apps/agent-registration/src/app/(main)/customer/[customerId]/_components/modify-product-dialog.tsx
@@ -123,14 +123,14 @@ export default function ModifyProductDialog({
     if (!plan) return null;
     const cat = plan.categories[options.familyCategory];
     if (!cat) return null;
-    const spouse = options.additionalSpouse;
-    const daily = (cat.daily ?? 0) + (spouse ? plan.additional_spouse.daily ?? 0 : 0);
-    const weekly = (cat.weekly ?? 0) + (spouse ? plan.additional_spouse.weekly ?? 0 : 0);
+    const extraSpouse = options.additionalSpouseCount ?? (options.additionalSpouse ? 1 : 0);
+    const daily = (cat.daily ?? 0) + extraSpouse * (plan.additional_spouse.daily ?? 0);
+    const weekly = (cat.weekly ?? 0) + extraSpouse * (plan.additional_spouse.weekly ?? 0);
     const lookupRates: PricingRateBand = {
       daily,
       weekly,
-      monthly: (cat.monthly ?? 0) + (spouse ? plan.additional_spouse.monthly ?? 0 : 0),
-      annually: (cat.annually ?? 0) + (spouse ? plan.additional_spouse.annually ?? 0 : 0),
+      monthly: (cat.monthly ?? 0) + extraSpouse * (plan.additional_spouse.monthly ?? 0),
+      annually: (cat.annually ?? 0) + extraSpouse * (plan.additional_spouse.annually ?? 0),
     };
     return { daily, weekly, lookupRates };
   }, [pricing, options, selectedPlan]);

--- a/apps/agent-registration/src/app/(main)/customer/[customerId]/_components/policy-detail-view.tsx
+++ b/apps/agent-registration/src/app/(main)/customer/[customerId]/_components/policy-detail-view.tsx
@@ -199,6 +199,12 @@ export default function PolicyDetailView({
           {data.policyNumber && (
             <p className="text-sm text-muted-foreground">Policy # {data.policyNumber}</p>
           )}
+          {data.beneficiary ? (
+            <p className="text-sm text-muted-foreground">
+              Next of kin: {data.beneficiary.firstName} {data.beneficiary.lastName}
+              {data.beneficiary.relationship ? ` (${data.beneficiary.relationship})` : ''}
+            </p>
+          ) : null}
           {canEditScheme ? (
             <div className="space-y-2 pt-2 max-w-xs">
               <Label className="text-sm text-muted-foreground">Staff number (LCT)</Label>

--- a/apps/agent-registration/src/app/(main)/customer/[customerId]/_components/products-tab.tsx
+++ b/apps/agent-registration/src/app/(main)/customer/[customerId]/_components/products-tab.tsx
@@ -42,6 +42,7 @@ interface ProductsTabProps {
   customerId: string;
   /** 'admin' | 'dashboard' | 'agent' — used for policy detail link */
   basePath: 'admin' | 'dashboard' | 'agent';
+  customerStatus?: string;
 }
 
 type RowAction =
@@ -54,7 +55,7 @@ type RowAction =
   | 'terminate'
   | null;
 
-export default function ProductsTab({ customerId, basePath }: ProductsTabProps) {
+export default function ProductsTab({ customerId, basePath, customerStatus }: ProductsTabProps) {
   const router = useRouter();
   const { isAdmin } = useAuth();
   const showAdminActions = basePath === 'admin' && isAdmin;
@@ -159,12 +160,25 @@ export default function ProductsTab({ customerId, basePath }: ProductsTabProps) 
   return (
     <>
       <Card>
-        <CardHeader>
-          <CardTitle>Products</CardTitle>
-          <CardDescription>
-            Policies this customer is enrolled in. Click a row to view product and enrollment
-            details.
-          </CardDescription>
+        <CardHeader className="flex flex-row items-start justify-between space-y-0">
+          <div>
+            <CardTitle>Products</CardTitle>
+            <CardDescription>
+              Policies this customer is enrolled in. Click a row to view product and enrollment
+              details.
+            </CardDescription>
+          </div>
+          {showAdminActions && (
+            <Button
+              onClick={() => router.push(`/admin/customer/${customerId}/add-product`)}
+              disabled={
+                customerStatus === 'TERMINATED' ||
+                policies.some((p) => p.status === 'TERMINATED')
+              }
+            >
+              Add product
+            </Button>
+          )}
         </CardHeader>
         <CardContent>
           {successMessage && (

--- a/apps/agent-registration/src/app/(main)/register/customer/page.tsx
+++ b/apps/agent-registration/src/app/(main)/register/customer/page.tsx
@@ -12,7 +12,18 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Plus, Trash2, Loader2, CheckCircle, LayoutDashboard } from 'lucide-react';
-import { createCustomer, createAgentRegistration, CustomerRegistrationRequest } from '@/lib/api';
+import {
+  createCustomer,
+  createAgentRegistration,
+  CustomerRegistrationRequest,
+  getPackagePlans,
+  getPackagePricing,
+  listPackagesForSchemes,
+  type Plan,
+} from '@/lib/api';
+import SchemeTypeahead from '@/components/scheme-typeahead';
+import { maxDependantSlots, packageHasFamilyBands } from '@/lib/family-category';
+import { pricingBandsFromApi } from '@/lib/package-pricing-ui';
 import { useAuth } from '@/hooks/useAuth';
 import { useBrandAmbassador } from '@/hooks/useBrandAmbassador';
 import DateOfBirthInput from '@/components/date-of-birth-input';
@@ -177,9 +188,14 @@ export default function CustomerStep() {
   const [schemes, setSchemes] = useState<Array<{id: number, name: string, description?: string, packageSchemeId?: number, parentsSupported?: boolean}>>([]);
   const [selectedPackageId, setSelectedPackageId] = useState<number | null>(null);
   const [selectedSchemeId, setSelectedSchemeId] = useState<number | null>(null);
+  const [selectedSchemeName, setSelectedSchemeName] = useState('');
+  const [plans, setPlans] = useState<Plan[]>([]);
+  const [selectedPlanId, setSelectedPlanId] = useState<number | null>(null);
   const [loadingSchemes, setLoadingSchemes] = useState(false);
+  const [hasFamilyBands, setHasFamilyBands] = useState(true);
+  const [dependantCap, setDependantCap] = useState(7);
   const selectedSchemeParentsSupported = Boolean(
-    schemes.find((s) => s.id === selectedSchemeId)?.parentsSupported
+    hasFamilyBands && schemes.find((s) => s.id === selectedSchemeId)?.parentsSupported
   );
 
   // Date constraints - set after mount to avoid server/client hydration mismatch (new Date() differs by timezone)
@@ -207,19 +223,9 @@ export default function CustomerStep() {
     }
   }, [searchParams, router]);
 
-  // Load packages on mount and restore last selections from localStorage
   useEffect(() => {
-    fetchPackages();
-
-    const savedPackageId = localStorage.getItem('lastSelectedPackageId');
-    const savedSchemeId = localStorage.getItem('lastSelectedSchemeId');
-
-    if (savedPackageId) {
-      const pkgId = parseInt(savedPackageId);
-      setSelectedPackageId(pkgId);
-      fetchSchemes(pkgId, savedSchemeId ? parseInt(savedSchemeId) : null);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    const savedPlanId = localStorage.getItem('lastSelectedPlanId');
+    if (savedPlanId) setSelectedPlanId(parseInt(savedPlanId, 10));
   }, []);
 
   // Helper to get Supabase token for API calls
@@ -228,35 +234,39 @@ export default function CustomerStep() {
     return session.session?.access_token;
   };
 
-  // Fetch all active packages
-  const fetchPackages = async () => {
+  const fetchPackagesForScheme = async (schemeId: number) => {
     try {
-      const token = await getSupabaseToken();
-      const response = await fetch(
-        `${process.env.NEXT_PUBLIC_INTERNAL_API_BASE_URL}/internal/product-management/packages`,
-        {
-          headers: {
-            'Authorization': `Bearer ${token}`,
-            'x-correlation-id': `req-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`
-          }
-        }
-      );
-
-      if (!response.ok) {
-        throw new Error('Failed to fetch packages');
-      }
-
-      const data = await response.json();
-      setPackages(data.data ?? []);
+      const pkgs = await listPackagesForSchemes([schemeId]);
+      setPackages(pkgs);
     } catch (err) {
       console.error('Error fetching packages:', err);
       Sentry.captureException(err, {
-        tags: { component: 'CustomerStep', action: 'fetchPackages' }
+        tags: { component: 'CustomerStep', action: 'fetchPackagesForScheme' },
       });
-      setError('Failed to load packages. Please refresh the page.');
+      setError('Failed to load packages for this scheme.');
     }
   };
 
+  const loadPlanAndPricing = async (packageId: number) => {
+    try {
+      const [pkgPlans, pricing] = await Promise.all([
+        getPackagePlans(packageId),
+        getPackagePricing(packageId).catch(() => null),
+      ]);
+      setPlans(pkgPlans);
+      const bands = pricing ? pricingBandsFromApi(pricing) : [];
+      const family = packageHasFamilyBands(bands);
+      setHasFamilyBands(family);
+      setDependantCap(maxDependantSlots(bands));
+      if (!family) {
+        setFormData((prev) => ({ ...prev, spouses: [], children: [], parents: [] }));
+      }
+    } catch (err) {
+      console.error('Error loading plans/pricing:', err);
+    }
+  };
+
+  // Fetch all active packages
   // Fetch schemes for a selected package
   const fetchSchemes = async (packageId: number, preselectedSchemeId?: number | null) => {
     setLoadingSchemes(true);
@@ -294,27 +304,38 @@ export default function CustomerStep() {
     }
   };
 
+  const handleSchemePicked = (scheme: { id: number; name: string; parentsSupported?: boolean; packageSchemeId?: number }) => {
+    setSelectedSchemeId(scheme.id);
+    setSelectedSchemeName(scheme.name);
+    setSchemes([
+      {
+        id: scheme.id,
+        name: scheme.name,
+        parentsSupported: scheme.parentsSupported,
+        packageSchemeId: scheme.packageSchemeId,
+      },
+    ]);
+    setSelectedPackageId(null);
+    setSelectedPlanId(null);
+    setPackages([]);
+    setPlans([]);
+    void fetchPackagesForScheme(scheme.id);
+    localStorage.setItem('lastSelectedSchemeId', String(scheme.id));
+    localStorage.removeItem('lastSelectedPackageId');
+    localStorage.removeItem('lastSelectedPlanId');
+  };
+
   // Handle package selection change
   const handlePackageChange = (value: string) => {
     const packageId = parseInt(value);
     setSelectedPackageId(packageId);
-    setSelectedSchemeId(null); // Reset scheme when package changes
-    setSchemes([]); // Clear schemes
+    setSelectedPlanId(null);
     setFormData((prev) => ({ ...prev, parents: [] }));
-    fetchSchemes(packageId);
-    localStorage.setItem('lastSelectedPackageId', value);
-    localStorage.removeItem('lastSelectedSchemeId'); // Clear saved scheme
-  };
-
-  // Handle scheme selection change
-  const handleSchemeChange = (value: string) => {
-    const schemeId = parseInt(value);
-    setSelectedSchemeId(schemeId);
-    localStorage.setItem('lastSelectedSchemeId', value);
-    const scheme = schemes.find((s) => s.id === schemeId);
-    if (!scheme?.parentsSupported) {
-      setFormData((prev) => ({ ...prev, parents: [] }));
+    void loadPlanAndPricing(packageId);
+    if (selectedSchemeId) {
+      void fetchSchemes(packageId, selectedSchemeId);
     }
+    localStorage.setItem('lastSelectedPackageId', value);
   };
 
   const handleInputChange = (field: keyof CustomerFormData, value: string) => {
@@ -334,12 +355,11 @@ export default function CustomerStep() {
   };
 
   const addSpouse = () => {
-    if (formData.spouses.length < 2) {
-      setFormData(prev => ({
-        ...prev,
-        spouses: [...prev.spouses, { firstName: '', middleName: '', lastName: '', gender: '', dateOfBirth: '', phoneNumber: '', idType: 'NATIONAL_ID', idNumber: '' }]
-      }));
-    }
+    if (formData.spouses.length + formData.children.length >= dependantCap) return;
+    setFormData(prev => ({
+      ...prev,
+      spouses: [...prev.spouses, { firstName: '', middleName: '', lastName: '', gender: '', dateOfBirth: '', phoneNumber: '', idType: 'NATIONAL_ID', idNumber: '' }]
+    }));
   };
 
   const removeSpouse = (spouseIndex: number) => {
@@ -350,12 +370,11 @@ export default function CustomerStep() {
   };
 
   const addChild = () => {
-    if (formData.children.length < 7) {
-      setFormData(prev => ({
-        ...prev,
-        children: [...prev.children, { firstName: '', middleName: '', lastName: '', gender: 'MALE', dateOfBirth: '', phoneNumber: '', idType: 'BIRTH_CERTIFICATE', idNumber: '' }]
-      }));
-    }
+    if (formData.spouses.length + formData.children.length >= dependantCap) return;
+    setFormData(prev => ({
+      ...prev,
+      children: [...prev.children, { firstName: '', middleName: '', lastName: '', gender: 'MALE', dateOfBirth: '', phoneNumber: '', idType: 'BIRTH_CERTIFICATE', idNumber: '' }]
+    }));
   };
 
   const removeChild = (index: number) => {
@@ -765,13 +784,21 @@ export default function CustomerStep() {
           <CardTitle>Select Product</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            {/* Package Dropdown */}
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <SchemeTypeahead
+              value={selectedSchemeId ?? undefined}
+              selectedName={selectedSchemeName}
+              onSelect={(s) => handleSchemePicked(s)}
+            />
             <div>
               <Label htmlFor="package">Package *</Label>
-              <Select value={selectedPackageId?.toString() ?? ''} onValueChange={handlePackageChange}>
+              <Select
+                value={selectedPackageId?.toString() ?? ''}
+                onValueChange={handlePackageChange}
+                disabled={!selectedSchemeId}
+              >
                 <SelectTrigger id="package">
-                  <SelectValue placeholder="Select package" />
+                  <SelectValue placeholder={selectedSchemeId ? 'Select package' : 'Select scheme first'} />
                 </SelectTrigger>
                 <SelectContent>
                   {packages.map(pkg => (
@@ -780,27 +807,26 @@ export default function CustomerStep() {
                 </SelectContent>
               </Select>
             </div>
-
-            {/* Scheme Dropdown */}
             <div>
-              <Label htmlFor="scheme">Scheme *</Label>
+              <Label htmlFor="plan">Plan *</Label>
               <Select
-                value={selectedSchemeId?.toString() ?? ''}
-                onValueChange={handleSchemeChange}
-                disabled={!selectedPackageId || loadingSchemes}
+                value={selectedPlanId?.toString() ?? ''}
+                onValueChange={(value) => {
+                  setSelectedPlanId(parseInt(value, 10));
+                  localStorage.setItem('lastSelectedPlanId', value);
+                  localStorage.setItem('selectedPlanName', plans.find((p) => p.id === parseInt(value, 10))?.name ?? '');
+                }}
+                disabled={!selectedPackageId}
               >
-                <SelectTrigger id="scheme">
-                  <SelectValue placeholder={loadingSchemes ? "Loading..." : "Select scheme"} />
+                <SelectTrigger id="plan">
+                  <SelectValue placeholder={selectedPackageId ? 'Select plan' : 'Select package first'} />
                 </SelectTrigger>
                 <SelectContent>
-                  {schemes.map(scheme => (
-                    <SelectItem key={scheme.id} value={scheme.id.toString()}>{scheme.name}</SelectItem>
+                  {plans.map((plan) => (
+                    <SelectItem key={plan.id} value={plan.id.toString()}>{plan.name}</SelectItem>
                   ))}
                 </SelectContent>
               </Select>
-              {selectedPackageId && schemes.length === 0 && !loadingSchemes && (
-                <p className="text-sm text-red-500 mt-1">This package has no schemes.</p>
-              )}
             </div>
           </div>
         </CardContent>
@@ -972,6 +998,7 @@ export default function CustomerStep() {
       </Card> */}
 
       {/* Dependants */}
+      {hasFamilyBands && (
       <Card>
         <CardHeader>
           <CardTitle>Dependants</CardTitle>
@@ -980,12 +1007,14 @@ export default function CustomerStep() {
           {/* Spouses */}
           <div>
             <div className="flex items-center justify-between mb-4">
-              <h3 className="text-lg font-semibold">Spouses ({formData.spouses.length}/2)</h3>
+              <h3 className="text-lg font-semibold">
+                Spouses ({formData.spouses.length}/{dependantCap})
+              </h3>
               <Button
                 variant="outline"
                 size="sm"
                 onClick={addSpouse}
-                disabled={formData.spouses.length >= 2}
+                disabled={formData.spouses.length + formData.children.length >= dependantCap}
               >
                 <Plus className="h-4 w-4 mr-2" />
                 Add Spouse
@@ -1111,12 +1140,14 @@ export default function CustomerStep() {
           {/* Children */}
           <div>
             <div className="flex items-center justify-between mb-4">
-              <h3 className="text-lg font-semibold">Children ({formData.children.length}/7)</h3>
+              <h3 className="text-lg font-semibold">
+                Children ({formData.children.length}/{dependantCap})
+              </h3>
               <Button
                 variant="outline"
                 size="sm"
                 onClick={addChild}
-                disabled={formData.children.length >= 7}
+                disabled={formData.spouses.length + formData.children.length >= dependantCap}
               >
                 <Plus className="h-4 w-4 mr-2" />
                 Add Child
@@ -1340,6 +1371,7 @@ export default function CustomerStep() {
           )}
         </CardContent>
       </Card>
+      )}
 
       {/* Error Display */}
       {error && (

--- a/apps/agent-registration/src/app/(main)/register/customer/page.tsx
+++ b/apps/agent-registration/src/app/(main)/register/customer/page.tsx
@@ -191,7 +191,7 @@ export default function CustomerStep() {
   const [selectedSchemeName, setSelectedSchemeName] = useState('');
   const [plans, setPlans] = useState<Plan[]>([]);
   const [selectedPlanId, setSelectedPlanId] = useState<number | null>(null);
-  const [loadingSchemes, setLoadingSchemes] = useState(false);
+  const [_loadingSchemes, setLoadingSchemes] = useState(false);
   const [hasFamilyBands, setHasFamilyBands] = useState(true);
   const [dependantCap, setDependantCap] = useState(7);
   const selectedSchemeParentsSupported = Boolean(

--- a/apps/agent-registration/src/app/(main)/register/payment/page.tsx
+++ b/apps/agent-registration/src/app/(main)/register/payment/page.tsx
@@ -36,6 +36,7 @@ import {
   type PricingRateBand,
 } from '@/lib/insurance-installment';
 import {
+  additionalSpouseCount,
   hasAdditionalSpousePremium,
   householdSizeFromRegistrationForm,
   validateSelectedFamilyCategory,
@@ -139,6 +140,7 @@ export default function PaymentStep() {
   const [pricingApiData, setPricingApiData] = useState<PackagePricingData | null>(null);
   const [pricingLoadError, setPricingLoadError] = useState<string | null>(null);
   const [selectedPlan, setSelectedPlan] = useState<string>('');
+  const [planLocked, setPlanLocked] = useState(false);
   const [selectedCategory, setSelectedCategory] = useState<string>('');
   const [additionalSpouse, setAdditionalSpouse] = useState(false);
   const [calculatedPricing, setCalculatedPricing] = useState({
@@ -165,7 +167,18 @@ export default function PaymentStep() {
     getPackagePricingBySlug(slug)
       .then((data) => {
         setPricingApiData(data);
-        setPricingData(mapPackagePricingToUi(data));
+        const ui = mapPackagePricingToUi(data);
+        setPricingData(ui);
+        const savedPlanName = localStorage.getItem('selectedPlanName')?.trim().toLowerCase();
+        if (savedPlanName) {
+          const match = Object.entries(ui.plans).find(
+            ([, plan]) => plan.name.toLowerCase() === savedPlanName
+          );
+          if (match) {
+            setSelectedPlan(match[0]);
+            setPlanLocked(true);
+          }
+        }
       })
       .catch((err) => {
         console.error('Error loading pricing data:', err);
@@ -225,6 +238,12 @@ export default function PaymentStep() {
       const customer = JSON.parse(savedCustomerData);
       setCustomerData(customer);
       setPaymentPhone(customer.phoneNumber); // Pre-populate with customer phone
+      const spouseCount = (customer.spouses ?? []).filter((s: { firstName?: string }) =>
+        s.firstName?.trim()
+      ).length;
+      if (spouseCount > 1) {
+        setAdditionalSpouse(true);
+      }
     }
 
     if (savedBeneficiaryData) {
@@ -312,16 +331,20 @@ export default function PaymentStep() {
     const spousePremium = plan.additional_spouse;
     if (!category) return;
 
+    const spouseCount = customerData?.spouses.filter((s) => s.firstName?.trim()).length ?? 0;
+    const extraSpouse = additionalSpouse
+      ? additionalSpouseCount(selectedCategory, spouseCount)
+      : 0;
     const baseDaily = category.daily ?? 0;
     const baseWeekly = category.weekly ?? 0;
-    const spouseDaily = additionalSpouse ? spousePremium.daily ?? 0 : 0;
-    const spouseWeekly = additionalSpouse ? spousePremium.weekly ?? 0 : 0;
+    const spouseDaily = extraSpouse * (spousePremium.daily ?? 0);
+    const spouseWeekly = extraSpouse * (spousePremium.weekly ?? 0);
 
     const lookupRates: PricingRateBand = {
-      daily: (category.daily ?? 0) + (additionalSpouse ? spousePremium.daily ?? 0 : 0),
-      weekly: (category.weekly ?? 0) + (additionalSpouse ? spousePremium.weekly ?? 0 : 0),
-      monthly: (category.monthly ?? 0) + (additionalSpouse ? spousePremium.monthly ?? 0 : 0),
-      annually: (category.annually ?? 0) + (additionalSpouse ? spousePremium.annually ?? 0 : 0),
+      daily: (category.daily ?? 0) + extraSpouse * (spousePremium.daily ?? 0),
+      weekly: (category.weekly ?? 0) + extraSpouse * (spousePremium.weekly ?? 0),
+      monthly: (category.monthly ?? 0) + extraSpouse * (spousePremium.monthly ?? 0),
+      annually: (category.annually ?? 0) + extraSpouse * (spousePremium.annually ?? 0),
     };
 
     setCalculatedPricing({
@@ -331,7 +354,7 @@ export default function PaymentStep() {
       totalWeekly: baseWeekly + spouseWeekly,
       lookupRates,
     });
-  }, [pricingData, selectedPlan, selectedCategory, additionalSpouse]);
+  }, [pricingData, selectedPlan, selectedCategory, additionalSpouse, customerData]);
 
   const installmentForSelection = (frequency: string) =>
     computeInstallmentPremium({
@@ -347,9 +370,10 @@ export default function PaymentStep() {
   useEffect(() => {
     if (selectedPlan) {
       setSelectedCategory('');
-      setAdditionalSpouse(false);
+      const spouseCount = customerData?.spouses.filter((s) => s.firstName?.trim()).length ?? 0;
+      setAdditionalSpouse(spouseCount > 1);
     }
-  }, [selectedPlan]);
+  }, [selectedPlan, customerData]);
 
   const handleBack = () => {
     router.push('/register/beneficiary');
@@ -711,7 +735,7 @@ export default function PaymentStep() {
                 <Select
                   value={selectedPlan}
                   onValueChange={setSelectedPlan}
-                  disabled={!pricingData}
+                  disabled={!pricingData || planLocked}
                 >
                   <SelectTrigger id="planSelection">
                     <SelectValue placeholder={pricingData ? 'Select insurance plan' : 'No pricing available'} />

--- a/apps/agent-registration/src/components/scheme-typeahead.tsx
+++ b/apps/agent-registration/src/components/scheme-typeahead.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { listSchemesForPicker, type Scheme } from '@/lib/api';
+
+interface SchemeTypeaheadProps {
+  value?: number;
+  selectedName?: string;
+  onSelect: (scheme: Scheme) => void;
+  disabled?: boolean;
+}
+
+export default function SchemeTypeahead({
+  value,
+  selectedName,
+  onSelect,
+  disabled,
+}: SchemeTypeaheadProps) {
+  const [query, setQuery] = useState(selectedName ?? '');
+  const [results, setResults] = useState<Scheme[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (selectedName && value) {
+      setQuery(selectedName);
+    }
+  }, [selectedName, value]);
+
+  useEffect(() => {
+    const trimmed = query.trim();
+    if (trimmed.length < 2) {
+      setResults([]);
+      return;
+    }
+    if (selectedName && trimmed === selectedName) {
+      setResults([]);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    const handle = setTimeout(() => {
+      void listSchemesForPicker(trimmed)
+        .then((rows) => {
+          if (!cancelled) setResults(rows.filter((s) => s.isActive !== false));
+        })
+        .catch(() => {
+          if (!cancelled) setResults([]);
+        })
+        .finally(() => {
+          if (!cancelled) setLoading(false);
+        });
+    }, 200);
+    return () => {
+      cancelled = true;
+      clearTimeout(handle);
+    };
+  }, [query, selectedName]);
+
+  return (
+    <div className="relative">
+      <Label htmlFor="scheme-typeahead">Scheme *</Label>
+      <Input
+        id="scheme-typeahead"
+        value={query}
+        disabled={disabled}
+        placeholder="Type at least 2 letters"
+        onChange={(e) => setQuery(e.target.value)}
+        autoComplete="off"
+      />
+      {loading && <p className="text-xs text-muted-foreground mt-1">Searching…</p>}
+      {results.length > 0 && (
+        <ul className="absolute z-20 mt-1 max-h-48 w-full overflow-auto rounded-md border bg-background shadow">
+          {results.map((scheme) => (
+            <li key={scheme.id}>
+              <button
+                type="button"
+                className="w-full px-3 py-2 text-left text-sm hover:bg-muted"
+                onClick={() => {
+                  setQuery(scheme.name);
+                  setResults([]);
+                  onSelect(scheme);
+                }}
+              >
+                {scheme.name}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      {query.trim().length > 0 && query.trim().length < 2 && (
+        <p className="text-xs text-muted-foreground mt-1">Keep typing to search schemes.</p>
+      )}
+    </div>
+  );
+}

--- a/apps/agent-registration/src/lib/api.ts
+++ b/apps/agent-registration/src/lib/api.ts
@@ -964,6 +964,7 @@ export interface CustomerDetailData {
     policyNumber: string
     packageName: string
     planName?: string
+    packageId?: number
     status: string
   }>
 }
@@ -1065,6 +1066,14 @@ export interface CustomerPolicyDetail {
   missedPaymentsApproximate?: boolean
   paymentsMadeCount?: number
   missedPaymentsAmount: MissedPaymentsAmount
+  beneficiary?: {
+    id: string
+    firstName: string
+    middleName: string | null
+    lastName: string
+    relationship: string
+    percentage: number
+  } | null
 }
 
 export interface CustomerPolicyDetailResponse {
@@ -1969,6 +1978,7 @@ export interface Scheme {
   parentsSupported?: boolean
   /** Junction id for scheme assignment (PackageScheme.id); use as value when updating customer scheme */
   packageSchemeId?: number
+  isPostpaid?: boolean
 }
 
 export interface Plan {
@@ -2054,10 +2064,11 @@ export async function getPackages(options?: { includeInactive?: boolean }): Prom
 }
 
 /** All schemes including inactive (for campaign audience pickers). */
-export async function listSchemesForPicker(): Promise<Scheme[]> {
+export async function listSchemesForPicker(q?: string): Promise<Scheme[]> {
   const token = await getSupabaseToken()
+  const params = q && q.trim().length >= 2 ? `?q=${encodeURIComponent(q.trim())}` : ''
   const response = await fetch(
-    `${process.env.NEXT_PUBLIC_INTERNAL_API_BASE_URL}/internal/product-management/schemes`,
+    `${process.env.NEXT_PUBLIC_INTERNAL_API_BASE_URL}/internal/product-management/schemes${params}`,
     {
       method: 'GET',
       headers: {
@@ -2648,6 +2659,55 @@ export async function createPolicyFromRecovery(
   return response.json()
 }
 
+export async function getAdditionalPolicyEligibility(
+  customerId: string
+): Promise<{ canAdd: boolean; blockedReasons: string[] }> {
+  const token = await getSupabaseToken()
+  const response = await fetch(
+    `${process.env.NEXT_PUBLIC_INTERNAL_API_BASE_URL}/internal/customers/${customerId}/additional-policies/eligibility`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'x-correlation-id': `add-product-elig-${Date.now()}`,
+      },
+    }
+  )
+  if (!response.ok) {
+    throw new Error('Failed to check add-product eligibility')
+  }
+  return response.json()
+}
+
+export async function createAdditionalPolicy(
+  customerId: string,
+  data: Record<string, unknown>
+): Promise<{
+  status: number
+  data: {
+    policy: { id: string; paymentAcNumber: string | null; status: string; productName: string }
+    stkPush: unknown
+  }
+}> {
+  const token = await getSupabaseToken()
+  const response = await fetch(
+    `${process.env.NEXT_PUBLIC_INTERNAL_API_BASE_URL}/internal/customers/${customerId}/additional-policies`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+        'x-correlation-id': `add-product-${Date.now()}`,
+      },
+      body: JSON.stringify(data),
+    }
+  )
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}))
+    throw new Error(err?.error?.message ?? 'Failed to add product')
+  }
+  return response.json()
+}
+
 export async function createPolicyWithoutPayments(
   data: CreatePolicyFromRecoveryRequest
 ): Promise<{ policy: { id: string; policyNumber: string | null; status: string } }> {
@@ -3182,6 +3242,7 @@ export interface ModifyPolicyOptions {
   paymentFrequencies: Array<{ frequency: string; installmentCount: number }>
   familyCategory: string
   additionalSpouse: boolean
+  additionalSpouseCount?: number
   currentPackagePlanId: number
   currentPlanName?: string
   currentPremium: number

--- a/apps/agent-registration/src/lib/family-category.ts
+++ b/apps/agent-registration/src/lib/family-category.ts
@@ -10,6 +10,29 @@ export type FamilyCategoryResolution =
   | { ok: true; categoryKey: string }
   | { ok: false; reason: 'OVERFLOW' | 'UNDERSIZED' | 'UNKNOWN_CATEGORY' };
 
+export function resolveFamilyCategoryForHousehold(
+  householdSize: number,
+  bands: PackagePricingBand[]
+): FamilyCategoryResolution {
+  if (householdSize <= 1) {
+    const memberOnly = bands.find((b) => b.kind === 'MEMBER_ONLY');
+    if (!memberOnly) {
+      return { ok: false, reason: 'OVERFLOW' };
+    }
+    return { ok: true, categoryKey: memberOnly.key };
+  }
+
+  const upTo = bands
+    .filter((b) => b.kind === 'UP_TO_N' && b.maxMembers != null && b.maxMembers >= 2)
+    .sort((a, b) => (a.maxMembers ?? 0) - (b.maxMembers ?? 0));
+
+  const fit = upTo.find((b) => (b.maxMembers ?? 0) >= householdSize);
+  if (!fit) {
+    return { ok: false, reason: 'OVERFLOW' };
+  }
+  return { ok: true, categoryKey: fit.key };
+}
+
 export function validateSelectedFamilyCategory(params: {
   selectedCategoryKey: string;
   householdSize: number | null | undefined;
@@ -39,20 +62,37 @@ export function validateSelectedFamilyCategory(params: {
   return { ok: true, categoryKey: selectedCategoryKey };
 }
 
+export function packageHasFamilyBands(bands: PackagePricingBand[]): boolean {
+  return bands.some((b) => b.kind === 'UP_TO_N' && (b.maxMembers ?? 0) >= 2);
+}
+
+export function maxDependantSlots(bands: PackagePricingBand[]): number {
+  const upTo = bands
+    .filter((b) => b.kind === 'UP_TO_N' && b.maxMembers != null && b.maxMembers >= 2)
+    .map((b) => b.maxMembers ?? 0);
+  if (upTo.length === 0) return 0;
+  return Math.max(...upTo) - 1;
+}
+
+export function additionalSpouseCount(
+  category: string,
+  spouseCount: number,
+  options?: { optedIn?: boolean; householdKnown?: boolean }
+): number {
+  if (category === 'member_only' || category === 'MEMBER_ONLY') return 0;
+  if (options?.optedIn === false) return 0;
+  if (options?.householdKnown === false) {
+    return options.optedIn === true ? 1 : 0;
+  }
+  return Math.max(0, spouseCount - 1);
+}
+
 export function hasAdditionalSpousePremium(
   category: string,
   spouseCount: number,
   options?: { optedIn?: boolean; householdKnown?: boolean }
 ): boolean {
-  if (category === 'member_only' || category === 'MEMBER_ONLY') return false;
-  if (options?.optedIn === false) return false;
-
-  if (options?.householdKnown === false) {
-    return options.optedIn === true;
-  }
-
-  if (spouseCount <= 1) return false;
-  return true;
+  return additionalSpouseCount(category, spouseCount, options) > 0;
 }
 
 export function householdSizeFromRegistrationForm(params: {

--- a/apps/api/prisma/migrations/20260903180000_policy_beneficiaries/migration.sql
+++ b/apps/api/prisma/migrations/20260903180000_policy_beneficiaries/migration.sql
@@ -1,0 +1,42 @@
+-- CreateTable
+CREATE TABLE "policy_beneficiaries" (
+    "id" UUID NOT NULL,
+    "policyId" UUID NOT NULL,
+    "beneficiaryId" UUID NOT NULL,
+    "percentage" INTEGER NOT NULL DEFAULT 100,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "policy_beneficiaries_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "policy_beneficiaries_policyId_key" ON "policy_beneficiaries"("policyId");
+CREATE INDEX "policy_beneficiaries_beneficiaryId_idx" ON "policy_beneficiaries"("beneficiaryId");
+
+ALTER TABLE "policy_beneficiaries" ADD CONSTRAINT "policy_beneficiaries_policyId_fkey" FOREIGN KEY ("policyId") REFERENCES "policies"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "policy_beneficiaries" ADD CONSTRAINT "policy_beneficiaries_beneficiaryId_fkey" FOREIGN KEY ("beneficiaryId") REFERENCES "beneficiaries"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Backfill: each policy in a customer's supersession-aware set gets one join
+-- to the earliest remaining beneficiary (prefer percentage = 100).
+INSERT INTO "policy_beneficiaries" ("id", "policyId", "beneficiaryId", "percentage", "createdAt", "updatedAt")
+SELECT
+  gen_random_uuid(),
+  p.id,
+  b.id,
+  COALESCE(b.percentage, 100),
+  NOW(),
+  NOW()
+FROM "policies" p
+INNER JOIN LATERAL (
+  SELECT b2.id, b2.percentage
+  FROM "beneficiaries" b2
+  WHERE b2."customerId" = p."customerId"
+    AND b2."deletedAt" IS NULL
+  ORDER BY
+    CASE WHEN b2.percentage = 100 THEN 0 ELSE 1 END,
+    b2."createdAt" ASC
+  LIMIT 1
+) b ON TRUE
+WHERE NOT EXISTS (
+  SELECT 1 FROM "policy_beneficiaries" pb WHERE pb."policyId" = p.id
+);

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -269,6 +269,8 @@ model Beneficiary {
   deletedAt DateTime? @db.Timestamptz
   deletedBy String?   @db.Uuid // User ID who deleted
 
+  policyBeneficiaries PolicyBeneficiary[]
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -376,6 +378,7 @@ model Policy {
   lifecycleNotifications PolicyLifecycleNotification[]
   policyMemberPrincipals PolicyMemberPrincipal[]
   policyMemberDependants PolicyMemberDependant[]
+  policyBeneficiaries    PolicyBeneficiary[]
   lctMemberSyncTargets   LctMemberSyncTarget[]
 
   supersedesPolicy       Policy?  @relation("PolicySupersedes", fields: [supersedesPolicyId], references: [id], onDelete: SetNull)
@@ -390,6 +393,24 @@ model Policy {
 
   @@index([customerId, packageId])
   @@map("policies")
+}
+
+/// Links a beneficiary person to a specific policy (one NOK per policy).
+model PolicyBeneficiary {
+  id            String @id @default(uuid()) @db.Uuid
+  policyId      String @db.Uuid
+  beneficiaryId String @db.Uuid
+  percentage    Int    @default(100)
+
+  policy      Policy      @relation(fields: [policyId], references: [id], onDelete: Cascade)
+  beneficiary Beneficiary @relation(fields: [beneficiaryId], references: [id], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([policyId])
+  @@index([beneficiaryId])
+  @@map("policy_beneficiaries")
 }
 
 /// Idempotent scheduled/event notification ledger for policy lifecycle SMS

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -22,6 +22,7 @@ import { MissingRequirementService } from './services/missing-requirement.servic
 import { ProductManagementService } from './services/product-management.service';
 import { PackagePricingService } from './services/package-pricing/package-pricing.service';
 import { PolicyService } from './services/policy.service';
+import { AdditionalPolicyService } from './services/additional-policy.service';
 import { PolicyLifecycleService } from './services/policy-lifecycle.service';
 import { PolicyLifecycleJobService } from './services/policy-lifecycle-job.service';
 import { EntityStatusChangeService } from './services/entity-status-change.service';
@@ -90,7 +91,7 @@ import { IdNumberRevealService } from './services/id-number-reveal.service';
     CustomerPortalModule,
   ],
   controllers: [AppController, CustomerController, InternalCustomerController, InternalPartnerManagementController, PublicPartnerManagementController, SupabaseTestController, ConnectionMonitorController, SosController, AgentRegistrationController, BootstrapController, ProductManagementController, PolicyController, PolicyLifecycleController, PolicyLifecycleOpsController, UnderwriterController, UserController, MpesaPaymentsController, MpesaIpnController, MpesaStkPushController, MpesaStkPushPublicController, RecoveryController, TestCustomersController, InternalLctExportsController, HealthcareProvidersController],
-  providers: [AppService, ExternalIntegrationsService, CustomerService, PartnerManagementService, SupabaseService, SosService, AgentRegistrationService, MissingRequirementService, ProductManagementService, PackagePricingService, PolicyService, PolicyLifecycleService, PolicyLifecycleJobService, EntityStatusChangeService, UnderwriterService, MpesaPaymentsService, PaymentAccountNumberService, SchemeContactService, PostpaidSchemePaymentService, MpesaIpnService, MpesaStkPushService, MpesaDarajaApiService, MpesaErrorMapperService, TestCustomersService, BootstrapUserService, IpWhitelistGuard, RootOnlyGuard, BAAuthorizationGuard, PaymentStatusGateway, PremiumStatementService, LctSyncService, LctExportService, LctStorageService, HealthcareProviderService, IdNumberRevealService],
+  providers: [AppService, ExternalIntegrationsService, CustomerService, PartnerManagementService, SupabaseService, SosService, AgentRegistrationService, MissingRequirementService, ProductManagementService, PackagePricingService, PolicyService, AdditionalPolicyService, PolicyLifecycleService, PolicyLifecycleJobService, EntityStatusChangeService, UnderwriterService, MpesaPaymentsService, PaymentAccountNumberService, SchemeContactService, PostpaidSchemePaymentService, MpesaIpnService, MpesaStkPushService, MpesaDarajaApiService, MpesaErrorMapperService, TestCustomersService, BootstrapUserService, IpWhitelistGuard, RootOnlyGuard, BAAuthorizationGuard, PaymentStatusGateway, PremiumStatementService, LctSyncService, LctExportService, LctStorageService, HealthcareProviderService, IdNumberRevealService],
   exports: [PrismaModule], // Export PrismaModule so middleware can access PrismaService
 })
 export class AppModule implements NestModule {

--- a/apps/api/src/controllers/internal/customer.controller.ts
+++ b/apps/api/src/controllers/internal/customer.controller.ts
@@ -24,6 +24,8 @@ import {
   ApiBearerAuth,
 } from '@nestjs/swagger';
 import { CustomerService } from '../../services/customer.service';
+import { AdditionalPolicyService } from '../../services/additional-policy.service';
+import { AdditionalPolicyRequestDto } from '../../dto/policies/additional-policy.dto';
 import { PartnerManagementService } from '../../services/partner-management.service';
 import { PrismaService } from '../../prisma/prisma.service';
 // TODO: Create UpdatePrincipalMemberRequestDto when implementing update functionality
@@ -90,6 +92,7 @@ import {
 export class InternalCustomerController {
   constructor(
     private readonly customerService: CustomerService,
+    private readonly additionalPolicyService: AdditionalPolicyService,
     private readonly partnerManagementService: PartnerManagementService,
     private readonly prismaService: PrismaService,
     private readonly idNumberRevealService: IdNumberRevealService,
@@ -772,6 +775,46 @@ export class InternalCustomerController {
     const userId = req.user?.id ?? 'system';
     const userRoles = req.user?.roles ?? [];
     return this.customerService.getCustomerPoliciesList(customerId, userId, userRoles, correlationId);
+  }
+
+  @Get(':customerId/additional-policies/eligibility')
+  @AdminOnly()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Check whether admin can add another product' })
+  async getAdditionalPolicyEligibility(
+    @Param('customerId') customerId: string,
+    @Req() req: Request,
+  ) {
+    const userId = req.user?.id ?? 'system';
+    const userRoles = req.user?.roles ?? [];
+    return this.additionalPolicyService.getEligibility(customerId, userId, userRoles);
+  }
+
+  @Post(':customerId/additional-policies')
+  @AdminOnly()
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Add another product/policy for an existing customer (admin)' })
+  async createAdditionalPolicy(
+    @Param('customerId') customerId: string,
+    @Body() dto: AdditionalPolicyRequestDto,
+    @CorrelationId() correlationId: string,
+    @Req() req: Request,
+  ) {
+    const userId = req.user?.id ?? 'system';
+    const userRoles = req.user?.roles ?? [];
+    const result = await this.additionalPolicyService.createAdditionalPolicy(
+      customerId,
+      dto,
+      userId,
+      userRoles,
+      correlationId
+    );
+    return {
+      status: HttpStatus.CREATED,
+      correlationId,
+      message: 'Additional policy created',
+      data: result,
+    };
   }
 
   /**

--- a/apps/api/src/controllers/internal/product-management.controller.ts
+++ b/apps/api/src/controllers/internal/product-management.controller.ts
@@ -153,8 +153,11 @@ export class ProductManagementController {
     description: 'All schemes with isActive flag (inactive rows are for display only).',
   })
   @ApiResponse({ status: 200, description: 'Schemes retrieved successfully' })
-  async listSchemesForPicker(@CorrelationId() correlationId: string) {
-    const schemes = await this.productManagementService.listSchemesForPicker(correlationId);
+  async listSchemesForPicker(
+    @CorrelationId() correlationId: string,
+    @Query('q') q?: string,
+  ) {
+    const schemes = await this.productManagementService.listSchemesForPicker(correlationId, q);
     return {
       status: HttpStatus.OK,
       correlationId,

--- a/apps/api/src/dto/customers/customer-detail.dto.ts
+++ b/apps/api/src/dto/customers/customer-detail.dto.ts
@@ -36,6 +36,12 @@ export class PolicySummaryDto {
   planName?: string;
 
   @ApiProperty({
+    description: 'Package ID',
+    example: 1,
+  })
+  packageId?: number;
+
+  @ApiProperty({
     description: 'Policy status',
     example: 'ACTIVE',
   })

--- a/apps/api/src/dto/customers/customer-products.dto.ts
+++ b/apps/api/src/dto/customers/customer-products.dto.ts
@@ -179,6 +179,19 @@ export class CustomerPolicyDetailDto {
     enum: ['prepaid', 'postpaid'],
   })
   schemeBillingMode: 'prepaid' | 'postpaid';
+
+  @ApiProperty({
+    description: 'Next of kin for this policy (one person, 100%)',
+    nullable: true,
+  })
+  beneficiary: {
+    id: string;
+    firstName: string;
+    middleName: string | null;
+    lastName: string;
+    relationship: string;
+    percentage: number;
+  } | null;
 }
 
 export class CustomerPolicyDetailResponseDto {

--- a/apps/api/src/dto/policies/additional-policy.dto.ts
+++ b/apps/api/src/dto/policies/additional-policy.dto.ts
@@ -1,0 +1,114 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsArray,
+  IsBoolean,
+  IsEnum,
+  IsInt,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Min,
+  MinLength,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { PaymentFrequency } from '@prisma/client';
+import { ChildDto } from '../family-members/child.dto';
+import { SpouseDto } from '../family-members/spouse.dto';
+import { BeneficiaryDto } from '../family-members/beneficiary.dto';
+
+export class AdditionalPolicyRequestDto {
+  @ApiProperty()
+  @IsInt()
+  @Min(1)
+  packageId: number;
+
+  @ApiProperty()
+  @IsInt()
+  @Min(1)
+  packagePlanId: number;
+
+  @ApiProperty()
+  @IsInt()
+  @Min(1)
+  packageSchemeId: number;
+
+  @ApiProperty({ enum: PaymentFrequency })
+  @IsEnum(PaymentFrequency)
+  frequency: PaymentFrequency;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  customDays?: number;
+
+  @ApiProperty()
+  @IsNumber()
+  @Min(0)
+  premium: number;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  annualPremium?: number;
+
+  @ApiProperty()
+  @IsString()
+  @MinLength(1)
+  productName: string;
+
+  @ApiProperty({ type: [String], required: false })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  dependantIds?: string[];
+
+  @ApiProperty({ type: [SpouseDto], required: false })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => SpouseDto)
+  newSpouses?: SpouseDto[];
+
+  @ApiProperty({ type: [ChildDto], required: false })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ChildDto)
+  newChildren?: ChildDto[];
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  beneficiaryId?: string;
+
+  @ApiProperty({ type: BeneficiaryDto, required: false })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => BeneficiaryDto)
+  newBeneficiary?: BeneficiaryDto;
+
+  @ApiProperty({ description: 'Skip STK and leave the policy PENDING_ACTIVATION' })
+  @IsBoolean()
+  skipPayment: boolean;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  paymentPhone?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsBoolean()
+  initiateStk?: boolean;
+}
+
+export class AdditionalPolicyEligibilityDto {
+  @ApiProperty()
+  canAdd: boolean;
+
+  @ApiProperty({ type: [String] })
+  blockedReasons: string[];
+}

--- a/apps/api/src/dto/policy-lifecycle/policy-lifecycle.dto.ts
+++ b/apps/api/src/dto/policy-lifecycle/policy-lifecycle.dto.ts
@@ -183,6 +183,9 @@ export class ModifyPolicyOptionsResponseDto {
   @ApiProperty()
   additionalSpouse: boolean;
 
+  @ApiProperty({ description: 'Extra-spouse add-on count (spouses after the first)' })
+  additionalSpouseCount: number;
+
   @ApiProperty()
   currentPackagePlanId: number;
 

--- a/apps/api/src/modules/lct/__tests__/ensure-member-rows-late-dependants.spec.ts
+++ b/apps/api/src/modules/lct/__tests__/ensure-member-rows-late-dependants.spec.ts
@@ -63,7 +63,10 @@ describe('LctSyncService.ensureMemberRowsForLateDependants', () => {
       },
     });
 
-    await service.ensureMemberRowsForLateDependants('pol-1', correlationId);
+    await service.ensureMemberRowsForLateDependants('pol-1', correlationId, undefined, [
+      'simon',
+      'brian',
+    ]);
 
     expect(orderDependantsForMemberNumbers).toHaveBeenCalledWith(
       expect.arrayContaining([
@@ -123,7 +126,10 @@ describe('LctSyncService.ensureMemberRowsForLateDependants', () => {
       },
     });
 
-    await service.ensureMemberRowsForLateDependants('pol-1', correlationId);
+    await service.ensureMemberRowsForLateDependants('pol-1', correlationId, undefined, [
+      'simon',
+      'brian',
+    ]);
     expect(create).not.toHaveBeenCalled();
   });
 
@@ -156,7 +162,41 @@ describe('LctSyncService.ensureMemberRowsForLateDependants', () => {
       },
     });
 
-    await service.ensureMemberRowsForLateDependants('pol-1', correlationId);
+    await service.ensureMemberRowsForLateDependants('pol-1', correlationId, undefined, [
+      'simon',
+      'brian',
+    ]);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('skips expired and terminated policies', async () => {
+    const create = jest.fn();
+    const prisma = {
+      policy: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'pol-expired',
+          packageId: 1,
+          policyNumber: 'MP/MFG/001',
+          status: PolicyStatus.EXPIRED,
+          customer: {
+            dependants: [{ id: 'dep-1', relationship: DependantRelationship.CHILD }],
+            policyMemberPrincipals: [{ id: 'pmp' }],
+          },
+        }),
+      },
+      policyMemberDependant: { findMany: jest.fn(), create },
+    };
+    const service = buildService({
+      prisma,
+      policyService: {
+        orderDependantsForMemberNumbers: jest.fn((d: any[]) => d) as any,
+        generateMemberNumberForPolicy: jest.fn(),
+      },
+    });
+
+    await service.ensureMemberRowsForLateDependants('pol-expired', correlationId, undefined, [
+      'dep-1',
+    ]);
     expect(create).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/modules/lct/lct-sync.service.ts
+++ b/apps/api/src/modules/lct/lct-sync.service.ts
@@ -401,7 +401,7 @@ export class LctSyncService {
       },
     });
     if (!policy) return;
-    if (!(OCCUPYING_POLICY_STATUSES as PolicyStatus[]).includes(policy.status)) return;
+    if (!(OCCUPYING_POLICY_STATUSES).includes(policy.status)) return;
     if (policy.customer.policyMemberPrincipals.length === 0) return;
     if (!policy.policyNumber && policy.status === PolicyStatus.PENDING_ACTIVATION) return;
 

--- a/apps/api/src/modules/lct/lct-sync.service.ts
+++ b/apps/api/src/modules/lct/lct-sync.service.ts
@@ -14,6 +14,7 @@ import {
   mapPolicyStatusToLctAction,
   shouldEnqueueStatusChange,
 } from './lct.types';
+import { OCCUPYING_POLICY_STATUSES } from '../../utils/occupying-policy.util';
 
 type Tx = Prisma.TransactionClient;
 
@@ -382,21 +383,25 @@ export class LctSyncService {
   async ensureMemberRowsForLateDependants(
     policyId: string,
     correlationId: string,
-    tx?: Tx
+    tx?: Tx,
+    dependantIds?: string[]
   ): Promise<void> {
+    if (!dependantIds || dependantIds.length === 0) return;
+
     const client = tx ?? this.prisma;
     const policy = await client.policy.findUnique({
       where: { id: policyId },
       include: {
         customer: {
           include: {
-            dependants: { where: { deletedAt: null } },
+            dependants: { where: { deletedAt: null, id: { in: dependantIds } } },
             policyMemberPrincipals: { where: { policyId } },
           },
         },
       },
     });
     if (!policy) return;
+    if (!(OCCUPYING_POLICY_STATUSES as PolicyStatus[]).includes(policy.status)) return;
     if (policy.customer.policyMemberPrincipals.length === 0) return;
     if (!policy.policyNumber && policy.status === PolicyStatus.PENDING_ACTIVATION) return;
 

--- a/apps/api/src/services/__tests__/additional-policy.service.spec.ts
+++ b/apps/api/src/services/__tests__/additional-policy.service.spec.ts
@@ -1,0 +1,61 @@
+/// <reference types="jest" />
+import { AdditionalPolicyService } from '../additional-policy.service';
+import { ValidationException } from '../../exceptions/validation.exception';
+import { ErrorCodes } from '../../enums/error-codes.enum';
+import { CustomerStatus, PolicyStatus } from '@prisma/client';
+
+describe('AdditionalPolicyService', () => {
+  const policyService = {
+    loadEnrolmentSnapshots: jest.fn(),
+    createPolicyWithoutPayments: jest.fn(),
+  };
+  const mpesa = { initiateStkPush: jest.fn() };
+  const packagePricing = { getPricing: jest.fn() };
+  const prisma = {
+    customer: { findUnique: jest.fn(), findFirst: jest.fn() },
+  };
+
+  const service = new AdditionalPolicyService(
+    prisma as never,
+    policyService as never,
+    mpesa as never,
+    packagePricing as never
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('blocks non-admins with insufficient permissions', async () => {
+    await expect(service.getEligibility('cust-1', 'user-1', ['brand_ambassador'])).rejects.toBeInstanceOf(
+      ValidationException
+    );
+    try {
+      await service.getEligibility('cust-1', 'user-1', ['brand_ambassador']);
+    } catch (err) {
+      expect((err as ValidationException).errorCode).toBe(ErrorCodes.INSUFFICIENT_PERMISSIONS);
+    }
+  });
+
+  it('blocks terminated customers', async () => {
+    policyService.loadEnrolmentSnapshots.mockResolvedValue({
+      customerStatus: CustomerStatus.TERMINATED,
+      snapshots: [],
+    });
+    const result = await service.getEligibility('cust-1', 'user-1', ['registration_admin']);
+    expect(result.canAdd).toBe(false);
+    expect(result.blockedReasons.some((r) => r.toLowerCase().includes('terminated'))).toBe(true);
+  });
+
+  it('blocks when an occupying postpaid policy exists', async () => {
+    policyService.loadEnrolmentSnapshots.mockResolvedValue({
+      customerStatus: CustomerStatus.ACTIVE,
+      snapshots: [
+        { id: 'p1', packageId: 1, status: PolicyStatus.ACTIVE, isPostpaid: true },
+      ],
+    });
+    const result = await service.getEligibility('cust-1', 'user-1', ['registration_admin']);
+    expect(result.canAdd).toBe(false);
+    expect(result.blockedReasons.some((r) => r.toLowerCase().includes('postpaid'))).toBe(true);
+  });
+});

--- a/apps/api/src/services/__tests__/attach-policy-membership.spec.ts
+++ b/apps/api/src/services/__tests__/attach-policy-membership.spec.ts
@@ -1,0 +1,71 @@
+/// <reference types="jest" />
+import { PolicyService } from '../policy.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { PaymentAccountNumberService } from '../payment-account-number.service';
+import { PaymentMessagingService } from '../../modules/messaging/payment-messaging.service';
+import { PolicyLifecycleMessagingService } from '../../modules/messaging/policy-lifecycle-messaging.service';
+
+function buildService(tx: Record<string, unknown>) {
+  return new PolicyService(
+    { $transaction: (fn: (client: unknown) => unknown) => fn(tx) } as unknown as PrismaService,
+    {} as PaymentAccountNumberService,
+    {} as PaymentMessagingService,
+    {} as PolicyLifecycleMessagingService,
+    { onPolicyActivated: jest.fn() } as never
+  );
+}
+
+describe('PolicyService.attachPolicyMembership', () => {
+  it('attaches only the listed dependants and one beneficiary', async () => {
+    const upsertDependant = jest.fn();
+    const upsertBeneficiary = jest.fn();
+    const tx = {
+      policyMemberDependant: { upsert: upsertDependant },
+      policyBeneficiary: { upsert: upsertBeneficiary },
+    };
+    const service = buildService(tx);
+
+    await service.attachPolicyMembership(
+      tx as never,
+      {
+        policyId: 'pol-2',
+        customerId: 'cust-1',
+        dependantIds: ['dep-new'],
+        beneficiaryId: 'ben-1',
+      },
+      'corr'
+    );
+
+    expect(upsertDependant).toHaveBeenCalledTimes(1);
+    expect(upsertDependant).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { policyId_dependantId: { policyId: 'pol-2', dependantId: 'dep-new' } },
+      })
+    );
+    expect(upsertBeneficiary).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { policyId: 'pol-2' },
+        create: expect.objectContaining({ beneficiaryId: 'ben-1', percentage: 100 }),
+      })
+    );
+  });
+
+  it('attaches no dependants when the list is empty', async () => {
+    const upsertDependant = jest.fn();
+    const tx = {
+      policyMemberDependant: { upsert: upsertDependant },
+      policyBeneficiary: { upsert: jest.fn() },
+      dependant: { findMany: jest.fn() },
+    };
+    const service = buildService(tx);
+
+    await service.attachPolicyMembership(
+      tx as never,
+      { policyId: 'pol-2', customerId: 'cust-1', dependantIds: [] },
+      'corr'
+    );
+
+    expect(tx.dependant.findMany).not.toHaveBeenCalled();
+    expect(upsertDependant).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/__tests__/customer-create-postpaid-dependant-order.spec.ts
+++ b/apps/api/src/services/__tests__/customer-create-postpaid-dependant-order.spec.ts
@@ -106,6 +106,9 @@ describe('CustomerService.createCustomer — postpaid dependant order', () => {
 
     policyServiceMock = {
       resolveExpectedInstallmentCount: jest.fn().mockResolvedValue(12),
+      attachPolicyMembership: jest.fn().mockImplementation(async () => {
+        callOrder.push('attachPolicyMembership');
+      }),
       mapUnmappedMpesaItemsToPolicy: jest.fn().mockImplementation(async () => {
         callOrder.push('mapUnmappedMpesa');
         return 1;
@@ -179,6 +182,7 @@ describe('CustomerService.createCustomer — postpaid dependant order', () => {
     const ensureIdx = callOrder.indexOf('ensureMemberRows');
 
     expect(dependantIdx).toBeGreaterThanOrEqual(0);
+    expect(callOrder.indexOf('attachPolicyMembership')).toBeGreaterThan(dependantIdx);
     expect(mapIdx).toBeGreaterThan(dependantIdx);
     expect(ensureIdx).toBeGreaterThan(mapIdx);
     expect(callOrder.indexOf('policy.create')).toBeLessThan(dependantIdx);
@@ -191,7 +195,9 @@ describe('CustomerService.createCustomer — postpaid dependant order', () => {
     );
     expect(lctSyncServiceMock.ensureMemberRowsForLateDependants).toHaveBeenCalledWith(
       'postpaid-policy-1',
-      correlationId
+      correlationId,
+      undefined,
+      ['dep-kailani']
     );
   });
 });

--- a/apps/api/src/services/__tests__/payment-account-number.service.spec.ts
+++ b/apps/api/src/services/__tests__/payment-account-number.service.spec.ts
@@ -1,0 +1,48 @@
+/// <reference types="jest" />
+import { PaymentAccountNumberService } from '../payment-account-number.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { PolicyStatus } from '@prisma/client';
+
+describe('PaymentAccountNumberService.generateForPolicy', () => {
+  const service = new PaymentAccountNumberService({} as PrismaService);
+
+  function txMock(params: { occupyingCount: number; idNumber?: string }) {
+    return {
+      customer: {
+        findUnique: jest.fn().mockResolvedValue({ idNumber: params.idNumber ?? '12345678' }),
+      },
+      policy: {
+        count: jest.fn().mockResolvedValue(params.occupyingCount),
+        updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+      },
+    };
+  }
+
+  it('uses the id number and steals it from expired policies when none occupy', async () => {
+    const tx = txMock({ occupyingCount: 0 });
+    const result = await service.generateForPolicy('cust-1', true, tx as never, 'corr');
+    expect(result).toBe('12345678');
+    expect(tx.policy.updateMany).toHaveBeenCalledWith({
+      where: {
+        customerId: 'cust-1',
+        paymentAcNumber: '12345678',
+        status: {
+          in: [PolicyStatus.EXPIRED, PolicyStatus.DEACTIVATED, PolicyStatus.INACTIVE],
+        },
+      },
+      data: { paymentAcNumber: null },
+    });
+  });
+
+  it('suffixes B for the second occupying policy', async () => {
+    const tx = txMock({ occupyingCount: 1 });
+    const result = await service.generateForPolicy('cust-1', false, tx as never, 'corr');
+    expect(result).toBe('12345678B');
+  });
+
+  it('suffixes C for the third occupying policy', async () => {
+    const tx = txMock({ occupyingCount: 2 });
+    const result = await service.generateForPolicy('cust-1', false, tx as never, 'corr');
+    expect(result).toBe('12345678C');
+  });
+});

--- a/apps/api/src/services/additional-policy.service.ts
+++ b/apps/api/src/services/additional-policy.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger, NotFoundException } from '@nestjs/common';
-import { PaymentFrequency, Prisma } from '@prisma/client';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { PolicyService } from './policy.service';
 import { MpesaStkPushService } from './mpesa-stk-push.service';
@@ -227,7 +227,7 @@ export class AdditionalPolicyService {
         where: { id: created.id },
         data: {
           productName: dto.productName,
-          frequency: frequency as PaymentFrequency,
+          frequency: frequency,
           paymentCadence: packageScheme.scheme.paymentCadence ?? created.paymentCadence,
         },
       });

--- a/apps/api/src/services/additional-policy.service.ts
+++ b/apps/api/src/services/additional-policy.service.ts
@@ -1,0 +1,416 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { PaymentFrequency, Prisma } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { PolicyService } from './policy.service';
+import { MpesaStkPushService } from './mpesa-stk-push.service';
+import { PackagePricingService } from './package-pricing/package-pricing.service';
+import { ValidationException } from '../exceptions/validation.exception';
+import { ErrorCodes } from '../enums/error-codes.enum';
+import { AdditionalPolicyRequestDto } from '../dto/policies/additional-policy.dto';
+import { validateAdditionalProductEnrolment } from '../utils/additional-product.rules';
+import { SharedMapperUtils } from '../mappers/shared.mapper.utils';
+import { matchExistingPerson } from '../utils/person-duplicate.util';
+import { hasGlobalCustomerAccess } from '../utils/roles.util';
+import { isOccupyingPolicyStatus } from '../utils/occupying-policy.util';
+import {
+  maxDependantSlots,
+  packageHasFamilyBands,
+} from '../utils/family-category.util';
+import { computeHouseholdPremium } from '../utils/household-premium.util';
+
+@Injectable()
+export class AdditionalPolicyService {
+  private readonly logger = new Logger(AdditionalPolicyService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly policyService: PolicyService,
+    private readonly mpesaStkPushService: MpesaStkPushService,
+    private readonly packagePricingService: PackagePricingService
+  ) {}
+
+  async getEligibility(customerId: string, userId: string, userRoles: string[]) {
+    await this.assertAdminAccess(customerId, userId, userRoles);
+    const enrolment = await this.policyService.loadEnrolmentSnapshots(customerId);
+    const reasons: string[] = [];
+    if (enrolment.customerStatus === 'TERMINATED') {
+      reasons.push('Customer is terminated');
+    }
+    if (enrolment.snapshots.some((p) => p.status === 'TERMINATED')) {
+      reasons.push('A policy on this customer is terminated');
+    }
+    const occupyingPostpaid = enrolment.snapshots.some(
+      (p) => isOccupyingPolicyStatus(p.status) && p.isPostpaid
+    );
+    if (occupyingPostpaid) {
+      reasons.push(
+        'A postpaid policy is occupying. Deactivate it before adding another product.'
+      );
+    }
+    return { canAdd: reasons.length === 0, blockedReasons: reasons };
+  }
+
+  async createAdditionalPolicy(
+    customerId: string,
+    dto: AdditionalPolicyRequestDto,
+    userId: string,
+    userRoles: string[],
+    correlationId: string
+  ) {
+    await this.assertAdminAccess(customerId, userId, userRoles);
+    const customer = await this.prisma.customer.findUnique({
+      where: { id: customerId },
+      include: {
+        dependants: { where: { deletedAt: null } },
+        beneficiaries: { where: { deletedAt: null } },
+      },
+    });
+    if (!customer) {
+      throw new NotFoundException('Customer not found');
+    }
+
+    const packageScheme = await this.prisma.packageScheme.findUnique({
+      where: { id: dto.packageSchemeId },
+      include: {
+        scheme: { select: { isPostpaid: true, frequency: true, paymentCadence: true } },
+        package: { select: { id: true, name: true } },
+      },
+    });
+    if (!packageScheme || packageScheme.packageId !== dto.packageId) {
+      throw ValidationException.forField(
+        'packageSchemeId',
+        'Scheme must belong to the selected package',
+        ErrorCodes.VALIDATION_ERROR
+      );
+    }
+
+    const enrolment = await this.policyService.loadEnrolmentSnapshots(customerId);
+    const check = validateAdditionalProductEnrolment({
+      customerStatus: enrolment.customerStatus,
+      policies: enrolment.snapshots,
+      newPackageId: dto.packageId,
+      newIsPostpaid: packageScheme.scheme.isPostpaid,
+    });
+    if (!check.ok) {
+      throw ValidationException.forField(check.field, check.message, ErrorCodes.RESOURCE_CONFLICT);
+    }
+
+    if (!dto.beneficiaryId && !dto.newBeneficiary) {
+      throw ValidationException.forField(
+        'beneficiaryId',
+        'Exactly one beneficiary is required',
+        ErrorCodes.NO_BENEFICIARIES_PROVIDED
+      );
+    }
+    if (dto.beneficiaryId && dto.newBeneficiary) {
+      throw ValidationException.forField(
+        'beneficiaryId',
+        'Select an existing beneficiary or create one, not both',
+        ErrorCodes.VALIDATION_ERROR
+      );
+    }
+
+    if (dto.beneficiaryId && !customer.beneficiaries.some((b) => b.id === dto.beneficiaryId)) {
+      throw ValidationException.forField(
+        'beneficiaryId',
+        'Beneficiary does not belong to this customer',
+        ErrorCodes.VALIDATION_ERROR
+      );
+    }
+
+    const unknownDependants = (dto.dependantIds ?? []).filter(
+      (id) => !customer.dependants.some((d) => d.id === id)
+    );
+    if (unknownDependants.length > 0) {
+      throw ValidationException.forField(
+        'dependantIds',
+        'One or more dependants do not belong to this customer',
+        ErrorCodes.VALIDATION_ERROR
+      );
+    }
+
+    const pricing = await this.packagePricingService.getPricing(dto.packageId);
+    const bands = pricing.categories.map((c) => ({
+      key: c.key,
+      kind: c.kind,
+      maxMembers: c.maxMembers,
+    }));
+    const hasFamily = packageHasFamilyBands(bands);
+    const cap = maxDependantSlots(bands);
+    const incomingDependantCount =
+      (dto.dependantIds?.length ?? 0) + (dto.newSpouses?.length ?? 0) + (dto.newChildren?.length ?? 0);
+    if (!hasFamily && incomingDependantCount > 0) {
+      throw ValidationException.forField(
+        'dependantIds',
+        'This package is member-only and cannot cover spouses or children',
+        ErrorCodes.VALIDATION_ERROR
+      );
+    }
+    if (hasFamily && incomingDependantCount > cap) {
+      throw ValidationException.forField(
+        'dependantIds',
+        `This product allows at most ${cap} spouse(s) or children`,
+        ErrorCodes.VALIDATION_ERROR
+      );
+    }
+
+    const prepared = await this.prisma.$transaction(async (tx) => {
+      await this.ensurePackageSchemeCustomer(
+        tx,
+        customerId,
+        dto.packageSchemeId,
+        customer.createdByPartnerId
+      );
+
+      const dependantIds = [...(dto.dependantIds ?? [])];
+      if (dto.newSpouses?.length) {
+        for (const spouse of dto.newSpouses) {
+          const id = await this.createOrReuseDependant(tx, customer, spouse, 'SPOUSE', correlationId);
+          dependantIds.push(id);
+        }
+      }
+      if (dto.newChildren?.length) {
+        for (const child of dto.newChildren) {
+          const id = await this.createOrReuseDependant(tx, customer, child, 'CHILD', correlationId);
+          dependantIds.push(id);
+        }
+      }
+
+      let beneficiaryId = dto.beneficiaryId ?? null;
+      if (!beneficiaryId && dto.newBeneficiary) {
+        beneficiaryId = await this.createOrReuseBeneficiary(tx, customer, dto.newBeneficiary);
+      }
+
+      return { dependantIds, beneficiaryId };
+    });
+
+    let frequency = dto.frequency;
+    const customDays = dto.customDays;
+    if (packageScheme.scheme.isPostpaid) {
+      frequency = packageScheme.scheme.frequency ?? dto.frequency;
+    }
+
+    const householdDependants =
+      prepared.dependantIds.length === 0
+        ? []
+        : await this.prisma.dependant.findMany({
+            where: { id: { in: prepared.dependantIds }, deletedAt: null },
+            select: { relationship: true, deletedAt: true },
+          });
+    const priced = computeHouseholdPremium({
+      pricing,
+      packagePlanId: dto.packagePlanId,
+      frequency,
+      dependants: householdDependants,
+    });
+    if (!priced.ok) {
+      throw ValidationException.forField('premium', priced.reason, ErrorCodes.VALIDATION_ERROR);
+    }
+
+    const created = await this.policyService.createPolicyWithoutPayments(
+      {
+        customerId,
+        packageId: dto.packageId,
+        packagePlanId: dto.packagePlanId,
+        premium: priced.premium,
+        annualPremium: priced.annualPremium,
+        frequency,
+        customDays,
+        dependantIds: prepared.dependantIds,
+        beneficiaryId: prepared.beneficiaryId,
+      },
+      correlationId
+    );
+
+    if (packageScheme.scheme.isPostpaid) {
+      await this.prisma.policy.update({
+        where: { id: created.id },
+        data: {
+          productName: dto.productName,
+          frequency: frequency as PaymentFrequency,
+          paymentCadence: packageScheme.scheme.paymentCadence ?? created.paymentCadence,
+        },
+      });
+    }
+
+    let stk = null;
+    if (
+      !dto.skipPayment &&
+      dto.initiateStk !== false &&
+      !packageScheme.scheme.isPostpaid &&
+      dto.paymentPhone &&
+      created.paymentAcNumber
+    ) {
+      stk = await this.mpesaStkPushService.initiateStkPush(
+        {
+          phoneNumber: dto.paymentPhone,
+          amount: priced.premium,
+          accountReference: created.paymentAcNumber,
+          transactionDesc: `Premium payment for ${dto.productName}`,
+        },
+        correlationId,
+        userId
+      );
+    }
+
+    return {
+      policy: created,
+      stkPush: stk,
+    };
+  }
+
+  private async assertAdminAccess(customerId: string, userId: string, userRoles: string[]) {
+    if (!userRoles.includes('registration_admin') && !userRoles.includes('system_admin')) {
+      throw ValidationException.forField(
+        'user',
+        'Only registration admins can add another product',
+        ErrorCodes.INSUFFICIENT_PERMISSIONS
+      );
+    }
+    if (hasGlobalCustomerAccess(userRoles)) return;
+    const customer = await this.prisma.customer.findFirst({
+      where: { id: customerId },
+      select: { id: true },
+    });
+    if (!customer) {
+      throw new NotFoundException('Customer not found');
+    }
+  }
+
+  private async ensurePackageSchemeCustomer(
+    tx: Prisma.TransactionClient,
+    customerId: string,
+    packageSchemeId: number,
+    partnerId: number
+  ) {
+    const existing = await tx.packageSchemeCustomer.findFirst({
+      where: { customerId, packageScheme: { packageId: (await tx.packageScheme.findUniqueOrThrow({ where: { id: packageSchemeId } })).packageId } },
+    });
+    if (existing) {
+      await tx.packageSchemeCustomer.update({
+        where: { id: existing.id },
+        data: { packageSchemeId },
+      });
+      return;
+    }
+    await tx.packageSchemeCustomer.create({
+      data: {
+        customerId,
+        packageSchemeId,
+        partnerId,
+        partnerCustomerId: '',
+      },
+    });
+  }
+
+  private async createOrReuseDependant(
+    tx: Prisma.TransactionClient,
+    customer: {
+      id: string;
+      createdByPartnerId: number;
+      dependants: Array<{
+        id: string;
+        firstName: string;
+        lastName: string;
+        idNumber: string | null;
+        phoneNumber: string | null;
+      }>;
+    },
+    person: {
+      firstName: string;
+      lastName: string;
+      middleName?: string;
+      dateOfBirth?: string;
+      gender?: string;
+      idType?: string;
+      idNumber?: string;
+      phoneNumber?: string;
+    },
+    relationship: 'SPOUSE' | 'CHILD',
+    _correlationId: string
+  ): Promise<string> {
+    const match = matchExistingPerson(person, customer.dependants);
+    if (match.kind === 'auto') return match.person.id;
+    if (match.kind === 'confirm') {
+      throw ValidationException.forField(
+        'dependants',
+        'A similar dependant already exists. Select the existing record instead of creating a duplicate.',
+        ErrorCodes.VALIDATION_ERROR
+      );
+    }
+
+    const created = await tx.dependant.create({
+      data: {
+        customerId: customer.id,
+        firstName: person.firstName,
+        middleName: person.middleName ?? null,
+        lastName: person.lastName,
+        dateOfBirth: person.dateOfBirth ? new Date(person.dateOfBirth) : null,
+        gender: person.gender ? SharedMapperUtils.mapGenderFromDto(person.gender) : null,
+        idType: person.idType ? SharedMapperUtils.mapIdTypeFromDto(person.idType) : null,
+        idNumber: person.idNumber ?? null,
+        phoneNumber: person.phoneNumber ?? null,
+        relationship,
+        createdByPartnerId: customer.createdByPartnerId,
+      },
+    });
+    return created.id;
+  }
+
+  private async createOrReuseBeneficiary(
+    tx: Prisma.TransactionClient,
+    customer: {
+      id: string;
+      createdByPartnerId: number;
+      beneficiaries: Array<{
+        id: string;
+        firstName: string;
+        lastName: string;
+        idNumber: string | null;
+        phoneNumber: string | null;
+      }>;
+    },
+    person: {
+      firstName: string;
+      lastName: string;
+      middleName?: string;
+      dateOfBirth?: string;
+      gender?: string;
+      relationship?: string;
+      relationshipDescription?: string;
+      idType?: string;
+      idNumber?: string;
+      phoneNumber?: string;
+      percentage?: number;
+    }
+  ): Promise<string> {
+    const match = matchExistingPerson(person, customer.beneficiaries);
+    if (match.kind === 'auto') return match.person.id;
+    if (match.kind === 'confirm') {
+      throw ValidationException.forField(
+        'beneficiary',
+        'A similar beneficiary already exists. Select the existing record instead of creating a duplicate.',
+        ErrorCodes.VALIDATION_ERROR
+      );
+    }
+
+    const created = await tx.beneficiary.create({
+      data: {
+        customerId: customer.id,
+        firstName: person.firstName,
+        middleName: person.middleName ?? null,
+        lastName: person.lastName,
+        dateOfBirth: person.dateOfBirth ? new Date(person.dateOfBirth) : null,
+        gender: person.gender ? SharedMapperUtils.mapGenderFromDto(person.gender) : null,
+        idType: person.idType ? SharedMapperUtils.mapIdTypeFromDto(person.idType) : null,
+        idNumber: person.idNumber ?? null,
+        phoneNumber: person.phoneNumber ?? null,
+        relationship: person.relationship ?? 'other',
+        relationshipDescription: person.relationshipDescription ?? null,
+        percentage: person.percentage ?? 100,
+        createdByPartnerId: customer.createdByPartnerId,
+      },
+    });
+    return created.id;
+  }
+}

--- a/apps/api/src/services/customer.service.ts
+++ b/apps/api/src/services/customer.service.ts
@@ -3056,7 +3056,7 @@ export class CustomerService {
               firstName: policy.policyBeneficiaries[0].beneficiary.firstName,
               middleName: policy.policyBeneficiaries[0].beneficiary.middleName,
               lastName: policy.policyBeneficiaries[0].beneficiary.lastName,
-              relationship: policy.policyBeneficiaries[0].beneficiary.relationship,
+              relationship: policy.policyBeneficiaries[0].beneficiary.relationship ?? 'other',
               percentage: policy.policyBeneficiaries[0].percentage,
             }
           : null,

--- a/apps/api/src/services/customer.service.ts
+++ b/apps/api/src/services/customer.service.ts
@@ -674,8 +674,20 @@ export class CustomerService {
       if (postpaidPolicyId && createdCustomer.idNumber) {
         const deferredPostpaidPolicyId = postpaidPolicyId;
         const idNumber = createdCustomer.idNumber;
+        const createdDependantIds = [...createdChildren, ...createdSpouses].map((d) => d.id);
+        const createdBeneficiaryId = createdBeneficiaries[0]?.id ?? null;
         try {
           await this.prismaService.$transaction(async (tx) => {
+            await this.policyService.attachPolicyMembership(
+              tx,
+              {
+                policyId: deferredPostpaidPolicyId,
+                customerId: createdCustomer.id,
+                dependantIds: createdDependantIds,
+                beneficiaryId: createdBeneficiaryId,
+              },
+              correlationId
+            );
             await this.policyService.mapUnmappedMpesaItemsToPolicy(
               deferredPostpaidPolicyId,
               idNumber,
@@ -684,10 +696,11 @@ export class CustomerService {
               { activateIfPending: true }
             );
           });
-          // Safety net if activation ran with partial family, or map left policy already active.
           await this.lctSyncService.ensureMemberRowsForLateDependants(
             deferredPostpaidPolicyId,
-            correlationId
+            correlationId,
+            undefined,
+            createdDependantIds
           );
           await this.lctSyncService.upsertTargetsForPolicy(
             deferredPostpaidPolicyId,
@@ -1158,16 +1171,21 @@ export class CustomerService {
 
       this.logger.log(`[${correlationId}] Successfully added ${result.totalProcessed} dependants to customer ${customerId}`);
 
-      // Late dependants: create member numbers + LCT pending for syncable policies
-      const policies = await this.prismaService.policy.findMany({
+      const newDependantIds = result.addedDependants.map((d) => d.dependantId);
+      const occupyingPolicies = await this.prismaService.policy.findMany({
         where: {
           customerId,
-          status: { in: ['ACTIVE', 'SUSPENDED', 'INACTIVE', 'DEACTIVATED', 'TERMINATED', 'EXPIRED'] },
+          status: { in: ['ACTIVE', 'PENDING_ACTIVATION', 'SUSPENDED'] },
         },
         select: { id: true },
       });
-      for (const policy of policies) {
-        await this.lctSyncService.ensureMemberRowsForLateDependants(policy.id, correlationId);
+      for (const policy of occupyingPolicies) {
+        await this.lctSyncService.ensureMemberRowsForLateDependants(
+          policy.id,
+          correlationId,
+          undefined,
+          newDependantIds
+        );
         await this.lctSyncService.upsertTargetsForPolicy(policy.id, correlationId);
         await this.lctSyncService.onPolicyActivated(policy.id, correlationId);
       }
@@ -2675,6 +2693,7 @@ export class CustomerService {
         policyNumber: p.policyNumber,
         packageName: p.package.name,
         planName: p.packagePlan?.name,
+        packageId: p.packageId,
         status: p.status,
       }));
 
@@ -2906,6 +2925,21 @@ export class CustomerService {
           },
         },
         packagePlan: { select: { name: true } },
+        policyBeneficiaries: {
+          take: 1,
+          include: {
+            beneficiary: {
+              select: {
+                id: true,
+                firstName: true,
+                middleName: true,
+                lastName: true,
+                relationship: true,
+                phoneNumber: true,
+              },
+            },
+          },
+        },
         policyPayments: {
           where: notDetachedPaymentWhere(),
           select: {
@@ -3016,6 +3050,16 @@ export class CustomerService {
         paymentsMadeCount: countConfirmedPayments(policy.policyPayments),
         missedPaymentsAmount,
         schemeBillingMode,
+        beneficiary: policy.policyBeneficiaries[0]
+          ? {
+              id: policy.policyBeneficiaries[0].beneficiary.id,
+              firstName: policy.policyBeneficiaries[0].beneficiary.firstName,
+              middleName: policy.policyBeneficiaries[0].beneficiary.middleName,
+              lastName: policy.policyBeneficiaries[0].beneficiary.lastName,
+              relationship: policy.policyBeneficiaries[0].beneficiary.relationship,
+              percentage: policy.policyBeneficiaries[0].percentage,
+            }
+          : null,
       },
     };
   }

--- a/apps/api/src/services/payment-account-number.service.ts
+++ b/apps/api/src/services/payment-account-number.service.ts
@@ -2,12 +2,11 @@ import { Injectable, Logger } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { Prisma } from '@prisma/client';
 import * as Sentry from '@sentry/nestjs';
-
-/**
- * Letters for policy payment account suffix (2nd policy = B, 3rd = C, ...).
- * Excludes A, I, J, O to avoid confusion with numbers and readability.
- */
-const POLICY_SUFFIX_LETTERS = 'BCDEFGHKLMNPQRSTUVWXYZ';
+import {
+  OCCUPYING_POLICY_STATUSES,
+  STEALABLE_PAYMENT_AC_STATUSES,
+} from '../utils/occupying-policy.util';
+import { occupyingPolicyPaymentAcSuffix } from '../utils/payment-ac-suffix.util';
 
 /**
  * Payment Account Number Generation Service
@@ -22,18 +21,6 @@ export class PaymentAccountNumberService {
   private readonly logger = new Logger(PaymentAccountNumberService.name);
 
   constructor(private readonly prismaService: PrismaService) {}
-
-  /**
-   * Get letter suffix for (n+1)th policy: index 0 = B (2nd), 1 = C (3rd), ... 21 = Z, 22+ = two letters (e.g. BB, BC).
-   */
-  private getPolicySuffixLetter(index: number): string {
-    const n = POLICY_SUFFIX_LETTERS.length;
-    if (index < n) return POLICY_SUFFIX_LETTERS[index];
-    const i = index - n;
-    const first = Math.floor(i / n);
-    const second = i % n;
-    return POLICY_SUFFIX_LETTERS[first] + POLICY_SUFFIX_LETTERS[second];
-  }
 
   /**
    * Check if a number contains digits 0 or 1
@@ -132,14 +119,9 @@ export class PaymentAccountNumberService {
   }
 
   /**
-   * Generate payment account number for a policy
-   * First policy: customer idNumber. Subsequent: idNumber + letter (B, C, D, ... excluding A, I, J, O).
-   *
-   * @param customerId - Customer UUID
-   * @param isFirstPolicy - Whether this is the customer's first policy
-   * @param tx - Prisma transaction client
-   * @param correlationId - Correlation ID for logging
-   * @returns Payment account number
+   * Generate payment account number for a policy.
+   * No occupying policy: customer idNumber (steal from EXPIRED/DEACTIVATED/INACTIVE if needed).
+   * Already occupying: idNumber + letter (B, C, ... excluding A, I, J, O).
    */
   async generateForPolicy(
     customerId: string,
@@ -150,7 +132,7 @@ export class PaymentAccountNumberService {
     try {
       this.logger.log(
         `[${correlationId}] Generating payment account number for policy. ` +
-          `Customer: ${customerId}, First policy: ${isFirstPolicy}`
+          `Customer: ${customerId}, First occupying: ${isFirstPolicy}`
       );
 
       const customer = await tx.customer.findUnique({
@@ -167,20 +149,26 @@ export class PaymentAccountNumberService {
         throw new Error(`Customer ${customerId} has no idNumber`);
       }
 
-      if (isFirstPolicy) {
-        this.logger.log(
-          `[${correlationId}] Using customer ID number for first policy: ${idNumber}`
-        );
-        return idNumber;
-      }
-
-      const existingCount = await tx.policy.count({
-        where: { customerId },
+      const occupyingCount = await tx.policy.count({
+        where: { customerId, status: { in: OCCUPYING_POLICY_STATUSES } },
       });
-      const suffix = this.getPolicySuffixLetter(existingCount);
-      const paymentAcNumber = idNumber + suffix;
+      const treatAsFirst = isFirstPolicy || occupyingCount === 0;
+      const suffix = treatAsFirst ? null : occupyingPolicyPaymentAcSuffix(occupyingCount);
+      const paymentAcNumber = suffix ? `${idNumber}${suffix}` : idNumber;
+
+      await tx.policy.updateMany({
+        where: {
+          customerId,
+          paymentAcNumber,
+          status: { in: STEALABLE_PAYMENT_AC_STATUSES },
+        },
+        data: { paymentAcNumber: null },
+      });
+
       this.logger.log(
-        `[${correlationId}] Using idNumber + suffix for policy ${existingCount + 1}: ${paymentAcNumber}`
+        treatAsFirst
+          ? `[${correlationId}] Using customer ID number for first occupying policy: ${paymentAcNumber}`
+          : `[${correlationId}] Using idNumber + suffix for occupying policy ${occupyingCount + 1}: ${paymentAcNumber}`
       );
       return paymentAcNumber;
     } catch (error) {
@@ -339,12 +327,7 @@ export class PaymentAccountNumberService {
   }
 
   /**
-   * Check if a customer has any existing policies
-   *
-   * @param customerId - Customer UUID
-   * @param tx - Prisma transaction client (optional)
-   * @param correlationId - Correlation ID for logging
-   * @returns True if customer has existing policies
+   * Check if a customer has occupying policies (ACTIVE / PENDING_ACTIVATION / SUSPENDED).
    */
   async customerHasExistingPolicies(
     customerId: string,
@@ -355,12 +338,12 @@ export class PaymentAccountNumberService {
       const prisma = tx ?? this.prismaService;
 
       const policyCount = await prisma.policy.count({
-        where: { customerId },
+        where: { customerId, status: { in: OCCUPYING_POLICY_STATUSES } },
       });
 
       const hasExisting = policyCount > 0;
       this.logger.log(
-        `[${correlationId}] Customer ${customerId} has ${policyCount} existing policies`
+        `[${correlationId}] Customer ${customerId} has ${policyCount} occupying policies`
       );
 
       return hasExisting;

--- a/apps/api/src/services/policy-lifecycle.service.ts
+++ b/apps/api/src/services/policy-lifecycle.service.ts
@@ -27,8 +27,8 @@ import {
   nextDisabledPolicyNumber,
 } from '../utils/disabled-policy-number.util';
 import {
+  additionalSpouseCount,
   deriveFamilyCategoryFromDependants,
-  hasAdditionalSpousePremium,
 } from '../utils/family-category.util';
 import {
   ActivatePolicyRequestDto,
@@ -1082,6 +1082,21 @@ export class PolicyLifecycleService {
         },
       });
 
+      const priorBeneficiaries = await tx.policyBeneficiary.findMany({
+        where: { policyId: prior.id },
+      });
+      for (const row of priorBeneficiaries) {
+        await tx.policyBeneficiary.upsert({
+          where: { policyId: created.id },
+          create: {
+            policyId: created.id,
+            beneficiaryId: row.beneficiaryId,
+            percentage: row.percentage,
+          },
+          update: { beneficiaryId: row.beneficiaryId, percentage: row.percentage },
+        });
+      }
+
       if (prior.status === PolicyStatus.SUSPENDED || prior.status === PolicyStatus.INACTIVE) {
         await this.statusChangeService.recordPolicyChange({
           customerId: prior.customerId,
@@ -1697,7 +1712,14 @@ export class PolicyLifecycleService {
         nextStatus = CustomerStatus.ACTIVE;
       }
     } else if (hasPending) {
-      if (customer.status !== CustomerStatus.PENDING_ACTIVATION) {
+      // Unpaid extra policies must not flip SUSPENDED / DEACTIVATED customers.
+      if (
+        customer.status === CustomerStatus.SUSPENDED ||
+        customer.status === CustomerStatus.DEACTIVATED ||
+        customer.status === CustomerStatus.TERMINATED
+      ) {
+        nextStatus = null;
+      } else if (customer.status !== CustomerStatus.PENDING_ACTIVATION) {
         nextStatus = CustomerStatus.PENDING_ACTIVATION;
       }
     } else if (hasSuspended) {
@@ -2160,7 +2182,8 @@ export class PolicyLifecycleService {
       where: { customerId, deletedAt: null },
     });
     const familyCategory = deriveFamilyCategoryFromDependants(dependants);
-    const additionalSpouse = hasAdditionalSpousePremium(familyCategory, dependants);
+    const extraSpouseCount = additionalSpouseCount(familyCategory, dependants);
+    const additionalSpouse = extraSpouseCount > 0;
 
     const completedPayments = await this.prisma.policyPayment.findMany({
       where: {
@@ -2201,6 +2224,7 @@ export class PolicyLifecycleService {
       })),
       familyCategory,
       additionalSpouse,
+      additionalSpouseCount: extraSpouseCount,
       currentPackagePlanId: policy.packagePlanId ?? 0,
       currentPlanName: policy.packagePlan?.name,
       currentPremium: Number(policy.premium),
@@ -2420,6 +2444,21 @@ export class PolicyLifecycleService {
         data: { supersededByPolicyId: newPolicy.id },
       });
 
+      const sourceBeneficiaries = await tx.policyBeneficiary.findMany({
+        where: { policyId },
+      });
+      for (const row of sourceBeneficiaries) {
+        await tx.policyBeneficiary.upsert({
+          where: { policyId: newPolicy.id },
+          create: {
+            policyId: newPolicy.id,
+            beneficiaryId: row.beneficiaryId,
+            percentage: row.percentage,
+          },
+          update: { beneficiaryId: row.beneficiaryId, percentage: row.percentage },
+        });
+      }
+
       if (dto.packageSchemeId != null) {
         await tx.packageSchemeCustomer.updateMany({
           where: { customerId, packageScheme: { packageId: source.packageId } },
@@ -2448,6 +2487,20 @@ export class PolicyLifecycleService {
             pendingSince: null,
           },
         });
+      } else {
+        const sourceDependants = await tx.policyMemberDependant.findMany({
+          where: { policyId },
+          select: { dependantId: true },
+        });
+        await this.policyService.attachPolicyMembership(
+          tx,
+          {
+            policyId: newPolicy.id,
+            customerId,
+            dependantIds: sourceDependants.map((d) => d.dependantId),
+          },
+          correlationId
+        );
       }
 
       if (paymentsToMove.length > 0) {

--- a/apps/api/src/services/policy.service.ts
+++ b/apps/api/src/services/policy.service.ts
@@ -27,6 +27,8 @@ import { notDetachedPaymentWhere } from '../utils/policy-payment-filters';
 import { computeNominalPaymentPeriodEndDate } from '../utils/package-payment-frequency.util';
 import { ValidationException } from '../exceptions/validation.exception';
 import { ErrorCodes } from '../enums/error-codes.enum';
+import { validateAdditionalProductEnrolment } from '../utils/additional-product.rules';
+import { CustomerStatus } from '@prisma/client';
 
 /**
  * Policy Service
@@ -248,6 +250,121 @@ export class PolicyService {
       if (bIsSpouse !== aIsSpouse) return bIsSpouse - aIsSpouse; // Spouse first
       return 0; // Stable order within same relationship
     });
+  }
+
+  /**
+   * Persist intended membership for a policy.
+   * `dependantIds` undefined = all current customer dependants (legacy first registration).
+   * `[]` = member-only. Specific IDs = those people only.
+   */
+  async attachPolicyMembership(
+    tx: Prisma.TransactionClient,
+    params: {
+      policyId: string;
+      customerId: string;
+      dependantIds?: string[] | null;
+      beneficiaryId?: string | null;
+    },
+    correlationId: string
+  ): Promise<void> {
+    let dependantIds = params.dependantIds;
+    if (dependantIds === undefined || dependantIds === null) {
+      const all = await tx.dependant.findMany({
+        where: { customerId: params.customerId, deletedAt: null },
+        select: { id: true, relationship: true },
+      });
+      dependantIds = this.orderDependantsForMemberNumbers(all).map((d) => d.id);
+    }
+
+    const uniqueDependantIds = [...new Set(dependantIds)];
+    for (const dependantId of uniqueDependantIds) {
+      await tx.policyMemberDependant.upsert({
+        where: {
+          policyId_dependantId: { policyId: params.policyId, dependantId },
+        },
+        create: {
+          policyId: params.policyId,
+          dependantId,
+          memberNumber: `PENDING-${dependantId.slice(0, 8)}`,
+        },
+        update: {},
+      });
+    }
+
+    if (params.beneficiaryId) {
+      await tx.policyBeneficiary.upsert({
+        where: { policyId: params.policyId },
+        create: {
+          policyId: params.policyId,
+          beneficiaryId: params.beneficiaryId,
+          percentage: 100,
+        },
+        update: { beneficiaryId: params.beneficiaryId, percentage: 100 },
+      });
+    }
+
+    this.logger.log(
+      `[${correlationId}] Attached membership on policy ${params.policyId}: ` +
+        `${uniqueDependantIds.length} dependants, beneficiary=${params.beneficiaryId ?? 'none'}`
+    );
+  }
+
+  async loadEnrolmentSnapshots(
+    customerId: string,
+    tx?: Prisma.TransactionClient | PrismaService
+  ): Promise<{
+    customerStatus: CustomerStatus;
+    snapshots: Array<{
+      id: string;
+      packageId: number;
+      status: string;
+      isPostpaid: boolean;
+    }>;
+  }> {
+    const db = tx ?? this.prismaService;
+    const customer = await db.customer.findUnique({
+      where: { id: customerId },
+      select: { status: true },
+    });
+    if (!customer) {
+      throw new NotFoundException(`Customer ${customerId} not found`);
+    }
+    const policies = await db.policy.findMany({
+      where: { customerId },
+      select: { id: true, packageId: true, status: true },
+    });
+    const pscs = await db.packageSchemeCustomer.findMany({
+      where: { customerId },
+      include: {
+        packageScheme: {
+          select: {
+            packageId: true,
+            scheme: { select: { isPostpaid: true } },
+          },
+        },
+      },
+    });
+    const postpaidByPackage = new Map<number, boolean>();
+    for (const row of pscs) {
+      postpaidByPackage.set(row.packageScheme.packageId, row.packageScheme.scheme.isPostpaid);
+    }
+    return {
+      customerStatus: customer.status,
+      snapshots: policies.map((p) => ({
+        id: p.id,
+        packageId: p.packageId,
+        status: p.status,
+        isPostpaid: postpaidByPackage.get(p.packageId) ?? false,
+      })),
+    };
+  }
+
+  async resolvePackageIsPostpaid(customerId: string, packageId: number): Promise<boolean> {
+    const row = await this.prismaService.packageSchemeCustomer.findFirst({
+      where: { customerId, packageScheme: { packageId } },
+      include: { packageScheme: { include: { scheme: { select: { isPostpaid: true } } } } },
+    });
+    return row?.packageScheme?.scheme?.isPostpaid ?? false;
   }
 
   /**
@@ -540,6 +657,8 @@ export class PolicyService {
         paymentMessageBlob?: string;
       };
       customDays?: number;
+      dependantIds?: string[] | null;
+      beneficiaryId?: string | null;
     },
     correlationId: string,
   ) {
@@ -610,17 +729,19 @@ export class PolicyService {
         );
       }
 
-      // At most one non-terminal policy per customer per package
-      const existingPolicyForPackage = await this.prismaService.policy.findFirst({
-        where: {
-          customerId: data.customerId,
-          packageId: data.packageId,
-          status: { in: ['ACTIVE', 'PENDING_ACTIVATION', 'SUSPENDED'] },
-        },
+      const enrolment = await this.loadEnrolmentSnapshots(data.customerId);
+      const newIsPostpaid = await this.resolvePackageIsPostpaid(data.customerId, data.packageId);
+      const enrolmentCheck = validateAdditionalProductEnrolment({
+        customerStatus: enrolment.customerStatus,
+        policies: enrolment.snapshots,
+        newPackageId: data.packageId,
+        newIsPostpaid,
       });
-      if (existingPolicyForPackage) {
-        throw new ConflictException(
-          `Customer already has an active policy for this package (policy ID: ${existingPolicyForPackage.id})`
+      if (!enrolmentCheck.ok) {
+        throw ValidationException.forField(
+          enrolmentCheck.field,
+          enrolmentCheck.message,
+          ErrorCodes.RESOURCE_CONFLICT
         );
       }
 
@@ -802,6 +923,17 @@ export class PolicyService {
 
           this.logger.log(
             `[${correlationId}] ✓ Successfully created policy: id=${policy.id}, policyNumber="${policy.policyNumber}"`
+          );
+
+          await this.attachPolicyMembership(
+            tx,
+            {
+              policyId: policy.id,
+              customerId: data.customerId,
+              dependantIds: data.dependantIds,
+              beneficiaryId: data.beneficiaryId,
+            },
+            correlationId
           );
         } catch (createError: unknown) {
           // Handle unique constraint violation on policyNumber (race condition safety net)
@@ -1645,56 +1777,52 @@ export class PolicyService {
           `for customer ${policy.customerId}`
         );
 
-        // Create PolicyMemberDependant records for each dependant
-        // Order: spouses first (01, 02, ...), then others (e.g. children). Principal is always 00.
-        if (policy.customer.dependants && policy.customer.dependants.length > 0) {
-          const orderedDependants = this.orderDependantsForMemberNumbers(
-            policy.customer.dependants
-          );
-          this.logger.log(
-            `[${correlationId}] Creating member records for ${orderedDependants.length} dependants (spouses first)`
-          );
-
-          for (let i = 0; i < orderedDependants.length; i++) {
-            const dependant = orderedDependants[i];
-            // Dependants start at sequence 1 (formatted as 01), then 2 (02), etc.
-            const dependantMemberNumber = await this.generateMemberNumber(
-              policy.packageId,
-              policyNumber,
-              txClient,
-              correlationId,
-              i + 1 // Dependant sequence: 1 -> 01, 2 -> 02, etc.
-            );
-
-            await txClient.policyMemberDependant.create({
-              data: {
-                dependantId: dependant.id,
-                policyId: policyId,
-                memberNumber: dependantMemberNumber,
-              },
-            });
-
-            this.logger.log(
-              `[${correlationId}] Created dependant member record with number ${dependantMemberNumber} ` +
-              `for dependant ${dependant.id}`
-            );
-          }
-        }
-
-        // Update customer status to ACTIVE if this is the first policy
-        const customerPoliciesCount = await txClient.policy.count({
-          where: { customerId: policy.customerId },
+        // Number only dependants already attached to THIS policy (explicit membership).
+        const intendedDependants = await txClient.policyMemberDependant.findMany({
+          where: { policyId },
+          include: { dependant: { select: { id: true, relationship: true } } },
         });
+        const orderedDependants = this.orderDependantsForMemberNumbers(
+          intendedDependants.map((row) => row.dependant)
+        );
+        this.logger.log(
+          `[${correlationId}] Assigning member numbers for ${orderedDependants.length} intended dependants`
+        );
 
-        if (customerPoliciesCount === 1) {
-          // This is the first policy - update customer status to ACTIVE
-          await txClient.customer.update({
-            where: { id: policy.customerId },
-            data: { status: 'ACTIVE' },
+        for (let i = 0; i < orderedDependants.length; i++) {
+          const dependant = orderedDependants[i];
+          const dependantMemberNumber = await this.generateMemberNumber(
+            policy.packageId,
+            policyNumber,
+            txClient,
+            correlationId,
+            i + 1
+          );
+
+          await txClient.policyMemberDependant.update({
+            where: {
+              policyId_dependantId: { policyId, dependantId: dependant.id },
+            },
+            data: { memberNumber: dependantMemberNumber },
           });
 
           this.logger.log(
-            `[${correlationId}] Updated customer ${policy.customerId} status to ACTIVE (first policy)`
+            `[${correlationId}] Set dependant member number ${dependantMemberNumber} ` +
+              `for dependant ${dependant.id}`
+          );
+        }
+
+        const customer = await txClient.customer.findUnique({
+          where: { id: policy.customerId },
+          select: { status: true },
+        });
+        if (customer && customer.status !== CustomerStatus.TERMINATED) {
+          await txClient.customer.update({
+            where: { id: policy.customerId },
+            data: { status: 'ACTIVE', deactivatedAt: null },
+          });
+          this.logger.log(
+            `[${correlationId}] Updated customer ${policy.customerId} status to ACTIVE after policy activation`
           );
         }
 
@@ -2111,6 +2239,12 @@ export class PolicyService {
         },
       });
 
+      await this.attachPolicyMembership(
+        tx,
+        { policyId: policy.id, customerId: data.customerId },
+        correlationId
+      );
+
       const mapped = await this.mapUnmappedMpesaItemsToPolicy(
         policy.id,
         paymentAcNumber,
@@ -2142,8 +2276,10 @@ export class PolicyService {
       annualPremium?: number;
       frequency: PaymentFrequency;
       customDays?: number;
+      dependantIds?: string[] | null;
+      beneficiaryId?: string | null;
     },
-    _correlationId: string
+    correlationId: string
   ) {
     const customer = await this.prismaService.customer.findUnique({
       where: { id: data.customerId },
@@ -2175,9 +2311,36 @@ export class PolicyService {
       data.packageId,
       data.frequency
     );
-    const paymentAcNumber = customer.idNumber ?? null;
+
+    const enrolment = await this.loadEnrolmentSnapshots(data.customerId);
+    const newIsPostpaid = await this.resolvePackageIsPostpaid(data.customerId, data.packageId);
+    const enrolmentCheck = validateAdditionalProductEnrolment({
+      customerStatus: enrolment.customerStatus,
+      policies: enrolment.snapshots,
+      newPackageId: data.packageId,
+      newIsPostpaid,
+    });
+    if (!enrolmentCheck.ok) {
+      throw ValidationException.forField(
+        enrolmentCheck.field,
+        enrolmentCheck.message,
+        ErrorCodes.RESOURCE_CONFLICT
+      );
+    }
 
     return this.prismaService.$transaction(async (tx) => {
+      const isFirstOccupying = !(await this.paymentAccountNumberService.customerHasExistingPolicies(
+        data.customerId,
+        tx,
+        correlationId
+      ));
+      const paymentAcNumber = await this.paymentAccountNumberService.generateForPolicy(
+        data.customerId,
+        isFirstOccupying,
+        tx,
+        correlationId
+      );
+
       const policy = await tx.policy.create({
         data: {
           policyNumber: null,
@@ -2197,12 +2360,22 @@ export class PolicyService {
         },
       });
 
-      // Defensive: if any historical M-Pesa items match, map them (list path usually has none)
+      await this.attachPolicyMembership(
+        tx,
+        {
+          policyId: policy.id,
+          customerId: data.customerId,
+          dependantIds: data.dependantIds,
+          beneficiaryId: data.beneficiaryId,
+        },
+        correlationId
+      );
+
       if (paymentAcNumber) {
         await this.mapUnmappedMpesaItemsToPolicy(
           policy.id,
           paymentAcNumber,
-          _correlationId,
+          correlationId,
           tx,
           { activateIfPending: true }
         );

--- a/apps/api/src/services/product-management.service.ts
+++ b/apps/api/src/services/product-management.service.ts
@@ -234,16 +234,24 @@ export class ProductManagementService {
   /**
    * Flat scheme list for pickers (includes inactive; UI disables inactive rows).
    */
-  async listSchemesForPicker(correlationId: string) {
-    this.logger.log(`[${correlationId}] Listing schemes for picker`);
+  async listSchemesForPicker(correlationId: string, q?: string) {
+    this.logger.log(`[${correlationId}] Listing schemes for picker q=${q ?? ''}`);
     try {
+      const prefix = (q ?? '').trim();
+      if (prefix.length > 0 && prefix.length < 2) {
+        return [];
+      }
       const schemes = await this.prismaService.scheme.findMany({
+        where: prefix.length >= 2
+          ? { schemeName: { startsWith: prefix, mode: 'insensitive' } }
+          : undefined,
         select: {
           id: true,
           schemeName: true,
           isActive: true,
         },
         orderBy: { schemeName: 'asc' },
+        take: prefix.length >= 2 ? 25 : 200,
       });
       return schemes.map((s) => ({
         id: s.id,
@@ -331,6 +339,7 @@ export class ProductManagementService {
               schemeName: true,
               description: true,
               parentsSupported: true,
+              isPostpaid: true,
             },
           },
         },
@@ -346,6 +355,7 @@ export class ProductManagementService {
         name: ps.scheme.schemeName,
         description: ps.scheme.description,
         parentsSupported: ps.scheme.parentsSupported,
+        isPostpaid: ps.scheme.isPostpaid,
         packageSchemeId: ps.id, // Include junction table ID for scheme assignment
       }));
 

--- a/apps/api/src/utils/__tests__/additional-product.rules.spec.ts
+++ b/apps/api/src/utils/__tests__/additional-product.rules.spec.ts
@@ -1,0 +1,82 @@
+import { CustomerStatus, PolicyStatus } from '@prisma/client';
+import { validateAdditionalProductEnrolment } from '../additional-product.rules';
+
+describe('validateAdditionalProductEnrolment', () => {
+  const prepaidA = {
+    id: 'p1',
+    packageId: 1,
+    status: PolicyStatus.ACTIVE,
+    isPostpaid: false,
+  };
+
+  it('blocks terminated customers', () => {
+    const result = validateAdditionalProductEnrolment({
+      customerStatus: CustomerStatus.TERMINATED,
+      policies: [],
+      newPackageId: 2,
+      newIsPostpaid: false,
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('blocks when any policy is terminated', () => {
+    const result = validateAdditionalProductEnrolment({
+      customerStatus: CustomerStatus.ACTIVE,
+      policies: [{ ...prepaidA, status: PolicyStatus.TERMINATED }],
+      newPackageId: 2,
+      newIsPostpaid: false,
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('blocks same package while occupying', () => {
+    const result = validateAdditionalProductEnrolment({
+      customerStatus: CustomerStatus.ACTIVE,
+      policies: [prepaidA],
+      newPackageId: 1,
+      newIsPostpaid: false,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.field).toBe('packageId');
+  });
+
+  it('allows two prepaid products on different packages', () => {
+    const result = validateAdditionalProductEnrolment({
+      customerStatus: CustomerStatus.ACTIVE,
+      policies: [prepaidA],
+      newPackageId: 2,
+      newIsPostpaid: false,
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('blocks postpaid while any occupying policy exists', () => {
+    const result = validateAdditionalProductEnrolment({
+      customerStatus: CustomerStatus.ACTIVE,
+      policies: [prepaidA],
+      newPackageId: 2,
+      newIsPostpaid: true,
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('blocks prepaid while a postpaid policy is occupying', () => {
+    const result = validateAdditionalProductEnrolment({
+      customerStatus: CustomerStatus.ACTIVE,
+      policies: [{ ...prepaidA, isPostpaid: true }],
+      newPackageId: 2,
+      newIsPostpaid: false,
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('allows same package when the old policy is expired', () => {
+    const result = validateAdditionalProductEnrolment({
+      customerStatus: CustomerStatus.DEACTIVATED,
+      policies: [{ ...prepaidA, status: PolicyStatus.EXPIRED }],
+      newPackageId: 1,
+      newIsPostpaid: false,
+    });
+    expect(result).toEqual({ ok: true });
+  });
+});

--- a/apps/api/src/utils/__tests__/family-category.util.spec.ts
+++ b/apps/api/src/utils/__tests__/family-category.util.spec.ts
@@ -1,6 +1,9 @@
 /// <reference types="jest" />
 import {
+  additionalSpouseCount,
   hasAdditionalSpousePremium,
+  maxDependantSlots,
+  packageHasFamilyBands,
   resolveFamilyCategoryForHousehold,
   validateSelectedFamilyCategory,
 } from '../family-category.util';
@@ -84,5 +87,32 @@ describe('hasAdditionalSpousePremium', () => {
 
   it('is true for non-member-only with >1 spouse', () => {
     expect(hasAdditionalSpousePremium('up_to_5', twoSpouses)).toBe(true);
+  });
+});
+
+describe('additionalSpouseCount', () => {
+  const threeSpouses = [
+    { relationship: DependantRelationship.SPOUSE },
+    { relationship: DependantRelationship.SPOUSE },
+    { relationship: DependantRelationship.SPOUSE },
+  ];
+
+  it('is 0 for member_only', () => {
+    expect(additionalSpouseCount('member_only', threeSpouses)).toBe(0);
+  });
+
+  it('is 2 for three spouses on a family band', () => {
+    expect(additionalSpouseCount('up_to_5', threeSpouses)).toBe(2);
+  });
+});
+
+describe('maxDependantSlots', () => {
+  it('is 0 when package has no UP_TO_N bands', () => {
+    expect(packageHasFamilyBands([{ key: 'member_only', kind: 'MEMBER_ONLY' }])).toBe(false);
+    expect(maxDependantSlots([{ key: 'member_only', kind: 'MEMBER_ONLY' }])).toBe(0);
+  });
+
+  it('uses the largest UP_TO_N minus principal', () => {
+    expect(maxDependantSlots(bands)).toBe(7);
   });
 });

--- a/apps/api/src/utils/__tests__/household-premium.util.spec.ts
+++ b/apps/api/src/utils/__tests__/household-premium.util.spec.ts
@@ -1,0 +1,59 @@
+import { DependantRelationship } from '@prisma/client';
+import { computeHouseholdPremium } from '../household-premium.util';
+
+const pricing = {
+  categories: [
+    { key: 'member_only', kind: 'MEMBER_ONLY', maxMembers: 1 },
+    { key: 'up_to_5', kind: 'UP_TO_N', maxMembers: 5 },
+    { key: 'additional_spouse', kind: 'ADDITIONAL_SPOUSE', maxMembers: null },
+  ],
+  plans: {
+    gold: {
+      planId: 10,
+      rates: {
+        member_only: { monthly: 100, annually: 1200 },
+        up_to_5: { monthly: 200, annually: 2400 },
+        additional_spouse: { monthly: 50, annually: 600 },
+      },
+    },
+  },
+};
+
+describe('computeHouseholdPremium', () => {
+  it('uses member-only rates for principal only', () => {
+    const result = computeHouseholdPremium({
+      pricing,
+      packagePlanId: 10,
+      frequency: 'MONTHLY',
+      dependants: [],
+    });
+    expect(result).toEqual({
+      ok: true,
+      premium: 100,
+      annualPremium: 1200,
+      categoryKey: 'member_only',
+      extraSpouseCount: 0,
+    });
+  });
+
+  it('adds extra-spouse rate for each spouse after the first', () => {
+    const threeSpouses = [
+      { relationship: DependantRelationship.SPOUSE },
+      { relationship: DependantRelationship.SPOUSE },
+      { relationship: DependantRelationship.SPOUSE },
+    ];
+    const result = computeHouseholdPremium({
+      pricing,
+      packagePlanId: 10,
+      frequency: 'MONTHLY',
+      dependants: threeSpouses,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.categoryKey).toBe('up_to_5');
+      expect(result.extraSpouseCount).toBe(2);
+      expect(result.premium).toBe(300);
+      expect(result.annualPremium).toBe(3600);
+    }
+  });
+});

--- a/apps/api/src/utils/__tests__/payment-ac-suffix.util.spec.ts
+++ b/apps/api/src/utils/__tests__/payment-ac-suffix.util.spec.ts
@@ -1,0 +1,31 @@
+import { occupyingPolicyPaymentAcSuffix, policySuffixLetterAt } from '../payment-ac-suffix.util';
+
+describe('occupyingPolicyPaymentAcSuffix', () => {
+  it('returns null for the first occupying policy', () => {
+    expect(occupyingPolicyPaymentAcSuffix(0)).toBeNull();
+  });
+
+  it('uses B for the second occupying policy', () => {
+    expect(occupyingPolicyPaymentAcSuffix(1)).toBe('B');
+  });
+
+  it('uses C for the third occupying policy', () => {
+    expect(occupyingPolicyPaymentAcSuffix(2)).toBe('C');
+  });
+});
+
+describe('policySuffixLetterAt', () => {
+  it('skips A, I, J, and O', () => {
+    expect(policySuffixLetterAt(0)).toBe('B');
+    expect(POLICY_SKIPPED_LETTERS_NOT_USED());
+  });
+});
+
+function POLICY_SKIPPED_LETTERS_NOT_USED(): void {
+  const letters = Array.from({ length: 22 }, (_, i) => policySuffixLetterAt(i)).join('');
+  expect(letters).toBe('BCDEFGHKLMNPQRSTUVWXYZ');
+  expect(letters).not.toContain('A');
+  expect(letters).not.toContain('I');
+  expect(letters).not.toContain('J');
+  expect(letters).not.toContain('O');
+}

--- a/apps/api/src/utils/__tests__/person-duplicate.util.spec.ts
+++ b/apps/api/src/utils/__tests__/person-duplicate.util.spec.ts
@@ -1,0 +1,42 @@
+import { matchExistingPerson } from '../person-duplicate.util';
+
+const jane = {
+  id: 'b1',
+  firstName: 'Jane',
+  lastName: 'Doe',
+  idNumber: '12345678',
+  phoneNumber: '254712345678',
+};
+
+describe('matchExistingPerson', () => {
+  it('auto-picks when names and ID match', () => {
+    const result = matchExistingPerson(
+      { firstName: 'jane', lastName: 'DOE', idNumber: '12345678' },
+      [jane]
+    );
+    expect(result).toEqual({ kind: 'auto', person: jane });
+  });
+
+  it('treats same names with different IDs as different people', () => {
+    const result = matchExistingPerson(
+      { firstName: 'Jane', lastName: 'Doe', idNumber: '99999999' },
+      [jane]
+    );
+    expect(result).toEqual({ kind: 'none' });
+  });
+
+  it('auto-picks when names and phone match and IDs are empty', () => {
+    const existing = { id: 'b2', firstName: 'Sam', lastName: 'Lee', phoneNumber: '254700000000' };
+    const result = matchExistingPerson(
+      { firstName: 'Sam', lastName: 'Lee', phoneNumber: '254700000000' },
+      [existing]
+    );
+    expect(result).toEqual({ kind: 'auto', person: existing });
+  });
+
+  it('forces confirm when names match and both ID and phone are empty', () => {
+    const existing = { id: 'b3', firstName: 'Pat', lastName: 'Okello' };
+    const result = matchExistingPerson({ firstName: 'Pat', lastName: 'Okello' }, [existing]);
+    expect(result).toEqual({ kind: 'confirm', candidates: [existing] });
+  });
+});

--- a/apps/api/src/utils/additional-product.rules.ts
+++ b/apps/api/src/utils/additional-product.rules.ts
@@ -1,0 +1,69 @@
+import { CustomerStatus, PolicyStatus } from '@prisma/client';
+import { isOccupyingPolicyStatus } from './occupying-policy.util';
+
+export type PolicyEnrolmentSnapshot = {
+  id: string;
+  packageId: number;
+  status: PolicyStatus | string;
+  isPostpaid: boolean;
+};
+
+export type EnrolmentBlock = {
+  ok: false;
+  field: string;
+  message: string;
+};
+
+export type EnrolmentOk = { ok: true };
+
+export function validateAdditionalProductEnrolment(params: {
+  customerStatus: CustomerStatus | string;
+  policies: PolicyEnrolmentSnapshot[];
+  newPackageId: number;
+  newIsPostpaid: boolean;
+}): EnrolmentOk | EnrolmentBlock {
+  if (params.customerStatus === CustomerStatus.TERMINATED) {
+    return {
+      ok: false,
+      field: 'customer',
+      message: 'Terminated customers cannot be enrolled in another product',
+    };
+  }
+
+  if (params.policies.some((p) => p.status === PolicyStatus.TERMINATED)) {
+    return {
+      ok: false,
+      field: 'policy',
+      message: 'Customers with a terminated policy cannot be enrolled in another product',
+    };
+  }
+
+  const occupying = params.policies.filter((p) => isOccupyingPolicyStatus(p.status));
+  const occupyingSamePackage = occupying.find((p) => p.packageId === params.newPackageId);
+  if (occupyingSamePackage) {
+    return {
+      ok: false,
+      field: 'packageId',
+      message:
+        'This customer already has an occupying policy for this package. Deactivate it before adding another.',
+    };
+  }
+
+  const occupyingPostpaid = occupying.some((p) => p.isPostpaid);
+  if (params.newIsPostpaid && occupying.length > 0) {
+    return {
+      ok: false,
+      field: 'packageSchemeId',
+      message: 'A postpaid product cannot occupy at the same time as another policy',
+    };
+  }
+  if (!params.newIsPostpaid && occupyingPostpaid) {
+    return {
+      ok: false,
+      field: 'packageSchemeId',
+      message: 'A prepaid product cannot occupy at the same time as a postpaid policy',
+    };
+  }
+
+  return { ok: true };
+}

--- a/apps/api/src/utils/family-category.util.ts
+++ b/apps/api/src/utils/family-category.util.ts
@@ -100,6 +100,41 @@ export function validateSelectedFamilyCategory(params: {
   return { ok: true, categoryKey: selectedCategoryKey };
 }
 
+export function packageHasFamilyBands(bands: PackagePricingBand[]): boolean {
+  return bands.some((b) => b.kind === 'UP_TO_N' && (b.maxMembers ?? 0) >= 2);
+}
+
+/** Max spouses+children allowed (principal is not counted). 0 = member-only product. */
+export function maxDependantSlots(bands: PackagePricingBand[]): number {
+  const upTo = bands
+    .filter((b) => b.kind === 'UP_TO_N' && b.maxMembers != null && b.maxMembers >= 2)
+    .map((b) => b.maxMembers ?? 0);
+  if (upTo.length === 0) return 0;
+  return Math.max(...upTo) - 1;
+}
+
+/**
+ * Extra-spouse add-on count: each spouse after the first.
+ * Member-only → 0. optedIn false → 0. Unknown household + opted in → 1.
+ */
+export function additionalSpouseCount(
+  category: string,
+  dependants: Array<{ relationship: DependantRelationship; deletedAt?: Date | null }>,
+  options?: { optedIn?: boolean; householdKnown?: boolean }
+): number {
+  if (category === 'member_only' || category === 'MEMBER_ONLY') return 0;
+  if (options?.optedIn === false) return 0;
+
+  if (options?.householdKnown === false) {
+    return options.optedIn === true ? 1 : 0;
+  }
+
+  const spouseCount = dependants.filter(
+    (d) => d.deletedAt == null && d.relationship === 'SPOUSE'
+  ).length;
+  return Math.max(0, spouseCount - 1);
+}
+
 /**
  * Additional spouse add-on applies when category is not Member only, agent opts in,
  * and (when household known) there is more than one spouse.
@@ -109,17 +144,5 @@ export function hasAdditionalSpousePremium(
   dependants: Array<{ relationship: DependantRelationship; deletedAt?: Date | null }>,
   options?: { optedIn?: boolean; householdKnown?: boolean }
 ): boolean {
-  if (category === 'member_only' || category === 'MEMBER_ONLY') return false;
-  if (options?.optedIn === false) return false;
-
-  const spouseCount = dependants.filter(
-    (d) => d.deletedAt == null && d.relationship === 'SPOUSE'
-  ).length;
-
-  if (options?.householdKnown === false) {
-    return options.optedIn === true;
-  }
-
-  if (spouseCount <= 1) return false;
-  return true;
+  return additionalSpouseCount(category, dependants, options) > 0;
 }

--- a/apps/api/src/utils/household-premium.util.ts
+++ b/apps/api/src/utils/household-premium.util.ts
@@ -1,0 +1,100 @@
+import {
+  additionalSpouseCount,
+  resolveFamilyCategoryForHousehold,
+  type PackagePricingBand,
+} from './family-category.util';
+import {
+  computeAnnualPremium,
+  computeInstallmentPremium,
+  type PricingRateBand,
+} from './insurance-installment.util';
+import { DependantRelationship } from '@prisma/client';
+
+export type HouseholdPremiumPricing = {
+  categories: Array<{
+    key: string;
+    kind: string;
+    maxMembers?: number | null;
+  }>;
+  plans: Record<
+    string,
+    {
+      planId: number;
+      rates: Record<string, PricingRateBand>;
+    }
+  >;
+};
+
+export type HouseholdPremiumOk = {
+  ok: true;
+  premium: number;
+  annualPremium: number;
+  categoryKey: string;
+  extraSpouseCount: number;
+};
+
+export type HouseholdPremiumErr = { ok: false; reason: string };
+
+export function computeHouseholdPremium(params: {
+  pricing: HouseholdPremiumPricing;
+  packagePlanId: number;
+  frequency: string;
+  dependants: Array<{ relationship: DependantRelationship; deletedAt?: Date | null }>;
+}): HouseholdPremiumOk | HouseholdPremiumErr {
+  const plan = Object.values(params.pricing.plans).find((p) => p.planId === params.packagePlanId);
+  if (!plan) {
+    return { ok: false, reason: 'Selected plan is not in package pricing' };
+  }
+
+  const bands: PackagePricingBand[] = params.pricing.categories.map((c) => ({
+    key: c.key,
+    kind: c.kind as PackagePricingBand['kind'],
+    maxMembers: c.maxMembers ?? null,
+  }));
+
+  const householdSize = 1 + params.dependants.filter((d) => d.deletedAt == null).length;
+  const resolved = resolveFamilyCategoryForHousehold(householdSize, bands);
+  if (!resolved.ok) {
+    return { ok: false, reason: 'Household is larger than this package allows' };
+  }
+
+  const categoryRates = plan.rates[resolved.categoryKey];
+  if (!categoryRates) {
+    return { ok: false, reason: 'No rates for the resolved family category' };
+  }
+
+  const extraSpouseCount = additionalSpouseCount(resolved.categoryKey, params.dependants);
+  const spouseBand = params.pricing.categories.find((c) => c.kind === 'ADDITIONAL_SPOUSE');
+  const spouseRates = spouseBand ? (plan.rates[spouseBand.key] ?? {}) : {};
+
+  const lookupRates: PricingRateBand = {
+    daily: (categoryRates.daily ?? 0) + extraSpouseCount * (spouseRates.daily ?? 0),
+    weekly: (categoryRates.weekly ?? 0) + extraSpouseCount * (spouseRates.weekly ?? 0),
+    monthly: (categoryRates.monthly ?? 0) + extraSpouseCount * (spouseRates.monthly ?? 0),
+    quarterly: (categoryRates.quarterly ?? 0) + extraSpouseCount * (spouseRates.quarterly ?? 0),
+    annually: (categoryRates.annually ?? 0) + extraSpouseCount * (spouseRates.annually ?? 0),
+  };
+
+  const premium = computeInstallmentPremium({
+    frequency: params.frequency,
+    daily: lookupRates.daily,
+    weekly: lookupRates.weekly,
+    lookupRates,
+  });
+  const annualPremium = computeAnnualPremium({
+    daily: lookupRates.daily,
+    lookupRates,
+  });
+
+  if (premium <= 0) {
+    return { ok: false, reason: 'Could not resolve an installment premium for this frequency' };
+  }
+
+  return {
+    ok: true,
+    premium,
+    annualPremium,
+    categoryKey: resolved.categoryKey,
+    extraSpouseCount,
+  };
+}

--- a/apps/api/src/utils/occupying-policy.util.ts
+++ b/apps/api/src/utils/occupying-policy.util.ts
@@ -1,0 +1,18 @@
+import { PolicyStatus } from '@prisma/client';
+
+/** Policies that currently hold a payment account / block same-package enrolment. */
+export const OCCUPYING_POLICY_STATUSES: PolicyStatus[] = [
+  PolicyStatus.ACTIVE,
+  PolicyStatus.PENDING_ACTIVATION,
+  PolicyStatus.SUSPENDED,
+];
+
+export const STEALABLE_PAYMENT_AC_STATUSES: PolicyStatus[] = [
+  PolicyStatus.EXPIRED,
+  PolicyStatus.DEACTIVATED,
+  PolicyStatus.INACTIVE,
+];
+
+export function isOccupyingPolicyStatus(status: PolicyStatus | string): boolean {
+  return (OCCUPYING_POLICY_STATUSES as string[]).includes(status);
+}

--- a/apps/api/src/utils/payment-ac-suffix.util.ts
+++ b/apps/api/src/utils/payment-ac-suffix.util.ts
@@ -1,0 +1,20 @@
+/** Letters for policy payment-account suffix (2nd policy = B). Excludes A, I, J, O. */
+export const POLICY_SUFFIX_LETTERS = 'BCDEFGHKLMNPQRSTUVWXYZ';
+
+export function policySuffixLetterAt(index: number): string {
+  const n = POLICY_SUFFIX_LETTERS.length;
+  if (index < n) return POLICY_SUFFIX_LETTERS[index];
+  const i = index - n;
+  const first = Math.floor(i / n);
+  const second = i % n;
+  return POLICY_SUFFIX_LETTERS[first] + POLICY_SUFFIX_LETTERS[second];
+}
+
+/**
+ * Suffix for a new occupying policy given how many occupying policies already exist.
+ * 0 occupying → no suffix (use id number). 1 occupying → B. 2 occupying → C.
+ */
+export function occupyingPolicyPaymentAcSuffix(occupyingCountBeforeNew: number): string | null {
+  if (occupyingCountBeforeNew <= 0) return null;
+  return policySuffixLetterAt(occupyingCountBeforeNew - 1);
+}

--- a/apps/api/src/utils/person-duplicate.util.ts
+++ b/apps/api/src/utils/person-duplicate.util.ts
@@ -1,0 +1,81 @@
+export type PersonDuplicateCandidate = {
+  id: string;
+  firstName: string;
+  lastName: string;
+  idNumber?: string | null;
+  phoneNumber?: string | null;
+};
+
+export type PersonDuplicateInput = {
+  firstName: string;
+  lastName: string;
+  idNumber?: string | null;
+  phoneNumber?: string | null;
+};
+
+export type PersonDuplicateMatch =
+  | { kind: 'none' }
+  | { kind: 'auto'; person: PersonDuplicateCandidate }
+  | { kind: 'confirm'; candidates: PersonDuplicateCandidate[] };
+
+function normName(value: string | null | undefined): string {
+  return (value ?? '').trim().toLowerCase();
+}
+
+function normId(value: string | null | undefined): string {
+  return (value ?? '').trim().replace(/\s/g, '');
+}
+
+function normPhone(value: string | null | undefined): string {
+  return (value ?? '').trim().replace(/\s/g, '');
+}
+
+function namesMatch(a: PersonDuplicateInput, b: PersonDuplicateCandidate): boolean {
+  return normName(a.firstName) === normName(b.firstName) && normName(a.lastName) === normName(b.lastName);
+}
+
+/**
+ * Match a net-new person against existing people.
+ * Same first+last (case-insensitive) and (same ID if both have one, or same phone if both have one).
+ * Names match but IDs differ → different people.
+ * Names match and both ID and phone empty → force pick-or-confirm.
+ */
+export function matchExistingPerson(
+  input: PersonDuplicateInput,
+  existing: PersonDuplicateCandidate[]
+): PersonDuplicateMatch {
+  const sameName = existing.filter((p) => namesMatch(input, p));
+  if (sameName.length === 0) return { kind: 'none' };
+
+  const inputId = normId(input.idNumber);
+  const inputPhone = normPhone(input.phoneNumber);
+
+  if (inputId) {
+    const idMatches = sameName.filter((p) => {
+      const existingId = normId(p.idNumber);
+      return existingId.length > 0 && existingId === inputId;
+    });
+    if (idMatches.length === 1) return { kind: 'auto', person: idMatches[0] };
+    if (idMatches.length > 1) return { kind: 'confirm', candidates: idMatches };
+    const conflictingId = sameName.some((p) => normId(p.idNumber).length > 0);
+    if (conflictingId) return { kind: 'none' };
+  }
+
+  if (inputPhone) {
+    const phoneMatches = sameName.filter((p) => {
+      const existingPhone = normPhone(p.phoneNumber);
+      return existingPhone.length > 0 && existingPhone === inputPhone;
+    });
+    if (phoneMatches.length === 1) return { kind: 'auto', person: phoneMatches[0] };
+    if (phoneMatches.length > 1) return { kind: 'confirm', candidates: phoneMatches };
+  }
+
+  const bothEmpty = sameName.filter(
+    (p) => !normId(p.idNumber) && !normPhone(p.phoneNumber)
+  );
+  if (!inputId && !inputPhone && bothEmpty.length > 0) {
+    return { kind: 'confirm', candidates: bothEmpty };
+  }
+
+  return { kind: 'none' };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Admin-only flow to enrol an existing customer in another product, plus the supporting occupancy, membership, pricing, and registration changes.

## What this does

- Adds a `policy_beneficiaries` join so each policy has one next of kin (100%) while beneficiary people stay shared. Existing policies are backfilled from the earliest remaining customer beneficiary.
- Registration admins can add another product from the Products tab. The wizard is scheme → package → plan, then household, beneficiary, and payment. Self-service and BA registration payouts are unchanged.
- Occupying policies (`ACTIVE` / `PENDING_ACTIVATION` / `SUSPENDED`) block the same package and any postpaid mix. Expired / deactivated / inactive rows can stay; the new policy does not auto-deactivate them.
- Payment account numbers: first occupying policy uses the ID number (stolen from expired/deactivated/inactive if needed). Later occupying policies use `idNumberB`, `idNumberC`, …
- Membership is explicit. Selected existing people get a new join row on the new policy; they stay on the old one. `activatePolicy` numbers only this policy’s dependants. Customer Details → add spouse/child still LCT-syncs only occupying policies and only the newly added IDs.
- Extra-spouse premium is `(spouseCount − 1) ×` the additional-spouse rate on add-product, registration, and modify. Household caps come from package `UP_TO_N` bands, not a hardcoded 2/7.
- Registration product pick is now searchable scheme (prefix, ≥2 letters) → packages for that scheme → plan. Member-only packages hide spouse, children, and parents.

## Out of scope

Repair-center / inventory / module 5.

## How to verify

1. As `registration_admin`, open a customer with an occupying prepaid policy → Products → Add product.
2. Same package while occupying → blocked with a deactivate instruction.
3. Different prepaid package → policy created; payment account is `idNumberB`; selected dependants stay on the first policy.
4. Skip payment → new policy is `PENDING_ACTIVATION` and does not flip a suspended/deactivated customer to `PENDING_ACTIVATION`.
5. Policy detail shows that policy’s next of kin.
6. Registration: type a scheme name (≥2 letters), pick package and plan; member-only hides household; two extra spouses multiply the additional-spouse rate.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86f7560f-badf-4bef-bc20-11a908f47fd1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86f7560f-badf-4bef-bc20-11a908f47fd1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

