### PR TITLE
Add additional product enrolment

### DIFF
--- a/apps/agent-registration/src/app/(main)/admin/customer/[customerId]/add-product/page.tsx
+++ b/apps/agent-registration/src/app/(main)/admin/customer/[customerId]/add-product/page.tsx
@@ -29,6 +29,7 @@ import {
   packageHasFamilyBands,
   resolveFamilyCategoryForHousehold,
 } from '@/lib/family-category';
+import { matchExistingPerson, type PersonDuplicateCandidate } from '@/lib/person-duplicate';
 import { mapPackagePricingToUi, pricingBandsFromApi } from '@/lib/package-pricing-ui';
 import {
   computeAnnualPremium,
@@ -61,6 +62,30 @@ function usablePhone(value?: string): string {
   return value;
 }
 
+type HouseholdPerson = {
+  id: string;
+  firstName: string;
+  lastName: string;
+  relationship: string;
+  deletedAt?: string | null;
+  idNumber?: string | null;
+  phoneNumber?: string | null;
+};
+
+type BeneficiaryPerson = {
+  id: string;
+  firstName: string;
+  lastName: string;
+  idNumber?: string | null;
+  phoneNumber?: string | null;
+};
+
+type DuplicatePrompt = {
+  source: 'spouse' | 'child' | 'beneficiary';
+  index: number;
+  candidates: PersonDuplicateCandidate[];
+};
+
 function filledPerson(p: NewPerson): boolean {
   return Boolean(p.firstName.trim() && p.lastName.trim());
 }
@@ -87,12 +112,8 @@ export default function AddProductPage() {
   const [parentsSupported, setParentsSupported] = useState(false);
   const [pricingApi, setPricingApi] = useState<PackagePricingData | null>(null);
 
-  const [existingDependants, setExistingDependants] = useState<
-    Array<{ id: string; firstName: string; lastName: string; relationship: string; deletedAt?: string | null }>
-  >([]);
-  const [existingBeneficiaries, setExistingBeneficiaries] = useState<
-    Array<{ id: string; firstName: string; lastName: string }>
-  >([]);
+  const [existingDependants, setExistingDependants] = useState<HouseholdPerson[]>([]);
+  const [existingBeneficiaries, setExistingBeneficiaries] = useState<BeneficiaryPerson[]>([]);
   const [occupyingPolicies, setOccupyingPolicies] = useState<
     Array<{ packageId?: number; status: string }>
   >([]);
@@ -108,6 +129,7 @@ export default function AddProductPage() {
   const [skipPayment, setSkipPayment] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [success, setSuccess] = useState<string | null>(null);
+  const [duplicatePrompt, setDuplicatePrompt] = useState<DuplicatePrompt | null>(null);
 
   useEffect(() => {
     void getAdditionalPolicyEligibility(customerId)
@@ -220,6 +242,49 @@ export default function AddProductPage() {
 
   const householdSlotsUsed = spouseSelected + childSelected;
 
+  const applyDuplicatePick = (personId: string) => {
+    if (!duplicatePrompt) return;
+    if (duplicatePrompt.source === 'beneficiary') {
+      setBeneficiaryId(personId);
+      setNewBeneficiary(null);
+    } else if (duplicatePrompt.source === 'spouse') {
+      setSelectedDependantIds((ids) => (ids.includes(personId) ? ids : [...ids, personId]));
+      setNewSpouses((rows) => rows.filter((_, i) => i !== duplicatePrompt.index));
+    } else {
+      setSelectedDependantIds((ids) => (ids.includes(personId) ? ids : [...ids, personId]));
+      setNewChildren((rows) => rows.filter((_, i) => i !== duplicatePrompt.index));
+    }
+    setDuplicatePrompt(null);
+    setError(null);
+  };
+
+  const splitNetNew = (rows: NewPerson[], existing: PersonDuplicateCandidate[]) => {
+    const leftover: NewPerson[] = [];
+    const autoIds: string[] = [];
+    let confirm:
+      | { index: number; candidates: PersonDuplicateCandidate[] }
+      | null = null;
+    for (const person of rows) {
+      if (!filledPerson(person)) continue;
+      if (confirm) {
+        leftover.push(person);
+        continue;
+      }
+      const match = matchExistingPerson(person, existing);
+      if (match.kind === 'auto') {
+        autoIds.push(match.person.id);
+        continue;
+      }
+      if (match.kind === 'confirm') {
+        leftover.push(person);
+        confirm = { index: leftover.length - 1, candidates: match.candidates };
+        continue;
+      }
+      leftover.push(person);
+    }
+    return { leftover, autoIds, confirm };
+  };
+
   const goNext = () => {
     setError(null);
     if (step === 'product') {
@@ -243,6 +308,39 @@ export default function AddProductPage() {
         setError('Household is larger than this package allows');
         return;
       }
+      const spouses = splitNetNew(newSpouses, existingDependants);
+      if (spouses.autoIds.length > 0) {
+        setSelectedDependantIds((ids) => [...new Set([...ids, ...spouses.autoIds])]);
+      }
+      setNewSpouses(spouses.leftover);
+      if (spouses.confirm) {
+        setDuplicatePrompt({
+          source: 'spouse',
+          index: spouses.confirm.index,
+          candidates: spouses.confirm.candidates,
+        });
+        setError(
+          'A similar person is already on file. Select the existing record, or add an ID/phone to show this is someone new.'
+        );
+        return;
+      }
+      const children = splitNetNew(newChildren, existingDependants);
+      if (children.autoIds.length > 0) {
+        setSelectedDependantIds((ids) => [...new Set([...ids, ...children.autoIds])]);
+      }
+      setNewChildren(children.leftover);
+      if (children.confirm) {
+        setDuplicatePrompt({
+          source: 'child',
+          index: children.confirm.index,
+          candidates: children.confirm.candidates,
+        });
+        setError(
+          'A similar person is already on file. Select the existing record, or add an ID/phone to show this is someone new.'
+        );
+        return;
+      }
+      setDuplicatePrompt(null);
       setStep('beneficiary');
       return;
     }
@@ -255,6 +353,20 @@ export default function AddProductPage() {
         setError('Select an existing beneficiary or create one, not both');
         return;
       }
+      if (newBeneficiary && filledPerson(newBeneficiary) && !beneficiaryId) {
+        const match = matchExistingPerson(newBeneficiary, existingBeneficiaries);
+        if (match.kind === 'auto') {
+          setBeneficiaryId(match.person.id);
+          setNewBeneficiary(null);
+        } else if (match.kind === 'confirm') {
+          setDuplicatePrompt({ source: 'beneficiary', index: 0, candidates: match.candidates });
+          setError(
+            'A similar next of kin is already on file. Select the existing record, or add an ID/phone to show this is someone new.'
+          );
+          return;
+        }
+      }
+      setDuplicatePrompt(null);
       setStep('payment');
     }
   };
@@ -359,6 +471,31 @@ export default function AddProductPage() {
       </div>
       {error && <p className="text-sm text-destructive">{error}</p>}
       {success && <p className="text-sm text-green-700">{success}</p>}
+      {duplicatePrompt && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Select existing person</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <p className="text-sm text-muted-foreground">
+              Names match an existing record with no ID or phone to tell them apart. Pick the
+              existing person, or go back and add an ID or phone if this is someone new.
+            </p>
+            {duplicatePrompt.candidates.map((person) => (
+              <Button
+                key={person.id}
+                type="button"
+                variant="outline"
+                className="w-full justify-start"
+                onClick={() => applyDuplicatePick(person.id)}
+              >
+                {person.firstName} {person.lastName}
+                {person.idNumber ? ` · ${person.idNumber}` : ''}
+              </Button>
+            ))}
+          </CardContent>
+        </Card>
+      )}
 
       {step === 'product' && (
         <Card>
@@ -481,6 +618,24 @@ export default function AddProductPage() {
                       )
                     }
                   />
+                  <Input
+                    placeholder="ID number (optional)"
+                    value={person.idNumber}
+                    onChange={(e) =>
+                      setNewSpouses((rows) =>
+                        rows.map((r, i) => (i === index ? { ...r, idNumber: e.target.value } : r))
+                      )
+                    }
+                  />
+                  <Input
+                    placeholder="Phone (optional)"
+                    value={person.phoneNumber}
+                    onChange={(e) =>
+                      setNewSpouses((rows) =>
+                        rows.map((r, i) => (i === index ? { ...r, phoneNumber: e.target.value } : r))
+                      )
+                    }
+                  />
                 </div>
               ))}
             </div>
@@ -515,6 +670,24 @@ export default function AddProductPage() {
                     onChange={(e) =>
                       setNewChildren((rows) =>
                         rows.map((r, i) => (i === index ? { ...r, lastName: e.target.value } : r))
+                      )
+                    }
+                  />
+                  <Input
+                    placeholder="ID number (optional)"
+                    value={person.idNumber}
+                    onChange={(e) =>
+                      setNewChildren((rows) =>
+                        rows.map((r, i) => (i === index ? { ...r, idNumber: e.target.value } : r))
+                      )
+                    }
+                  />
+                  <Input
+                    placeholder="Phone (optional)"
+                    value={person.phoneNumber}
+                    onChange={(e) =>
+                      setNewChildren((rows) =>
+                        rows.map((r, i) => (i === index ? { ...r, phoneNumber: e.target.value } : r))
                       )
                     }
                   />
@@ -580,6 +753,16 @@ export default function AddProductPage() {
                   placeholder="Last name"
                   value={newBeneficiary.lastName}
                   onChange={(e) => setNewBeneficiary({ ...newBeneficiary, lastName: e.target.value })}
+                />
+                <Input
+                  placeholder="ID number (optional)"
+                  value={newBeneficiary.idNumber}
+                  onChange={(e) => setNewBeneficiary({ ...newBeneficiary, idNumber: e.target.value })}
+                />
+                <Input
+                  placeholder="Phone (optional)"
+                  value={newBeneficiary.phoneNumber}
+                  onChange={(e) => setNewBeneficiary({ ...newBeneficiary, phoneNumber: e.target.value })}
                 />
               </div>
             )}

--- a/apps/agent-registration/src/app/(main)/dashboard/recovery/page.tsx
+++ b/apps/agent-registration/src/app/(main)/dashboard/recovery/page.tsx
@@ -26,6 +26,7 @@ import {
   getCustomersWithoutPolicyNoPayments,
   createPolicyFromRecovery,
   createPolicyWithoutPayments,
+  getCustomerDetails,
   getPackagePlans,
   getPackagePricingBySlug,
   type RecoveryCustomer,
@@ -39,6 +40,7 @@ import {
   type PricingRateBand,
 } from '@/lib/insurance-installment';
 import { mapPackagePricingToUi, type UiInsurancePricing } from '@/lib/package-pricing-ui';
+import { additionalSpouseCount } from '@/lib/family-category';
 import { formatTransactionReferenceForDisplay } from '@/lib/transaction-reference-display';
 import { formatDate } from '@/lib/utils';
 import { ViewIdNumber } from '@/components/view-id-number/view-id-number';
@@ -68,6 +70,7 @@ export default function RecoveryPage() {
     frequency: 'DAILY' as string,
     customDays: '',
   });
+  const [spouseCount, setSpouseCount] = useState<number | null>(null);
 
   const loadCustomers = async () => {
     try {
@@ -104,10 +107,19 @@ export default function RecoveryPage() {
     setPricingData(null);
     setPricingLoadError(null);
     setPaymentFrequencies([]);
+    setSpouseCount(null);
     setCreateDialogOpen(true);
     try {
-      const plansData = await getPackagePlans(customer.packageId);
+      const [plansData, details] = await Promise.all([
+        getPackagePlans(customer.packageId),
+        getCustomerDetails(customer.id).catch(() => null),
+      ]);
       setPlans(plansData);
+      if (details?.data?.dependants) {
+        setSpouseCount(
+          details.data.dependants.filter((d) => !d.deletedAt && d.relationship === 'SPOUSE').length
+        );
+      }
 
       const { data: session } = await supabase.auth.getSession();
       const token = session.session?.access_token;
@@ -161,18 +173,21 @@ export default function RecoveryPage() {
     if (!category) {
       return { daily: 0, weekly: 0, totalDaily: 0, totalWeekly: 0, lookupRates: null };
     }
+    const extraSpouse =
+      spouseCount == null
+        ? additionalSpouseCount(formData.selectedCategory, 0, {
+            optedIn: formData.additionalSpouse,
+            householdKnown: false,
+          })
+        : additionalSpouseCount(formData.selectedCategory, spouseCount);
     const spousePremium = plan.additional_spouse;
-    const spouseDaily = formData.additionalSpouse ? spousePremium.daily ?? 0 : 0;
-    const spouseWeekly = formData.additionalSpouse ? spousePremium.weekly ?? 0 : 0;
+    const spouseDaily = extraSpouse * (spousePremium.daily ?? 0);
+    const spouseWeekly = extraSpouse * (spousePremium.weekly ?? 0);
     const lookupRates: PricingRateBand = {
       daily: (category.daily ?? 0) + spouseDaily,
       weekly: (category.weekly ?? 0) + spouseWeekly,
-      monthly:
-        (category.monthly ?? 0) +
-        (formData.additionalSpouse ? spousePremium.monthly ?? 0 : 0),
-      annually:
-        (category.annually ?? 0) +
-        (formData.additionalSpouse ? spousePremium.annually ?? 0 : 0),
+      monthly: (category.monthly ?? 0) + extraSpouse * (spousePremium.monthly ?? 0),
+      annually: (category.annually ?? 0) + extraSpouse * (spousePremium.annually ?? 0),
     };
     return {
       daily: category.daily ?? 0,
@@ -186,6 +201,7 @@ export default function RecoveryPage() {
     formData.selectedPlan,
     formData.selectedCategory,
     formData.additionalSpouse,
+    spouseCount,
   ]);
 
   // Sync installment premium from pricing inputs. Bail out when unchanged;
@@ -470,17 +486,27 @@ export default function RecoveryPage() {
                 </SelectContent>
               </Select>
             </div>
-            <div className="flex items-center space-x-2">
-              <Checkbox
-                id="additionalSpouse"
-                checked={formData.additionalSpouse}
-                onCheckedChange={(checked) => setFormData((f) => ({ ...f, additionalSpouse: checked === true }))}
-                disabled={!formData.selectedCategory || formData.selectedCategory === 'member_only'}
-              />
-              <Label htmlFor="additionalSpouse" className="text-sm">
-                Additional Spouse Premium
-              </Label>
-            </div>
+            {spouseCount == null ? (
+              <div className="flex items-center space-x-2">
+                <Checkbox
+                  id="additionalSpouse"
+                  checked={formData.additionalSpouse}
+                  onCheckedChange={(checked) =>
+                    setFormData((f) => ({ ...f, additionalSpouse: checked === true }))
+                  }
+                  disabled={!formData.selectedCategory || formData.selectedCategory === 'member_only'}
+                />
+                <Label htmlFor="additionalSpouse" className="text-sm">
+                  Additional Spouse Premium
+                </Label>
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                Extra spouse add-ons:{' '}
+                {additionalSpouseCount(formData.selectedCategory || 'member_only', spouseCount)}
+                {spouseCount > 0 ? ` (${spouseCount} spouse${spouseCount === 1 ? '' : 's'} on file)` : ''}
+              </p>
+            )}
             <div>
               <Label>Installment (KES)</Label>
               <Input

--- a/apps/agent-registration/src/app/(main)/register/payment/page.tsx
+++ b/apps/agent-registration/src/app/(main)/register/payment/page.tsx
@@ -14,6 +14,7 @@ import {
   createPolicy,
   CreatePolicyRequest,
   completePostpaidEnrollment,
+  getCustomerDetails,
   getPackagePlans,
   getPackagePricingBySlug,
   Plan,
@@ -639,6 +640,19 @@ export default function PaymentStep() {
         // Add customDays if CUSTOM frequency is selected
         ...(frequency === 'CUSTOM' && customCadence ? { customDays: parseInt(customCadence) } : {}),
       };
+
+      try {
+        const details = await getCustomerDetails(customerId);
+        policyRequest.dependantIds = (details.data.dependants ?? [])
+          .filter((d) => !d.deletedAt)
+          .map((d) => d.id);
+        const nok = (details.data.beneficiaries ?? []).find((b) => !b.deletedAt);
+        if (nok?.id) {
+          policyRequest.beneficiaryId = nok.id;
+        }
+      } catch (membershipErr) {
+        console.warn('Could not load explicit membership for policy create', membershipErr);
+      }
 
       console.log('Creating policy first (before payment):', policyRequest);
 

--- a/apps/agent-registration/src/components/scheme-typeahead.tsx
+++ b/apps/agent-registration/src/components/scheme-typeahead.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { listSchemesForPicker, type Scheme } from '@/lib/api';
+import { schemeSearchQueryReady } from '@/lib/scheme-search';
 
 interface SchemeTypeaheadProps {
   value?: number;
@@ -30,7 +31,7 @@ export default function SchemeTypeahead({
 
   useEffect(() => {
     const trimmed = query.trim();
-    if (trimmed.length < 2) {
+    if (!schemeSearchQueryReady(trimmed)) {
       setResults([]);
       return;
     }

--- a/apps/agent-registration/src/lib/api.ts
+++ b/apps/agent-registration/src/lib/api.ts
@@ -2440,6 +2440,8 @@ export interface CreatePolicyRequest {
     paymentMessageBlob?: string
   }
   customDays?: number
+  dependantIds?: string[]
+  beneficiaryId?: string
 }
 
 export interface CompletePostpaidEnrollmentRequest {

--- a/apps/agent-registration/src/lib/person-duplicate.ts
+++ b/apps/agent-registration/src/lib/person-duplicate.ts
@@ -1,0 +1,81 @@
+/** FE mirror of API person-duplicate.util for add-product pick-or-confirm. */
+
+export type PersonDuplicateCandidate = {
+  id: string;
+  firstName: string;
+  lastName: string;
+  idNumber?: string | null;
+  phoneNumber?: string | null;
+};
+
+export type PersonDuplicateInput = {
+  firstName: string;
+  lastName: string;
+  idNumber?: string | null;
+  phoneNumber?: string | null;
+};
+
+export type PersonDuplicateMatch =
+  | { kind: 'none' }
+  | { kind: 'auto'; person: PersonDuplicateCandidate }
+  | { kind: 'confirm'; candidates: PersonDuplicateCandidate[] };
+
+function normName(value: string | null | undefined): string {
+  return (value ?? '').trim().toLowerCase();
+}
+
+function normId(value: string | null | undefined): string {
+  return (value ?? '').trim().replace(/\s/g, '');
+}
+
+function normPhone(value: string | null | undefined): string {
+  return (value ?? '').trim().replace(/\s/g, '');
+}
+
+function namesMatch(a: PersonDuplicateInput, b: PersonDuplicateCandidate): boolean {
+  return normName(a.firstName) === normName(b.firstName) && normName(a.lastName) === normName(b.lastName);
+}
+
+/**
+ * Match a net-new person against existing people.
+ * Same first+last (case-insensitive) and (same ID if both have one, or same phone if both have one).
+ * Names match but IDs differ → different people.
+ * Names match and both ID and phone empty → force pick-or-confirm.
+ */
+export function matchExistingPerson(
+  input: PersonDuplicateInput,
+  existing: PersonDuplicateCandidate[]
+): PersonDuplicateMatch {
+  const sameName = existing.filter((p) => namesMatch(input, p));
+  if (sameName.length === 0) return { kind: 'none' };
+
+  const inputId = normId(input.idNumber);
+  const inputPhone = normPhone(input.phoneNumber);
+
+  if (inputId) {
+    const idMatches = sameName.filter((p) => {
+      const existingId = normId(p.idNumber);
+      return existingId.length > 0 && existingId === inputId;
+    });
+    if (idMatches.length === 1) return { kind: 'auto', person: idMatches[0] };
+    if (idMatches.length > 1) return { kind: 'confirm', candidates: idMatches };
+    const conflictingId = sameName.some((p) => normId(p.idNumber).length > 0);
+    if (conflictingId) return { kind: 'none' };
+  }
+
+  if (inputPhone) {
+    const phoneMatches = sameName.filter((p) => {
+      const existingPhone = normPhone(p.phoneNumber);
+      return existingPhone.length > 0 && existingPhone === inputPhone;
+    });
+    if (phoneMatches.length === 1) return { kind: 'auto', person: phoneMatches[0] };
+    if (phoneMatches.length > 1) return { kind: 'confirm', candidates: phoneMatches };
+  }
+
+  const bothEmpty = sameName.filter((p) => !normId(p.idNumber) && !normPhone(p.phoneNumber));
+  if (!inputId && !inputPhone && bothEmpty.length > 0) {
+    return { kind: 'confirm', candidates: bothEmpty };
+  }
+
+  return { kind: 'none' };
+}

--- a/apps/agent-registration/src/lib/scheme-search.ts
+++ b/apps/agent-registration/src/lib/scheme-search.ts
@@ -1,0 +1,4 @@
+/** Scheme typeahead searches only after 2+ non-space characters (prefix match). */
+export function schemeSearchQueryReady(query: string): boolean {
+  return query.trim().length >= 2;
+}

--- a/apps/agent-registration/tests/family-category.spec.ts
+++ b/apps/agent-registration/tests/family-category.spec.ts
@@ -1,0 +1,34 @@
+/// <reference types="jest" />
+import {
+  additionalSpouseCount,
+  maxDependantSlots,
+  packageHasFamilyBands,
+} from '../src/lib/family-category';
+
+const familyBands = [
+  { key: 'member_only', kind: 'MEMBER_ONLY' as const },
+  { key: 'up_to_5', kind: 'UP_TO_N' as const, maxMembers: 5 },
+  { key: 'additional_spouse', kind: 'ADDITIONAL_SPOUSE' as const },
+];
+
+describe('household cap helpers', () => {
+  it('hides family slots for member-only packages', () => {
+    expect(packageHasFamilyBands([{ key: 'member_only', kind: 'MEMBER_ONLY' }])).toBe(false);
+    expect(maxDependantSlots([{ key: 'member_only', kind: 'MEMBER_ONLY' }])).toBe(0);
+  });
+
+  it('caps spouses+children at largest UP_TO_N minus principal', () => {
+    expect(packageHasFamilyBands(familyBands)).toBe(true);
+    expect(maxDependantSlots(familyBands)).toBe(4);
+  });
+});
+
+describe('additionalSpouseCount', () => {
+  it('is 2 for three spouses on a family band', () => {
+    expect(additionalSpouseCount('up_to_5', 3)).toBe(2);
+  });
+
+  it('is 0 for member-only', () => {
+    expect(additionalSpouseCount('member_only', 3)).toBe(0);
+  });
+});

--- a/apps/agent-registration/tests/person-duplicate.spec.ts
+++ b/apps/agent-registration/tests/person-duplicate.spec.ts
@@ -1,0 +1,26 @@
+/// <reference types="jest" />
+import { matchExistingPerson } from '../src/lib/person-duplicate';
+
+const jane = {
+  id: 'b1',
+  firstName: 'Jane',
+  lastName: 'Doe',
+  idNumber: '12345678',
+  phoneNumber: '254712345678',
+};
+
+describe('matchExistingPerson', () => {
+  it('auto-picks when names and ID match', () => {
+    expect(
+      matchExistingPerson({ firstName: 'jane', lastName: 'DOE', idNumber: '12345678' }, [jane])
+    ).toEqual({ kind: 'auto', person: jane });
+  });
+
+  it('forces confirm when names match and both ID and phone are empty', () => {
+    const existing = { id: 'b3', firstName: 'Pat', lastName: 'Okello' };
+    expect(matchExistingPerson({ firstName: 'Pat', lastName: 'Okello' }, [existing])).toEqual({
+      kind: 'confirm',
+      candidates: [existing],
+    });
+  });
+});

--- a/apps/agent-registration/tests/scheme-search.spec.ts
+++ b/apps/agent-registration/tests/scheme-search.spec.ts
@@ -1,0 +1,12 @@
+/// <reference types="jest" />
+import { schemeSearchQueryReady } from '../src/lib/scheme-search';
+
+describe('schemeSearchQueryReady', () => {
+  it('requires at least two letters before searching', () => {
+    expect(schemeSearchQueryReady('')).toBe(false);
+    expect(schemeSearchQueryReady('M')).toBe(false);
+    expect(schemeSearchQueryReady('  m ')).toBe(false);
+    expect(schemeSearchQueryReady('Ma')).toBe(true);
+    expect(schemeSearchQueryReady('Mfanisi')).toBe(true);
+  });
+});

--- a/apps/api/src/controllers/internal/policy.controller.ts
+++ b/apps/api/src/controllers/internal/policy.controller.ts
@@ -82,6 +82,8 @@ export class PolicyController {
         productName: createRequest.productName,
         tags: createRequest.tags,
         customDays: createRequest.customDays,
+        dependantIds: createRequest.dependantIds,
+        beneficiaryId: createRequest.beneficiaryId,
         paymentData: {
           paymentType: createRequest.paymentData.paymentType,
           transactionReference: createRequest.paymentData.transactionReference,

--- a/apps/api/src/dto/policies/create-policy.dto.ts
+++ b/apps/api/src/dto/policies/create-policy.dto.ts
@@ -189,6 +189,24 @@ export class CreatePolicyRequestDto {
   @IsInt()
   @Min(1)
   customDays?: number;
+
+  @ApiProperty({
+    description: 'Dependant IDs to attach to this policy. Omit to attach all current dependants.',
+    type: [String],
+    required: false,
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  dependantIds?: string[];
+
+  @ApiProperty({
+    description: 'Beneficiary ID to attach as this policy NOK join (100 percent).',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  beneficiaryId?: string;
 }
 
 export class PolicyResponseDto {

--- a/apps/api/src/services/__tests__/additional-policy.service.spec.ts
+++ b/apps/api/src/services/__tests__/additional-policy.service.spec.ts
@@ -58,4 +58,27 @@ describe('AdditionalPolicyService', () => {
     expect(result.canAdd).toBe(false);
     expect(result.blockedReasons.some((r) => r.toLowerCase().includes('postpaid'))).toBe(true);
   });
+
+  it('blocks additional-policy create for non-admins', async () => {
+    await expect(
+      service.createAdditionalPolicy(
+        'cust-1',
+        { packageId: 1 } as never,
+        'user-1',
+        ['brand_ambassador'],
+        'corr'
+      )
+    ).rejects.toBeInstanceOf(ValidationException);
+    try {
+      await service.createAdditionalPolicy(
+        'cust-1',
+        { packageId: 1 } as never,
+        'user-1',
+        ['brand_ambassador'],
+        'corr'
+      );
+    } catch (err) {
+      expect((err as ValidationException).errorCode).toBe(ErrorCodes.INSUFFICIENT_PERMISSIONS);
+    }
+  });
 });

--- a/apps/api/src/services/__tests__/attach-policy-membership.spec.ts
+++ b/apps/api/src/services/__tests__/attach-policy-membership.spec.ts
@@ -68,4 +68,37 @@ describe('PolicyService.attachPolicyMembership', () => {
     expect(tx.dependant.findMany).not.toHaveBeenCalled();
     expect(upsertDependant).not.toHaveBeenCalled();
   });
+
+  it('allows the same dependantId on two policies', async () => {
+    const upsertDependant = jest.fn();
+    const tx = {
+      policyMemberDependant: { upsert: upsertDependant },
+      policyBeneficiary: { upsert: jest.fn() },
+    };
+    const service = buildService(tx);
+
+    await service.attachPolicyMembership(
+      tx as never,
+      { policyId: 'pol-1', customerId: 'cust-1', dependantIds: ['dep-shared'] },
+      'corr'
+    );
+    await service.attachPolicyMembership(
+      tx as never,
+      { policyId: 'pol-2', customerId: 'cust-1', dependantIds: ['dep-shared'] },
+      'corr'
+    );
+
+    expect(upsertDependant).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        where: { policyId_dependantId: { policyId: 'pol-1', dependantId: 'dep-shared' } },
+      })
+    );
+    expect(upsertDependant).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        where: { policyId_dependantId: { policyId: 'pol-2', dependantId: 'dep-shared' } },
+      })
+    );
+  });
 });

--- a/apps/api/src/services/__tests__/product-management-picker-lists.spec.ts
+++ b/apps/api/src/services/__tests__/product-management-picker-lists.spec.ts
@@ -70,6 +70,24 @@ describe('ProductManagementService picker lists', () => {
     ]);
   });
 
+  it('listSchemesForPicker returns nothing until the prefix is at least 2 characters', async () => {
+    const result = await service.listSchemesForPicker('corr', 'M');
+    expect(result).toEqual([]);
+    expect(prisma.scheme.findMany).not.toHaveBeenCalled();
+  });
+
+  it('listSchemesForPicker prefix-matches scheme names', async () => {
+    prisma.scheme.findMany.mockResolvedValue([{ id: 3, schemeName: 'Mfanisi', isActive: true }]);
+    const result = await service.listSchemesForPicker('corr', 'Mf');
+    expect(prisma.scheme.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { schemeName: { startsWith: 'Mf', mode: 'insensitive' } },
+        take: 25,
+      })
+    );
+    expect(result).toEqual([{ id: 3, name: 'Mfanisi', isActive: true }]);
+  });
+
   it('listPackagesForSchemes returns distinct packages for scheme ids', async () => {
     prisma.packageScheme.findMany.mockResolvedValue([
       { package: { id: 10, name: 'Pkg A', isActive: true } },

--- a/apps/api/src/services/customer.service.ts
+++ b/apps/api/src/services/customer.service.ts
@@ -85,6 +85,7 @@ import { SupabaseService } from './supabase.service';
 import { PaymentAccountNumberService } from './payment-account-number.service';
 import { assertKenyanPhoneForOndemandStk, normalizePhoneNumber } from '../utils/phone-number.util';
 import { hasGlobalCustomerAccess } from '../utils/roles.util';
+import { OCCUPYING_POLICY_STATUSES } from '../utils/occupying-policy.util';
 import { maskIdNumberForDisplay, maskIdNumberOrEmpty } from '../utils/id-number-masking';
 import {
   maskDateOfBirthForDisplay,
@@ -1454,6 +1455,27 @@ export class CustomerService {
             percentage: beneficiary.percentage ?? 0,
           }))
         );
+
+        const nokId = beneficiariesWithIds[0]?.id;
+        if (nokId) {
+          const occupyingWithoutNok = await tx.policy.findMany({
+            where: {
+              customerId,
+              status: { in: OCCUPYING_POLICY_STATUSES },
+              policyBeneficiaries: { none: {} },
+            },
+            select: { id: true },
+          });
+          for (const policy of occupyingWithoutNok) {
+            await tx.policyBeneficiary.create({
+              data: {
+                policyId: policy.id,
+                beneficiaryId: nokId,
+                percentage: 100,
+              },
+            });
+          }
+        }
 
         return {
           partnerCustomerId: partnerCustomer.partnerCustomerId,

--- a/apps/api/src/services/policy-lifecycle.service.ts
+++ b/apps/api/src/services/policy-lifecycle.service.ts
@@ -50,6 +50,8 @@ import {
   utcCalendarDaysBetween,
 } from '../utils/policy-due-date.util';
 import { assertPolicyMayBecomeActive } from '../utils/policy-activation-gate.util';
+import { copyPolicyBeneficiaryJoins } from '../utils/copy-policy-beneficiary.util';
+import { nextCustomerStatusAfterPolicies } from '../utils/customer-status-sync.util';
 import { computeNominalPaymentPeriodEndDate } from '../utils/package-payment-frequency.util';
 import {
   addUtcCalendarDays,
@@ -1082,20 +1084,7 @@ export class PolicyLifecycleService {
         },
       });
 
-      const priorBeneficiaries = await tx.policyBeneficiary.findMany({
-        where: { policyId: prior.id },
-      });
-      for (const row of priorBeneficiaries) {
-        await tx.policyBeneficiary.upsert({
-          where: { policyId: created.id },
-          create: {
-            policyId: created.id,
-            beneficiaryId: row.beneficiaryId,
-            percentage: row.percentage,
-          },
-          update: { beneficiaryId: row.beneficiaryId, percentage: row.percentage },
-        });
-      }
+      await copyPolicyBeneficiaryJoins(tx, prior.id, created.id);
 
       if (prior.status === PolicyStatus.SUSPENDED || prior.status === PolicyStatus.INACTIVE) {
         await this.statusChangeService.recordPolicyChange({
@@ -1702,33 +1691,13 @@ export class PolicyLifecycleService {
 
     const closedStatus = options?.whenNoOpenPolicies ?? CustomerStatus.DEACTIVATED;
 
-    let nextStatus: CustomerStatus | null = null;
-    if (hasActive) {
-      if (
-        customer.status === CustomerStatus.DEACTIVATED ||
-        customer.status === CustomerStatus.SUSPENDED ||
-        customer.status === CustomerStatus.TERMINATED
-      ) {
-        nextStatus = CustomerStatus.ACTIVE;
-      }
-    } else if (hasPending) {
-      // Unpaid extra policies must not flip SUSPENDED / DEACTIVATED customers.
-      if (
-        customer.status === CustomerStatus.SUSPENDED ||
-        customer.status === CustomerStatus.DEACTIVATED ||
-        customer.status === CustomerStatus.TERMINATED
-      ) {
-        nextStatus = null;
-      } else if (customer.status !== CustomerStatus.PENDING_ACTIVATION) {
-        nextStatus = CustomerStatus.PENDING_ACTIVATION;
-      }
-    } else if (hasSuspended) {
-      if (customer.status !== CustomerStatus.SUSPENDED) {
-        nextStatus = CustomerStatus.SUSPENDED;
-      }
-    } else {
-      nextStatus = closedStatus;
-    }
+    const nextStatus = nextCustomerStatusAfterPolicies({
+      customerStatus: customer.status,
+      hasActive,
+      hasPending,
+      hasSuspended,
+      closedStatus,
+    });
 
     if (nextStatus == null || nextStatus === customer.status) {
       return;
@@ -2444,20 +2413,7 @@ export class PolicyLifecycleService {
         data: { supersededByPolicyId: newPolicy.id },
       });
 
-      const sourceBeneficiaries = await tx.policyBeneficiary.findMany({
-        where: { policyId },
-      });
-      for (const row of sourceBeneficiaries) {
-        await tx.policyBeneficiary.upsert({
-          where: { policyId: newPolicy.id },
-          create: {
-            policyId: newPolicy.id,
-            beneficiaryId: row.beneficiaryId,
-            percentage: row.percentage,
-          },
-          update: { beneficiaryId: row.beneficiaryId, percentage: row.percentage },
-        });
-      }
+      await copyPolicyBeneficiaryJoins(tx, policyId, newPolicy.id);
 
       if (dto.packageSchemeId != null) {
         await tx.packageSchemeCustomer.updateMany({

--- a/apps/api/src/services/policy.service.ts
+++ b/apps/api/src/services/policy.service.ts
@@ -309,6 +309,18 @@ export class PolicyService {
     );
   }
 
+  /** Earliest remaining beneficiary person for a customer (registration / recovery default). */
+  async firstCustomerBeneficiaryId(
+    customerId: string,
+    tx: Prisma.TransactionClient | PrismaService
+  ): Promise<string | null> {
+    const row = await tx.beneficiary.findFirst({
+      where: { customerId, deletedAt: null },
+      orderBy: { createdAt: 'asc' },
+    });
+    return row?.id ?? null;
+  }
+
   async loadEnrolmentSnapshots(
     customerId: string,
     tx?: Prisma.TransactionClient | PrismaService
@@ -925,13 +937,17 @@ export class PolicyService {
             `[${correlationId}] ✓ Successfully created policy: id=${policy.id}, policyNumber="${policy.policyNumber}"`
           );
 
+          const beneficiaryId =
+            data.beneficiaryId !== undefined
+              ? data.beneficiaryId
+              : await this.firstCustomerBeneficiaryId(data.customerId, tx);
           await this.attachPolicyMembership(
             tx,
             {
               policyId: policy.id,
               customerId: data.customerId,
               dependantIds: data.dependantIds,
-              beneficiaryId: data.beneficiaryId,
+              beneficiaryId,
             },
             correlationId
           );
@@ -2239,9 +2255,14 @@ export class PolicyService {
         },
       });
 
+      const beneficiaryId = await this.firstCustomerBeneficiaryId(data.customerId, tx);
       await this.attachPolicyMembership(
         tx,
-        { policyId: policy.id, customerId: data.customerId },
+        {
+          policyId: policy.id,
+          customerId: data.customerId,
+          beneficiaryId,
+        },
         correlationId
       );
 
@@ -2360,13 +2381,17 @@ export class PolicyService {
         },
       });
 
+      const beneficiaryId =
+        data.beneficiaryId !== undefined
+          ? data.beneficiaryId
+          : await this.firstCustomerBeneficiaryId(data.customerId, tx);
       await this.attachPolicyMembership(
         tx,
         {
           policyId: policy.id,
           customerId: data.customerId,
           dependantIds: data.dependantIds,
-          beneficiaryId: data.beneficiaryId,
+          beneficiaryId,
         },
         correlationId
       );

--- a/apps/api/src/utils/__tests__/copy-policy-beneficiary.util.spec.ts
+++ b/apps/api/src/utils/__tests__/copy-policy-beneficiary.util.spec.ts
@@ -1,0 +1,41 @@
+import { copyPolicyBeneficiaryJoins } from '../copy-policy-beneficiary.util';
+
+describe('copyPolicyBeneficiaryJoins', () => {
+  it('copies the source policy NOK onto the new policy', async () => {
+    const upsert = jest.fn();
+    const tx = {
+      policyBeneficiary: {
+        findMany: jest.fn().mockResolvedValue([
+          { policyId: 'old', beneficiaryId: 'ben-1', percentage: 100 },
+        ]),
+        upsert,
+      },
+    };
+
+    await copyPolicyBeneficiaryJoins(tx as never, 'old', 'new');
+
+    expect(tx.policyBeneficiary.findMany).toHaveBeenCalledWith({ where: { policyId: 'old' } });
+    expect(upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { policyId: 'new' },
+        create: expect.objectContaining({
+          policyId: 'new',
+          beneficiaryId: 'ben-1',
+          percentage: 100,
+        }),
+      })
+    );
+  });
+
+  it('is a no-op when the source policy has no join row', async () => {
+    const upsert = jest.fn();
+    const tx = {
+      policyBeneficiary: {
+        findMany: jest.fn().mockResolvedValue([]),
+        upsert,
+      },
+    };
+    await copyPolicyBeneficiaryJoins(tx as never, 'old', 'new');
+    expect(upsert).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/utils/__tests__/customer-status-sync.util.spec.ts
+++ b/apps/api/src/utils/__tests__/customer-status-sync.util.spec.ts
@@ -1,0 +1,52 @@
+import { CustomerStatus } from '@prisma/client';
+import { nextCustomerStatusAfterPolicies } from '../customer-status-sync.util';
+
+describe('nextCustomerStatusAfterPolicies', () => {
+  it('does not flip SUSPENDED to PENDING_ACTIVATION for an unpaid extra policy', () => {
+    expect(
+      nextCustomerStatusAfterPolicies({
+        customerStatus: CustomerStatus.SUSPENDED,
+        hasActive: false,
+        hasPending: true,
+        hasSuspended: true,
+        closedStatus: CustomerStatus.DEACTIVATED,
+      })
+    ).toBeNull();
+  });
+
+  it('does not flip DEACTIVATED to PENDING_ACTIVATION for an unpaid extra policy', () => {
+    expect(
+      nextCustomerStatusAfterPolicies({
+        customerStatus: CustomerStatus.DEACTIVATED,
+        hasActive: false,
+        hasPending: true,
+        hasSuspended: false,
+        closedStatus: CustomerStatus.DEACTIVATED,
+      })
+    ).toBeNull();
+  });
+
+  it('moves PENDING_ACTIVATION to ACTIVE when a policy is active after payment', () => {
+    expect(
+      nextCustomerStatusAfterPolicies({
+        customerStatus: CustomerStatus.PENDING_ACTIVATION,
+        hasActive: true,
+        hasPending: true,
+        hasSuspended: false,
+        closedStatus: CustomerStatus.DEACTIVATED,
+      })
+    ).toBe(CustomerStatus.ACTIVE);
+  });
+
+  it('moves DEACTIVATED to ACTIVE when a new policy is paid', () => {
+    expect(
+      nextCustomerStatusAfterPolicies({
+        customerStatus: CustomerStatus.DEACTIVATED,
+        hasActive: true,
+        hasPending: false,
+        hasSuspended: false,
+        closedStatus: CustomerStatus.DEACTIVATED,
+      })
+    ).toBe(CustomerStatus.ACTIVE);
+  });
+});

--- a/apps/api/src/utils/copy-policy-beneficiary.util.ts
+++ b/apps/api/src/utils/copy-policy-beneficiary.util.ts
@@ -1,0 +1,23 @@
+import { Prisma } from '@prisma/client';
+
+/** Copy the one-NOK join from a source policy onto a superseding/renewed policy. */
+export async function copyPolicyBeneficiaryJoins(
+  tx: Prisma.TransactionClient,
+  fromPolicyId: string,
+  toPolicyId: string
+): Promise<void> {
+  const rows = await tx.policyBeneficiary.findMany({
+    where: { policyId: fromPolicyId },
+  });
+  for (const row of rows) {
+    await tx.policyBeneficiary.upsert({
+      where: { policyId: toPolicyId },
+      create: {
+        policyId: toPolicyId,
+        beneficiaryId: row.beneficiaryId,
+        percentage: row.percentage,
+      },
+      update: { beneficiaryId: row.beneficiaryId, percentage: row.percentage },
+    });
+  }
+}

--- a/apps/api/src/utils/customer-status-sync.util.ts
+++ b/apps/api/src/utils/customer-status-sync.util.ts
@@ -1,0 +1,49 @@
+import { CustomerStatus } from '@prisma/client';
+
+/**
+ * Decide the next customer status after a policy change.
+ * Unpaid extra PENDING_ACTIVATION policies must not flip SUSPENDED / DEACTIVATED / TERMINATED.
+ * An ACTIVE policy can move DEACTIVATED / PENDING_ACTIVATION / SUSPENDED (and similar) to ACTIVE.
+ */
+export function nextCustomerStatusAfterPolicies(params: {
+  customerStatus: CustomerStatus;
+  hasActive: boolean;
+  hasPending: boolean;
+  hasSuspended: boolean;
+  closedStatus: CustomerStatus;
+}): CustomerStatus | null {
+  const { customerStatus, hasActive, hasPending, hasSuspended, closedStatus } = params;
+
+  if (hasActive) {
+    if (customerStatus === CustomerStatus.ACTIVE) {
+      return null;
+    }
+    return CustomerStatus.ACTIVE;
+  }
+
+  if (hasPending) {
+    if (
+      customerStatus === CustomerStatus.SUSPENDED ||
+      customerStatus === CustomerStatus.DEACTIVATED ||
+      customerStatus === CustomerStatus.TERMINATED
+    ) {
+      return null;
+    }
+    if (customerStatus !== CustomerStatus.PENDING_ACTIVATION) {
+      return CustomerStatus.PENDING_ACTIVATION;
+    }
+    return null;
+  }
+
+  if (hasSuspended) {
+    if (customerStatus !== CustomerStatus.SUSPENDED) {
+      return CustomerStatus.SUSPENDED;
+    }
+    return null;
+  }
+
+  if (customerStatus === closedStatus) {
+    return null;
+  }
+  return closedStatus;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Admin-only additional product on the customer Products tab, plus the supporting membership, occupancy, payment-account, and registration selector changes from the plan.

## What this includes
- `policy_beneficiaries` join (one NOK per policy) with backfill
- Explicit dependant/beneficiary membership on policy create/activate; LCT late-add occupying-only
- Occupying uniqueness (one occupying policy per package; postpaid mix rules); PAN steal/suffix
- Admin `POST /internal/customers/:customerId/additional-policies` (`registration_admin`)
- Scheme typeahead (2+ letter prefix) → package → plan on registration and Add product
- Household caps from package pricing bands; extra-spouse premium × count (including recovery)
- Add-product wizard with pick-or-confirm for name-only duplicates
- Unpaid extra policy does not flip SUSPENDED/DEACTIVATED customers to PENDING_ACTIVATION

## Tests
API unit tests for occupancy, PAN, membership, NOK copy, customer status, scheme prefix, and additional-policy RBAC. FE tests for household caps, extra-spouse count, duplicate matcher, and scheme search prefix.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86f7560f-badf-4bef-bc20-11a908f47fd1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86f7560f-badf-4bef-bc20-11a908f47fd1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

